### PR TITLE
respecting same-origin policy

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -118,9 +118,6 @@ type wsHandler struct {
 // and handled correctly.
 func (t wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	u := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
 		EnableCompression: true,
 	}
 	ws, err := u.Upgrade(w, r, http.Header{})
@@ -208,7 +205,7 @@ func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]b
 		// Re-try to connect in case the websocket is just about to start
 		for a := 0; a < network.MaxRetryConnect; a++ {
 			c.conn, _, err = d.Dial(fmt.Sprintf("ws://%s/%s/%s", url, c.service, path),
-				http.Header{})
+				http.Header{"Origin": []string{"http://" + url}})
 			if err == nil {
 				break
 			}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -30,7 +30,7 @@ func TestNewWebSocket(t *testing.T) {
 	url, err := getWebAddress(c.ServerIdentity, false)
 	log.ErrFatal(err)
 	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/WebSocket/SimpleResponse", url),
-		"", "http://localhost/")
+		"", "http://"+url)
 	log.ErrFatal(err)
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.TypeFromData(req)).Bytes())

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -139,6 +139,11 @@ func TestNewClientError(t *testing.T) {
 	assert.True(t, NewClientError((error)(nil)) == nil)
 }
 
+func TestNewClientKeep(t *testing.T) {
+	c := NewClientKeep(serviceWebSocket)
+	assert.True(t, c.keep)
+}
+
 const serviceWebSocket = "WebSocket"
 
 type ServiceWebSocket struct {


### PR DESCRIPTION
closes #35 

Added correct header to `Client.Send` to respect same-origin policy.