### PR TITLE
Adds ErrorHandler accessors

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -44,7 +44,7 @@ type Router struct {
 	// Every handler in this list is called by this router when a network error occurs (Timeout, Connection
 	// Closed, or EOF). Those handler should be added by using SetErrorHandler(). The 1st argument is the remote
 	// server with whom the error happened
-	connectionsErrorHandler []func(*ServerIdentity)
+	connectionErrorHandlers []func(*ServerIdentity)
 
 	// keep bandwidth of closed connections
 	traffic counterSafe
@@ -58,7 +58,7 @@ func NewRouter(own *ServerIdentity, h Host) *Router {
 		connections:             make(map[ServerIdentityID][]Conn),
 		host:                    h,
 		Dispatcher:              NewBlockingDispatcher(),
-		connectionsErrorHandler: make([]func(*ServerIdentity), 0),
+		connectionErrorHandlers: make([]func(*ServerIdentity), 0),
 	}
 	r.address = h.Address()
 	return r
@@ -207,7 +207,7 @@ func (r *Router) removeConnection(si *ServerIdentity, c Conn) {
 
 // triggerConnectionErrorHandlers trigger all registered connectionsErrorHandlers
 func (r *Router) triggerConnectionErrorHandlers(remote *ServerIdentity) {
-	for _, v := range r.connectionsErrorHandler {
+	for _, v := range r.connectionErrorHandlers {
 		v(remote)
 	}
 }
@@ -373,5 +373,5 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 // on network error (e.g. Timeout, Connection Closed, or EOF) with the identity of the faulty
 // remote host as 1st parameter.
 func (r *Router) AddErrorHandler(errorHandler func(*ServerIdentity)) {
-	r.connectionsErrorHandler = append(r.connectionsErrorHandler, errorHandler)
+	r.connectionErrorHandlers = append(r.connectionErrorHandlers, errorHandler)
 }

--- a/network/router.go
+++ b/network/router.go
@@ -361,5 +361,8 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 // on network error (e.g. Timeout, Connection Closed, or EOF) with the identity of the faulty
 // remote host as 1st parameter.
 func (r *Router) SetErrorHandler(errorHandler func(*ServerIdentity)) {
+	if errorHandler != nil {
+		panic("error handler was already set, cannot replace")
+	}
 	r.errorHandler = errorHandler
 }

--- a/network/router.go
+++ b/network/router.go
@@ -44,18 +44,18 @@ type Router struct {
 	// Every handler in this list is called by this router when any network error occurs (Timeout, Connection
 	// Closed, or EOF). Those handler should be added by using SetErrorHandler(). The 1st argument is the remote
 	// server with whom the error happened
-	errorHandlers []func(*ServerIdentity)
+	connectionsErrorHandler []func(*ServerIdentity)
 }
 
 // NewRouter returns a new Router attached to a ServerIdentity and the host we want to
 // use.
 func NewRouter(own *ServerIdentity, h Host) *Router {
 	r := &Router{
-		ServerIdentity: own,
-		connections:    make(map[ServerIdentityID][]Conn),
-		host:           h,
-		Dispatcher:     NewBlockingDispatcher(),
-		errorHandlers:  make([]func(*ServerIdentity), 0),
+		ServerIdentity:          own,
+		connections:             make(map[ServerIdentityID][]Conn),
+		host:                    h,
+		Dispatcher:              NewBlockingDispatcher(),
+		connectionsErrorHandler: make([]func(*ServerIdentity), 0),
 	}
 	r.address = h.Address()
 	return r
@@ -202,6 +202,13 @@ func (r *Router) removeConnection(si *ServerIdentity, c Conn) {
 	r.connections[si.ID] = arr[:len(arr)-1]
 }
 
+// triggerConnectionErrorHandlers trigger all registered connectionsErrorHandlers
+func (r *Router) triggerConnectionErrorHandlers(remote *ServerIdentity) {
+	for _, v := range r.connectionsErrorHandler {
+		v(remote)
+	}
+}
+
 // handleConn waits for incoming messages and calls the dispatcher for
 // each new message. It only quits if the connection is closed or another
 // unrecoverable error in the connection appears.
@@ -226,18 +233,14 @@ func (r *Router) handleConn(remote *ServerIdentity, c Conn) {
 		if err != nil {
 			if err == ErrTimeout {
 				log.Lvlf5("%s drops %s connection: timeout", r.ServerIdentity.Address, remote.Address)
-				for _, v := range r.errorHandlers {
-					v(remote)
-				}
+				r.triggerConnectionErrorHandlers(remote)
 				return
 			}
 
 			if err == ErrClosed || err == ErrEOF {
 				// Connection got closed.
 				log.Lvlf5("%s drops %s connection: closed", r.ServerIdentity.Address, remote.Address)
-				for _, v := range r.errorHandlers {
-					v(remote)
-				}
+				r.triggerConnectionErrorHandlers(remote)
 				return
 			}
 			// Temporary error, continue.
@@ -363,5 +366,5 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 // on network error (e.g. Timeout, Connection Closed, or EOF) with the identity of the faulty
 // remote host as 1st parameter.
 func (r *Router) AddErrorHandler(errorHandler func(*ServerIdentity)) {
-	r.errorHandlers = append(r.errorHandlers, errorHandler)
+	r.connectionsErrorHandler = append(r.connectionsErrorHandler, errorHandler)
 }

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -80,8 +80,8 @@ func TestRouterErrorHandling(t *testing.T) {
 	}()
 
 	// tests the setting error handler
-	require.NotNil(t, h1.errorHandlers)
-	if len(h1.errorHandlers) != 0 {
+	require.NotNil(t, h1.connectionsErrorHandler)
+	if len(h1.connectionsErrorHandler) != 0 {
 		t.Error("errorHandlers should start empty")
 	}
 	errHandlerCalled := make(chan bool, 1)
@@ -89,7 +89,7 @@ func TestRouterErrorHandling(t *testing.T) {
 		errHandlerCalled <- true
 	}
 	h1.AddErrorHandler(errHandler)
-	if len(h1.errorHandlers) != 1 {
+	if len(h1.connectionsErrorHandler) != 1 {
 		t.Error("errorHandlers should now hold one function")
 	}
 
@@ -108,13 +108,12 @@ func TestRouterErrorHandling(t *testing.T) {
 
 	//stop node 2
 	h2.Stop()
-	time.Sleep(250 * time.Millisecond)
 
 	// test if the error handler was called
 	select {
 	case <-errHandlerCalled:
 		// all good
-	default:
+	case <-time.After(250 * time.Millisecond):
 		t.Error("Error handler should have been called after a disconnection")
 	}
 }

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -108,6 +108,7 @@ func TestRouterErrorHandling(t *testing.T) {
 
 	//stop node 2
 	h2.Stop()
+	time.Sleep(250 * time.Millisecond)
 
 	// test if the error handler was called
 	select {

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -80,8 +80,8 @@ func TestRouterErrorHandling(t *testing.T) {
 	}()
 
 	// tests the setting error handler
-	require.NotNil(t, h1.connectionsErrorHandler)
-	if len(h1.connectionsErrorHandler) != 0 {
+	require.NotNil(t, h1.connectionErrorHandlers)
+	if len(h1.connectionErrorHandlers) != 0 {
 		t.Error("errorHandlers should start empty")
 	}
 	errHandlerCalled := make(chan bool, 1)
@@ -89,7 +89,7 @@ func TestRouterErrorHandling(t *testing.T) {
 		errHandlerCalled <- true
 	}
 	h1.AddErrorHandler(errHandler)
-	if len(h1.connectionsErrorHandler) != 1 {
+	if len(h1.connectionErrorHandlers) != 1 {
 		t.Error("errorHandlers should now hold one function")
 	}
 

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -81,9 +81,9 @@ func TestRouterErrorHandling(t *testing.T) {
 
 	// tests the setting error handler
 	require.Nil(t, h1.errorHandler)
-	errHandlerCalled := false
+	errHandlerCalled := make(chan bool, 1)
 	errHandler := func(remote *ServerIdentity) {
-		errHandlerCalled = true
+		errHandlerCalled <- true
 	}
 	h1.SetErrorHandler(errHandler)
 	require.NotNil(t, h1.errorHandler)
@@ -105,7 +105,10 @@ func TestRouterErrorHandling(t *testing.T) {
 	h2.Stop()
 
 	// test if the error handler was called
-	if !errHandlerCalled {
+	select {
+	case _ = <-errHandlerCalled:
+		// all good
+	default:
 		t.Error("Error handler should have been called after a disconnection")
 	}
 }

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -61,6 +61,13 @@ func testRouter(t *testing.T, fac routerFactory) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("TcpHost should have returned from Run() by now")
 	}
+
+	require.Nil(t, h.errorHappened)
+	errHandler := func(remote *ServerIdentity) {
+		//nothing to do here
+	}
+	h.SetErrorHandler(errHandler)
+	require.NotNil(t, h.errorHappened)
 }
 
 func testRouterRemoveConnection(t *testing.T) {

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -106,7 +106,7 @@ func TestRouterErrorHandling(t *testing.T) {
 
 	// test if the error handler was called
 	select {
-	case _ = <-errHandlerCalled:
+	case <-errHandlerCalled:
 		// all good
 	default:
 		t.Error("Error handler should have been called after a disconnection")

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -80,13 +80,18 @@ func TestRouterErrorHandling(t *testing.T) {
 	}()
 
 	// tests the setting error handler
-	require.Nil(t, h1.errorHandler)
+	require.NotNil(t, h1.errorHandlers)
+	if len(h1.errorHandlers) != 0 {
+		t.Error("errorHandlers should start empty")
+	}
 	errHandlerCalled := make(chan bool, 1)
 	errHandler := func(remote *ServerIdentity) {
 		errHandlerCalled <- true
 	}
-	h1.SetErrorHandler(errHandler)
-	require.NotNil(t, h1.errorHandler)
+	h1.AddErrorHandler(errHandler)
+	if len(h1.errorHandlers) != 1 {
+		t.Error("errorHandlers should now hold one function")
+	}
 
 	//register handlers
 	proc := &simpleMessageProc{t, make(chan SimpleMessage)}


### PR DESCRIPTION
Gives the service the opportunity to register a error-handler function (type `func(*ServerIdentity)`). This function will be called on network error: Timeout, EOF, or ConnectionClosed, with the identity of the faulty remote server.