### PR TITLE
[Travis] Goveralls with race detection enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test_verbose:
 
 test_go:
 	@echo Running coveralls test suite
-	$$GOPATH/bin/goveralls -service=travis-ci
+	$$GOPATH/bin/goveralls -service=travis-ci -race -covermode=atomic
 
 test: test_fmt test_lint test_go
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test_verbose:
 
 test_go:
 	@echo Running coveralls test suite
-	$$GOPATH/bin/goveralls -service=travis-ci -covermode=atomic -flags race
+	$$GOPATH/bin/goveralls -service=travis-ci -covermode=atomic -flags="-race"
 
 test: test_fmt test_lint test_go
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test_verbose:
 
 test_go:
 	@echo Running coveralls test suite
-	$$GOPATH/bin/goveralls -service=travis-ci -race -covermode=atomic
+	$$GOPATH/bin/goveralls -service=travis-ci -covermode=atomic -flags race
 
 test: test_fmt test_lint test_go
 


### PR DESCRIPTION
Currently, the command from goveralls does not make race detection checks. This PR aims to fix that by adding `-race` and `-covermode=atomic` to the testing command.