### PR TITLE
[Network] Fixing panic memory invalid address

### DIFF
--- a/network/encoding.go
+++ b/network/encoding.go
@@ -241,8 +241,7 @@ func UnmarshalRegistered(buf []byte) (PacketTypeID, Body, error) {
 	}
 	typ, ok := registry.get(tID)
 	if !ok {
-		return ErrorType, nil, fmt.Errorf("type %s not registered",
-			tID)
+		return ErrorType, nil, fmt.Errorf("type %s not registered", tID.String())
 	}
 	ptrVal := reflect.New(typ)
 	ptr := ptrVal.Interface()

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -221,8 +221,7 @@ func UnmarshalRegisteredType(buf []byte, constructors protobuf.Constructors) (Pa
 	}
 	typ, ok := registry.get(tID)
 	if !ok {
-		return ErrorType, nil, fmt.Errorf("type %s not registered",
-			typ.Name())
+		return ErrorType, nil, fmt.Errorf("type %s not registered", tID.String())
 	}
 	ptrVal := reflect.New(typ)
 	ptr := ptrVal.Interface()

--- a/network/encoding_test.go
+++ b/network/encoding_test.go
@@ -1,10 +1,13 @@
 package network
 
 import (
+	"crypto/rand"
 	"reflect"
 	"testing"
 
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestRegisterS struct {
@@ -27,6 +30,25 @@ func TestRegister(t *testing.T) {
 	if TypeFromData(TestRegisterS{}) != trType {
 		t.Fatal("TestRegister is different now")
 	}
+}
+
+func TestUnmarshalRegister(t *testing.T) {
+	constructors := DefaultConstructors(Suite)
+	trType := RegisterPacketType(&TestRegisterS{})
+	buff, err := MarshalRegisteredType(&TestRegisterS{10})
+	require.Nil(t, err)
+
+	ty, b, err := UnmarshalRegisteredType(buff, constructors)
+	assert.Nil(t, err)
+	assert.Equal(t, trType, ty)
+	assert.Equal(t, 10, b.(TestRegisterS).I)
+
+	var randType [16]byte
+	rand.Read(randType[:])
+	buff = append(randType[:], buff[16:]...)
+	ty, b, err = UnmarshalRegisteredType(buff, constructors)
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrorType, ty)
 }
 
 func TestRegisterReflect(t *testing.T) {

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -75,12 +75,12 @@ func NewTCPConn(addr Address) (conn *TCPConn, err error) {
 // It returns the Packet with the Msg field decoded
 // or EmptyApplicationPacket and an error if something wrong happened.
 func (c *TCPConn) Receive() (nm Packet, e error) {
-	defer func() {
-		if err := recover(); err != nil {
-			e = fmt.Errorf("Error Received message: %v\n%s", err, log.Stack())
-			nm = EmptyApplicationPacket
-		}
-	}()
+	/*defer func() {*/
+	//if err := recover(); err != nil {
+	//e = fmt.Errorf("Error Received message: %v\n%s", err, log.Stack())
+	//nm = EmptyApplicationPacket
+	//}
+	/*}()*/
 
 	var am Packet
 	buff, err := c.receiveRaw()

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -75,12 +75,12 @@ func NewTCPConn(addr Address) (conn *TCPConn, err error) {
 // It returns the Packet with the Msg field decoded
 // or EmptyApplicationPacket and an error if something wrong happened.
 func (c *TCPConn) Receive() (nm Packet, e error) {
-	/*defer func() {*/
-	//if err := recover(); err != nil {
-	//e = fmt.Errorf("Error Received message: %v\n%s", err, log.Stack())
-	//nm = EmptyApplicationPacket
-	//}
-	/*}()*/
+	defer func() {
+		if err := recover(); err != nil {
+			e = fmt.Errorf("Error Received message: %v\n%s", err, log.Stack())
+			nm = EmptyApplicationPacket
+		}
+	}()
 
 	var am Packet
 	buff, err := c.receiveRaw()


### PR DESCRIPTION
In encoding.go when it receives an unknown type, it calls `type.Name()` while the `type` is nil, because we wanted nice error output :(  
