### PR TITLE
[Onet] Generic Config implementation

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -23,6 +23,9 @@ var SendTreeMessageID = TreeMarshalTypeID
 // SendRosterMessageID of Roster message as registered in network
 var SendRosterMessageID = RosterTypeID
 
+// ConfigMessageID of the generic config message
+var ConfigMessageID = network.RegisterPacketType(ConfigMessage{})
+
 // ProtocolMsg is to be embedded in every message that is made for a
 // ProtocolInstance
 type ProtocolMsg struct {
@@ -38,8 +41,13 @@ type ProtocolMsg struct {
 	Msg network.Body
 	// The actual data as binary blob
 	MsgSlice []byte
-	// Config the actual config
+}
+
+// ConfigMessage is sent by the overlay containing a generic slice of bytes to
+// give to service in the `NewProtocol` method.
+type ConfigMessage struct {
 	Config GenericConfig
+	Dest   TokenID
 }
 
 // RoundID uniquely identifies a round of a protocol run

--- a/overlay.go
+++ b/overlay.go
@@ -47,15 +47,9 @@ type Overlay struct {
 	transmitMux sync.Mutex
 
 	protoIO *messageProxyStore
-}
 
-// pendingMsg is used to store messages destined for ProtocolInstances but when
-// the tree designated is not known to the Overlay. When the tree is sent to the
-// overlay, then the pendingMsg that are relying on this tree will get
-// processed.
-type pendingMsg struct {
-	*ProtocolMsg
-	MessageProxy
+	pendingConfigs    map[TokenID]*GenericConfig
+	pendingConfigsMut sync.Mutex
 }
 
 // NewOverlay creates a new overlay-structure
@@ -69,6 +63,7 @@ func NewOverlay(c *Conode) *Overlay {
 		instancesInfo:      make(map[TokenID]bool),
 		protocolInstances:  make(map[TokenID]ProtocolInstance),
 		pendingTreeMarshal: make(map[RosterID][]*TreeMarshal),
+		pendingConfigs:     make(map[TokenID]*GenericConfig),
 	}
 	o.protoIO = newMessageProxyStore(c, o)
 	// messages going to protocol instances
@@ -77,13 +72,20 @@ func NewOverlay(c *Conode) *Overlay {
 		RequestTreeMessageID,   // request a tree
 		SendTreeMessageID,      // send a tree back to a request
 		RequestRosterMessageID, // request a roster
-		SendRosterMessageID)    // send a roster back to request
+		SendRosterMessageID,    // send a roster back to request
+		ConfigMessageID)        // fetch config information
 	return o
 }
 
 // Process implements the Processor interface so it process the messages that it
 // wants.
 func (o *Overlay) Process(data *network.Packet) {
+	// Messages handled by the overlay directly without any messageProxyIO
+	if data.MsgType == ConfigMessageID {
+		o.handleConfigMessage(data)
+		return
+	}
+
 	// get messageProxy or default one
 	io := o.protoIO.getByPacketType(data.MsgType)
 	inner, info, err := io.Unwrap(data.Msg)
@@ -160,8 +162,10 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 
 			/// use the Services to instantiate it
 		} else {
+			// retrieve the possible generic config for this message
+			config := o.getConfig(onetMsg.To.ID())
 			// request the PI from the Service and binds the two
-			pi, err = s.NewProtocol(tni, &onetMsg.Config)
+			pi, err = s.NewProtocol(tni, config)
 			if err != nil {
 				return err
 			}
@@ -441,13 +445,54 @@ func (o *Overlay) handleSendRoster(si *network.ServerIdentity, roster *Roster) {
 	log.Lvl4("Received new entityList")
 }
 
+// handleConfigMessage stores the config message so it can be dispatched
+// alongside with the protocol message later to the service.
+func (o *Overlay) handleConfigMessage(data *network.Packet) {
+	config, ok := data.Msg.(ConfigMessage)
+	if !ok {
+		// This should never happen <=> assert
+		log.Panic(o.conode.Address(), "wrong config type")
+		return
+	}
+
+	o.pendingConfigsMut.Lock()
+	defer o.pendingConfigsMut.Unlock()
+	// XXX do the GC can still garbage the "config" package ?
+	o.pendingConfigs[config.Dest] = &config.Config
+}
+
+// getConfig returns the generic config corresponding to this node if present,
+// and removes it from the list of pending configs.
+func (o *Overlay) getConfig(id TokenID) *GenericConfig {
+	o.pendingConfigsMut.Lock()
+	defer o.pendingConfigsMut.Unlock()
+	c := o.pendingConfigs[id]
+	delete(o.pendingConfigs, id)
+	return c
+}
+
 // SendToTreeNode sends a message to a treeNode
-func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body, io MessageProxy) error {
+// from is the sender token
+// to is the treenode of the destination
+// msg is the message to send
+// io is the messageproxy used to correctly create the wire format
+func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body,
+	io MessageProxy, c *GenericConfig) error {
+	tokenTo := from.ChangeTreeNodeID(to.ID)
+
+	// first send the config if present
+	if c != nil {
+		if err := o.conode.Send(to.ServerIdentity, &ConfigMessage{*c, tokenTo.ID()}); err != nil {
+			log.Error("sending config failed:", err)
+			return err
+		}
+	}
+	// then sends the message
 	var final interface{}
 	info := &OverlayMessage{
 		TreeNodeInfo: &TreeNodeInfo{
 			From: from,
-			To:   from.ChangeTreeNodeID(to.ID),
+			To:   tokenTo,
 		},
 	}
 	final, err := io.Wrap(msg, info)
@@ -619,6 +664,15 @@ func (o *Overlay) RegisterProtocolInstance(pi ProtocolInstance) error {
 	o.protocolInstances[tok.ID()] = pi
 	log.Lvlf4("%s registered ProtocolInstance %x", o.conode.Address(), tok.ID())
 	return nil
+}
+
+// pendingMsg is used to store messages destined for ProtocolInstances but when
+// the tree designated is not known to the Overlay. When the tree is sent to the
+// overlay, then the pendingMsg that are relying on this tree will get
+// processed.
+type pendingMsg struct {
+	*ProtocolMsg
+	MessageProxy
 }
 
 // TreeNodeCache is a cache that maps from token to treeNode. Since the mapping

--- a/overlay.go
+++ b/overlay.go
@@ -489,7 +489,7 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body,
 			return err
 		}
 	}
