### PR TITLE
[Onet] Reducing unused exported API

### DIFF
--- a/context.go
+++ b/context.go
@@ -111,18 +111,18 @@ func (c *Context) RegisterStatusReporter(name string, s StatusReporter) {
 // RegisterProcessor overrides the RegisterProcessor methods of the Dispatcher.
 // It delegates the dispatching to the serviceManager.
 func (c *Context) RegisterProcessor(p network.Processor, msgType network.MessageTypeID) {
-	c.manager.RegisterProcessor(p, msgType)
+	c.manager.registerProcessor(p, msgType)
 }
 
 // RegisterProcessorFunc takes a message-type and a function that will be called
 // if this message-type is received.
 func (c *Context) RegisterProcessorFunc(msgType network.MessageTypeID, fn func(*network.Envelope)) {
-	c.manager.RegisterProcessorFunc(msgType, fn)
+	c.manager.registerProcessorFunc(msgType, fn)
 }
 
 // Service returns the corresponding service.
 func (c *Context) Service(name string) Service {
-	return c.manager.Service(name)
+	return c.manager.service(name)
 }
 
 // String returns the host it's running on.

--- a/local.go
+++ b/local.go
@@ -174,7 +174,7 @@ func (l *LocalTest) CloseAll() {
 	}
 	for _, node := range l.Nodes {
 		log.Lvl3("Closing node", node)
-		node.Close()
+		node.closeDispatch()
 	}
 	l.Nodes = make([]*TreeNodeInstance, 0)
 	// Give the nodes some time to correctly close down

--- a/local.go
+++ b/local.go
@@ -181,8 +181,8 @@ func (l *LocalTest) CloseAll() {
 	//time.Sleep(time.Millisecond * 500)
 }
 
-// GetTree returns the tree of the given TreeNode
-func (l *LocalTest) GetTree(tn *TreeNode) *Tree {
+// getTree returns the tree of the given TreeNode
+func (l *LocalTest) getTree(tn *TreeNode) *Tree {
 	var tree *Tree
 	for _, t := range l.Trees {
 		if tn.IsInTree(t) {
@@ -199,7 +199,7 @@ func (l *LocalTest) NewTreeNodeInstance(tn *TreeNode, protName string) (*TreeNod
 	if o == nil {
 		return nil, errors.New("Didn't find corresponding overlay")
 	}
-	tree := l.GetTree(tn)
+	tree := l.getTree(tn)
 	if tree == nil {
 		return nil, errors.New("Didn't find tree corresponding to TreeNode")
 	}
@@ -220,8 +220,8 @@ func (l *LocalTest) NewTreeNodeInstance(tn *TreeNode, protName string) (*TreeNod
 	return node, nil
 }
 
-// GetNodes returns all Nodes that belong to a treeNode
-func (l *LocalTest) GetNodes(tn *TreeNode) []*TreeNodeInstance {
+// getNodes returns all Nodes that belong to a treeNode
+func (l *LocalTest) getNodes(tn *TreeNode) []*TreeNodeInstance {
 	var nodes []*TreeNodeInstance
 	for _, n := range l.Overlays[tn.ServerIdentity.ID].instances {
 		nodes = append(nodes, n)
@@ -229,9 +229,9 @@ func (l *LocalTest) GetNodes(tn *TreeNode) []*TreeNodeInstance {
 	return nodes
 }
 
-// SendTreeNode injects a message directly in the Overlay-layer, bypassing
+// sendTreeNode injects a message directly in the Overlay-layer, bypassing
 // Host and Network
-func (l *LocalTest) SendTreeNode(proto string, from, to *TreeNodeInstance, msg network.Message) error {
+func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg network.Message) error {
 	if from.Tree().ID != to.Tree().ID {
 		return errors.New("Can't send from one tree to another")
 	}
@@ -245,16 +245,16 @@ func (l *LocalTest) SendTreeNode(proto string, from, to *TreeNodeInstance, msg n
 	return to.overlay.TransmitMsg(onetMsg, io)
 }
 
-// AddPendingTreeMarshal takes a treeMarshal and adds it to the list of the
+// addPendingTreeMarshal takes a treeMarshal and adds it to the list of the
 // known trees, also triggering dispatching of onet-messages waiting for that
 // tree
-func (l *LocalTest) AddPendingTreeMarshal(c *Server, tm *TreeMarshal) {
+func (l *LocalTest) addPendingTreeMarshal(c *Server, tm *TreeMarshal) {
 	c.overlay.addPendingTreeMarshal(tm)
 }
 
-// CheckPendingTreeMarshal looks whether there are any treeMarshals to be
+// checkPendingTreeMarshal looks whether there are any treeMarshals to be
 // called
-func (l *LocalTest) CheckPendingTreeMarshal(c *Server, el *Roster) {
+func (l *LocalTest) checkPendingTreeMarshal(c *Server, el *Roster) {
 	c.overlay.checkPendingTreeMarshal(el)
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -221,15 +221,15 @@ func TestTreeNodeFlags(t *testing.T) {
 		t.Fatal("Couldn't create node.")
 	}
 	tni := p.(*ProtocolChannels).TreeNodeInstance
-	if tni.HasFlag(testType, AggregateMessages) {
+	if tni.hasFlag(testType, AggregateMessages) {
 		t.Fatal("Should NOT have AggregateMessages-flag")
 	}
-	tni.SetFlag(testType, AggregateMessages)
-	if !tni.HasFlag(testType, AggregateMessages) {
+	tni.setFlag(testType, AggregateMessages)
+	if !tni.hasFlag(testType, AggregateMessages) {
 		t.Fatal("Should HAVE AggregateMessages-flag cleared")
 	}
-	tni.ClearFlag(testType, AggregateMessages)
-	if tni.HasFlag(testType, AggregateMessages) {
+	tni.clearFlag(testType, AggregateMessages)
+	if tni.hasFlag(testType, AggregateMessages) {
 		t.Fatal("Should NOT have AggregateMessages-flag")
 	}
 }

--- a/node_test.go
+++ b/node_test.go
@@ -186,17 +186,17 @@ func TestTreeNodeMsgAggregation(t *testing.T) {
 	<-Incoming
 	<-Incoming
 	log.Lvl3("Both children are up")
-	child1 := local.GetNodes(tree.Root.Children[0])[0]
-	child2 := local.GetNodes(tree.Root.Children[1])[0]
+	child1 := local.getNodes(tree.Root.Children[0])[0]
+	child2 := local.getNodes(tree.Root.Children[1])[0]
 
-	err = local.SendTreeNode(ProtocolChannelsName, child1, proto.TreeNodeInstance, &NodeTestAggMsg{3})
+	err = local.sendTreeNode(ProtocolChannelsName, child1, proto.TreeNodeInstance, &NodeTestAggMsg{3})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(proto.IncomingAgg) > 0 {
 		t.Fatal("Messages should NOT be there")
 	}
-	err = local.SendTreeNode(ProtocolChannelsName, child2, proto.TreeNodeInstance, &NodeTestAggMsg{4})
+	err = local.sendTreeNode(ProtocolChannelsName, child2, proto.TreeNodeInstance, &NodeTestAggMsg{4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,17 +385,17 @@ func TestNodeBlocking(t *testing.T) {
 	tn2 := p2.TreeNodeInstance
 	go func() {
 		// Send two messages to n1, which blocks the old interface
-		err := l.SendTreeNode("", tn2, tn1, &NodeTestMsg{})
+		err := l.sendTreeNode("", tn2, tn1, &NodeTestMsg{})
 		if err != nil {
 			t.Fatal("Couldn't send message:", err)
 		}
-		err = l.SendTreeNode("", tn2, tn1, &NodeTestMsg{})
+		err = l.sendTreeNode("", tn2, tn1, &NodeTestMsg{})
 		if err != nil {
 			t.Fatal("Couldn't send message:", err)
 		}
 		// Now send a message to n2, but in the old interface this
 		// blocks.
-		err = l.SendTreeNode("", tn1, tn2, &NodeTestMsg{})
+		err = l.sendTreeNode("", tn1, tn2, &NodeTestMsg{})
 		if err != nil {
 			t.Fatal("Couldn't send message:", err)
 		}

--- a/onet.go
+++ b/onet.go
@@ -9,7 +9,7 @@ ONet is based on the following pieces:
 - Local* - offers the user-interface to the API for deploying your protocol
 locally and for testing
 - Node / ProtocolInstance - gives an interface to define your protocol
-- Host - handles all network-connections
+- Server - hold states for the different parts of Onet
 - network - uses secured connections between hosts
 
 If you just want to use an existing protocol, usually the ONet-part is enough.

--- a/onet.go
+++ b/onet.go
@@ -19,4 +19,4 @@ ProtocolInstance.
 package onet
 
 // Version of onet.
-const Version = "0.9.2"
+const Version = "1"

--- a/overlay.go
+++ b/overlay.go
@@ -503,7 +503,7 @@ func (o *Overlay) nodeDelete(tok *Token) {
 		return
 	}
 	log.Lvl4("Closing node", tok.ID())
-	err := tni.Close()
+	err := tni.closeDispatch()
 	if err != nil {
 		log.Error("Error while closing node:", err)
 	}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -75,12 +75,12 @@ func TestOverlayPendingTreeMarshal(t *testing.T) {
 	h1 := hosts[0]
 
 	// Add the marshalled version of the tree
-	local.AddPendingTreeMarshal(h1, tree.MakeTreeMarshal())
+	local.addPendingTreeMarshal(h1, tree.MakeTreeMarshal())
 	if _, ok := h1.GetTree(tree.ID); ok {
 		t.Fatal("host 1 should not have the tree definition yet.")
 	}
 	// Now make it check
-	local.CheckPendingTreeMarshal(h1, el)
+	local.checkPendingTreeMarshal(h1, el)
 	if _, ok := h1.GetTree(tree.ID); !ok {
 		t.Fatal("Host 1 should have the tree definition now.")
 	}

--- a/processor.go
+++ b/processor.go
@@ -104,7 +104,7 @@ func (p *ServiceProcessor) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig
 
 // ProcessClientRequest takes a request from a client, calculates the reply
 // and sends it back. It uses the path to find the appropriate handler-
-// function.
+// function. It implements the Server interface.
 func (p *ServiceProcessor) ProcessClientRequest(path string, buf []byte) ([]byte, ClientError) {
 	mh, ok := p.handlers[path]
 	reply, cerr := func() (interface{}, ClientError) {

--- a/server.go
+++ b/server.go
@@ -80,7 +80,7 @@ func (c *Server) Suite() abstract.Suite {
 
 // GetStatus is a function that returns the status report of the server.
 func (c *Server) GetStatus() *Status {
-	a := ServiceFactory.RegisteredServiceNames()
+	a := c.serviceManager.availableServices()
 	sort.Strings(a)
 	return &Status{map[string]string{
 		"Available_Services": strings.Join(a, ","),
@@ -114,7 +114,7 @@ func (c *Server) Address() network.Address {
 
 // GetService returns the service with the given name.
 func (c *Server) GetService(name string) Service {
-	return c.serviceManager.Service(name)
+	return c.serviceManager.service(name)
 }
 
 // ProtocolRegister will sign up a new protocol to this Server.

--- a/service.go
+++ b/service.go
@@ -225,21 +225,21 @@ func (s *serviceManager) Process(env *network.Envelope) {
 	s.Dispatch(env)
 }
 
-// RegisterProcessor the processor to the service manager and tells the host to dispatch
+// registerProcessor the processor to the service manager and tells the host to dispatch
 // this message to the service manager. The service manager will then dispatch
 // the message in a go routine. XXX This is needed because we need to have
 // messages for service dispatched in asynchronously regarding the protocols.
 // This behavior with go routine is fine for the moment but for better
 // performance / memory / resilience, it may be changed to a real queuing
 // system later.
-func (s *serviceManager) RegisterProcessor(p network.Processor, msgType network.MessageTypeID) {
+func (s *serviceManager) registerProcessor(p network.Processor, msgType network.MessageTypeID) {
 	// delegate message to host so the host will pass the message to ourself
 	s.server.RegisterProcessor(s, msgType)
 	// handle the message ourselves (will be launched in a go routine)
 	s.Dispatcher.RegisterProcessor(p, msgType)
 }
 
-func (s *serviceManager) RegisterProcessorFunc(msgType network.MessageTypeID, fn func(*network.Envelope)) {
+func (s *serviceManager) registerProcessorFunc(msgType network.MessageTypeID, fn func(*network.Envelope)) {
 	// delegate message to host so the host will pass the message to ourself
 	s.server.RegisterProcessor(s, msgType)
 	// handle the message ourselves (will be launched in a go routine)
@@ -247,18 +247,18 @@ func (s *serviceManager) RegisterProcessorFunc(msgType network.MessageTypeID, fn
 
 }
 
-// AvailableServices returns a list of all services available to the serviceManager.
+// availableServices returns a list of all services available to the serviceManager.
 // If no services are instantiated, it returns an empty list.
-func (s *serviceManager) AvailableServices() (ret []string) {
+func (s *serviceManager) availableServices() (ret []string) {
 	for id := range s.services {
 		ret = append(ret, ServiceFactory.Name(id))
 	}
 	return
 }
 
-// Service returns the Service implementation being registered to this name or
+// service returns the service implementation being registered to this name or
 // nil if no service by this name is available.
-func (s *serviceManager) Service(name string) Service {
+func (s *serviceManager) service(name string) Service {
 	id := ServiceFactory.ServiceID(name)
 	if id == NilServiceID {
 		return nil

--- a/service_test.go
+++ b/service_test.go
@@ -269,10 +269,10 @@ func TestServiceManager_Service(t *testing.T) {
 	defer local.CloseAll()
 	servers, _, _ := local.GenTree(2, true)
 
-	services := servers[0].serviceManager.AvailableServices()
+	services := servers[0].serviceManager.availableServices()
 	assert.NotEqual(t, 0, len(services), "no services available")
 
-	service := servers[0].serviceManager.Service("testService")
+	service := servers[0].serviceManager.service("testService")
 	assert.NotNil(t, service, "Didn't find service testService")
 }
 
@@ -281,7 +281,7 @@ func TestServiceMessages(t *testing.T) {
 	defer local.CloseAll()
 	servers, _, _ := local.GenTree(2, true)
 
-	service := servers[0].serviceManager.Service(ismServiceName)
+	service := servers[0].serviceManager.service(ismServiceName)
 	assert.NotNil(t, service, "Didn't find service ISMService")
 	ism := service.(*ServiceMessages)
 	ism.SendRaw(servers[0].ServerIdentity, &SimpleResponse{})
@@ -293,8 +293,8 @@ func TestServiceGenericConfig(t *testing.T) {
 	defer local.CloseAll()
 	servers, _, tree := local.GenTree(2, true)
 
-	s1 := servers[0].serviceManager.Service(dummyService2Name)
-	s2 := servers[1].serviceManager.Service(dummyService2Name)
+	s1 := servers[0].serviceManager.service(dummyService2Name)
+	s2 := servers[1].serviceManager.service(dummyService2Name)
 
 	ds1 := s1.(*dummyService2)
 	ds2 := s2.(*dummyService2)

--- a/simulation.go
+++ b/simulation.go
@@ -157,7 +157,7 @@ func (sc *SimulationConfig) Save(dir string) error {
 
 // GetService returns the service with the given name.
 func (sc *SimulationConfig) GetService(name string) Service {
-	return sc.Server.serviceManager.Service(name)
+	return sc.Server.serviceManager.service(name)
 }
 
 // SimulationRegister is must to be called to register a simulation.


### PR DESCRIPTION
This PR is a first shot to reducing the exported API that we have in Onet and which is not used at all elsewhere, and which should not be used at all elsewhere.
If a method has been privatized, it's because it's building everywhere, including cothority (i.e. cothority does not use it).

**Note**: One last thing I'd like to reduce is the `CloseHost` method on `TreeNodeInstance` which basically shutdowns everything... It's bad ! Unfortunatly it's used in the simulation,which is in a diferent package. Any ideas ?