-	// then sends the message
+	// then send the message
 	var final interface{}
 	info := &OverlayMessage{
 		TreeNodeInfo: &TreeNodeInfo{

--- a/overlay.go
+++ b/overlay.go
@@ -457,7 +457,6 @@ func (o *Overlay) handleConfigMessage(data *network.Packet) {
 
 	o.pendingConfigsMut.Lock()
 	defer o.pendingConfigsMut.Unlock()
-	// XXX do the GC can still garbage the "config" package ?
 	o.pendingConfigs[config.Dest] = &config.Config
 }
 

--- a/overlay.go
+++ b/overlay.go
@@ -475,6 +475,9 @@ func (o *Overlay) getConfig(id TokenID) *GenericConfig {
 // to is the treenode of the destination
 // msg is the message to send
 // io is the messageproxy used to correctly create the wire format
+// c is the generic config that should be sent beforehand in order to get passed
+// in the `NewProtocol` method if a Service has created the protocol and set the
+// config with `SetConfig`. It can be nil.
 func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body,
 	io MessageProxy, c *GenericConfig) error {
 	tokenTo := from.ChangeTreeNodeID(to.ID)

--- a/service.go
+++ b/service.go
@@ -60,7 +60,7 @@ type NewServiceFunc func(c *Context, path string) Service
 // GenericConfig is a config that can withhold any type of specific configs for
 // protocols. It is passed down to the service NewProtocol function.
 type GenericConfig struct {
-	Type uuid.UUID
+	Data []byte
 }
 
 // A serviceFactory is used to register a NewServiceFunc

--- a/service_test.go
+++ b/service_test.go
@@ -594,13 +594,7 @@ func (ds *dummyService2) ProcessClientRequest(path string, buf []byte) ([]byte, 
 var serviceConfig = []byte{0x01, 0x02, 0x03, 0x04}
 
 func (ds *dummyService2) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig) (ProtocolInstance, error) {
-	if conf == nil {
-		ds.link <- false
-	} else if bytes.Equal(conf.Data, serviceConfig) {
-		ds.link <- true
-	} else {
-		ds.link <- false
-	}
+	ds.link <- conf != nil && bytes.Equal(conf.Data, serviceConfig)
 	return newDummyProtocol2(tn)
 }
 
@@ -612,11 +606,7 @@ func (ds *dummyService2) launchProto(t *Tree, config bool) {
 	tni := ds.NewTreeNodeInstance(t, t.Root, dummyService2Name)
 	pi, err := newDummyProtocol2(tni)
 	err2 := ds.RegisterProtocolInstance(pi)
-	if err != nil || err2 != nil {
-		ds.link <- false
-	} else {
-		ds.link <- true
-	}
+	ds.link <- err == nil && err2 == nil
 
 	if config {
 		tni.SetConfig(&GenericConfig{serviceConfig})

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package onet
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 )
 
 const dummyServiceName = "dummyService"
+const dummyService2Name = "dummyService2"
 const ismServiceName = "ismService"
 const backForthServiceName = "backForth"
 
@@ -23,6 +25,8 @@ func init() {
 	network.RegisterPacketType(SimpleRequest{})
 	dummyMsgType = network.RegisterPacketType(DummyMsg{})
 	RegisterNewService(ismServiceName, newServiceMessages)
+	RegisterNewService(dummyService2Name, newDummyService2)
+	GlobalProtocolRegister("DummyProtocol2,", newDummyProtocol2)
 }
 
 func TestServiceRegistration(t *testing.T) {
@@ -287,6 +291,36 @@ func TestServiceMessages(t *testing.T) {
 	require.True(t, <-ism.GotResponse, "Didn't get response")
 }
 
+func TestServiceGenericConfig(t *testing.T) {
+	local := NewLocalTest()
+	defer local.CloseAll()
+	conodes, _, tree := local.GenTree(2, true)
+
+	s1 := conodes[0].serviceManager.Service(dummyService2Name)
+	s2 := conodes[1].serviceManager.Service(dummyService2Name)
+
+	ds1 := s1.(*dummyService2)
+	ds2 := s2.(*dummyService2)
+
+	link := make(chan bool)
+	ds1.link = link
+	ds2.link = link
+
+	// First launch without any config
+	go ds1.launchProto(tree, false)
+	// wait for the service's protocol creation
+	waitOrFatalValue(link, true, t)
+	// wait for the service 2 say there is no config
+	waitOrFatalValue(link, false, t)
+	// then laucnh with config
+	go ds1.launchProto(tree, true)
+	// wait for the service's protocol creation
+	waitOrFatalValue(link, true, t)
+	// wait for the service 2 say there is no config
+	waitOrFatalValue(link, true, t)
+
+}
+
 // BackForthProtocolForth & Back are messages that go down and up the tree.
 // => BackForthProtocol protocol / message
 type SimpleMessageForth struct {
@@ -542,6 +576,73 @@ func newServiceMessages(c *Context, path string) Service {
 	}
 	c.RegisterProcessorFunc(SimpleResponseType, s.SimpleResponse)
 	return s
+}
+
+type dummyService2 struct {
+	*Context
+	link chan bool
+}
+
+func newDummyService2(c *Context, path string) Service {
+	return &dummyService2{Context: c}
+}
+
+func (ds *dummyService2) ProcessClientRequest(path string, buf []byte) ([]byte, ClientError) {
+	panic("should not be called")
+}
+
+var serviceConfig = []byte{0x01, 0x02, 0x03, 0x04}
+
+func (ds *dummyService2) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig) (ProtocolInstance, error) {
+	if conf == nil {
+		ds.link <- false
+	} else if bytes.Equal(conf.Data, serviceConfig) {
+		ds.link <- true
+	} else {
+		ds.link <- false
+	}
+	return newDummyProtocol2(tn)
+}
+
+func (ds *dummyService2) Process(packet *network.Packet) {
+	panic("should not be called")
+}
+
+func (ds *dummyService2) launchProto(t *Tree, config bool) {
+	tni := ds.NewTreeNodeInstance(t, t.Root, dummyService2Name)
+	pi, err := newDummyProtocol2(tni)
+	err2 := ds.RegisterProtocolInstance(pi)
+	if err != nil || err2 != nil {
+		ds.link <- false
+	} else {
+		ds.link <- true
+	}
+
+	if config {
+		tni.SetConfig(&GenericConfig{serviceConfig})
+	}
+	go pi.Start()
+}
+
+type DummyProtocol2 struct {
+	*TreeNodeInstance
+	c chan WrapDummyMsg
+}
+
+type WrapDummyMsg struct {
+	*TreeNode
+	DummyMsg
+}
+
+func newDummyProtocol2(n *TreeNodeInstance) (ProtocolInstance, error) {
+	d := &DummyProtocol2{TreeNodeInstance: n}
+	d.c = make(chan WrapDummyMsg, 1)
+	d.RegisterChannel(d.c)
+	return d, nil
+}
+
+func (dp2 *DummyProtocol2) Start() error {
+	return dp2.SendToChildren(&DummyMsg{20})
 }
 
 func waitOrFatalValue(ch chan bool, v bool, t *testing.T) {

--- a/treenode.go
+++ b/treenode.go
@@ -48,6 +48,11 @@ type TreeNodeInstance struct {
 	closing bool
 
 	protoIO MessageProxy
+
+	// config is to be passed down in the first message of what the protocol is
+	// sending if it is non nil. Set with `tni.SetConfig()`.
+	config    *GenericConfig
+	configMut sync.Mutex
 }
 
 // aggregateMessages (if set) tells to aggregate messages from all children
@@ -118,7 +123,16 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 	if to == nil {
 		return errors.New("Sent to a nil TreeNode")
 	}
-	return n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO)
+	var c *GenericConfig
+	// only sends the config once
+	n.configMut.Lock()
+	defer n.configMut.Unlock()
+	if n.config != nil {
+		c = n.config
+		n.config = nil
+	}
+
+	return n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, c)
 }
 
 // Tree returns the tree of that node
@@ -644,6 +658,14 @@ func (n *TreeNodeInstance) Host() *Conode {
 func (n *TreeNodeInstance) TreeNodeInstance() *TreeNodeInstance {
 	return n
 }
+
+// SetConfig sets the GenericConfig c to be passed down in the first message
+// alongside with the protocol if it is non nil. This config can later be read
+// by Services in the NewProtocol method.
+func (n *TreeNodeInstance) SetConfig(c *GenericConfig) {
+	n.config = c
+}
+
 func (n *TreeNodeInstance) isBound() bool {
 	return n.instance != nil
 }

--- a/treenode.go
+++ b/treenode.go
@@ -126,11 +126,11 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 	var c *GenericConfig
 	// only sends the config once
 	n.configMut.Lock()
-	defer n.configMut.Unlock()
 	if n.config != nil {
 		c = n.config
 		n.config = nil
 	}
+	n.configMut.Unlock()
 
 	return n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, c)
 }

--- a/treenode.go
+++ b/treenode.go
@@ -663,6 +663,8 @@ func (n *TreeNodeInstance) TreeNodeInstance() *TreeNodeInstance {
 // alongside with the protocol if it is non nil. This config can later be read
 // by Services in the NewProtocol method.
 func (n *TreeNodeInstance) SetConfig(c *GenericConfig) {
+	n.configMut.Lock()
+	defer n.configMut.Unlock()
 	n.config = c
 }
 


### PR DESCRIPTION
This PR fixes #30 . Namely, it adds the possibility of giving a generic config by calling `treenodeinstance.SetConfig` by creating a new protocol. The config will be available in the `NewProtocol` of the corresponding `Service`.