### PR TITLE
TLS communication

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -26,14 +26,14 @@ func TestMain(m *testing.M) {
 var serverGroup string = `Description = "Default Dedis Cosi servers"
 
 [[servers]]
-Address = "tcp://5.135.161.91:2000"
+Address = "tls://1.2.3.4:2000"
 Public = "lLglU3nhHfUWe4p647hffn618TiUq+6FvTGzJw8eTGU="
-Description = "Nikkolasg's server: spreading the love of signing"
+Description = "testserver 1"
 
 [[servers]]
-Address = "tcp://185.26.156.40:61117"
+Address = "tcp://4.3.2.1:7770"
 Public = "apIWOKSt6JcOvNnjcVcPCNcaJJh/kPEjkbn2xSW+W+Q="
-Description = "Ismail's server"`
+Description = "testserver 2"`
 
 func TestReadGroupDescToml(t *testing.T) {
 	group, err := ReadGroupDescToml(strings.NewReader(serverGroup))
@@ -43,7 +43,7 @@ func TestReadGroupDescToml(t *testing.T) {
 		t.Fatal("Should have 2 ServerIdentities")
 	}
 	nikkoAddr := group.Roster.List[0].Address
-	if !nikkoAddr.Valid() || nikkoAddr != network.NewTCPAddress("5.135.161.91:2000") {
+	if !nikkoAddr.Valid() || nikkoAddr != network.NewTLSAddress("1.2.3.4:2000") {
 		t.Fatal("Address not valid " + group.Roster.List[0].Address.String())
 	}
 	if len(group.description) != 2 {

--- a/network/struct.go
+++ b/network/struct.go
@@ -78,6 +78,8 @@ type ServerIdentity struct {
 	Address Address
 	// Description of the server
 	Description string
+	// The self-signed TLS-certificate for that ServerIdentity, PEM-encoded.
+	Cert TLSCertPEM
 }
 
 // ServerIdentityID uniquely identifies an ServerIdentity struct
@@ -111,6 +113,17 @@ func NewServerIdentity(public abstract.Point, address Address) *ServerIdentity {
 		Address: address,
 		ID:      ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url)),
 	}
+}
+
+// NewServerIdentityTLS creates a new ServerIdentity and initialises it with
+// the given certificate for a tls-connection.
+func NewServerIdentityTLS(public abstract.Point, address Address, cert TLSCertPEM) *ServerIdentity {
+	if address.ConnType() != TLS {
+		return nil
+	}
+	si := NewServerIdentity(public, address)
+	si.Cert = cert
+	return si
 }
 
 // Equal tests on same public key

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -482,6 +482,13 @@ func NewTestServerIdentity(address Address) *ServerIdentity {
 	return e
 }
 
+// Returns a new tls ServerIdentity
+func NewTestServerIdentityTLS(address Address, cert TLSCertPEM) *ServerIdentity {
+	si := NewTestServerIdentity(address)
+	si.Cert = cert
+	return si
+}
+
 // SimpleMessage is just used to transfer one integer
 type SimpleMessage struct {
 	I int

--- a/network/tls.go
+++ b/network/tls.go
@@ -1,0 +1,149 @@
+package network
+
+import (
+	"crypto/tls"
+	"errors"
+
+	"fmt"
+
+	"github.com/dedis/cothority/log"
+)
+
+/*
+Implementation of a TLS-host to allow for tls-connections. Only the server
+will authenticate to the client.
+*/
+
+// NewTLSRouter returns a new Router using TLSHost as the underlying Host.
+func NewTLSRouter(sid *ServerIdentity, key TLSKeyPEM) (*Router, error) {
+	h, err := NewTLSHost(sid, key)
+	if err != nil {
+		return nil, err
+	}
+	r := NewRouter(sid, h)
+	return r, nil
+}
+
+// TLSHost implements the Host interface using TLS connections.
+type TLSHost struct {
+	*TLSListener
+	addr Address
+	cert TLSCertPEM
+	key  TLSKeyPEM
+}
+
+// NewTLSHost returns a new Host using TLS connection based type.
+func NewTLSHost(si *ServerIdentity, key TLSKeyPEM) (*TLSHost, error) {
+	h := &TLSHost{
+		addr: si.Address,
+		cert: si.Cert,
+		key:  key,
+	}
+	var err error
+	h.TLSListener, err = NewTLSListener(si, key)
+	return h, err
+}
+
+// Connect establishes a connection to the remote host given in addr.
+func (h *TLSHost) Connect(si *ServerIdentity) (Conn, error) {
+	log.Lvl3(h.addr, "connecting to", si.Address)
+	addr := si.Address
+	switch addr.ConnType() {
+	case TLS:
+		c, err := NewTLSConn(si)
+		return c, err
+	}
+	return nil, fmt.Errorf("Don't support connection: %s", addr.ConnType())
+}
+
+// TLSListener implements the Host-interface using TLS as a communication channel.
+type TLSListener struct {
+	*TCPListener
+	TLSConfig *tls.Config
+}
+
+// NewTLSListener returns a TLSListener. This function binds to the given
+// address.
+// It returns the listener and an error if one occurred during
+// the binding.
+// A subsequent call to Address() gives the actual listening
+// address which is different if you gave it a ":0"-address.
+func NewTLSListener(si *ServerIdentity, key TLSKeyPEM) (*TLSListener, error) {
+	log.Lvl3("Starting to listen on", si)
+	addr := si.Address
+	if addr.ConnType() != TLS {
+		return nil, errors.New("TLSListener can't listen on non-TLS address")
+	}
+	config, err := key.ConfigServer(si.Cert)
+	if err != nil {
+		return nil, err
+	}
+	tcpL, err := NewTCPListener(NewAddress(PlainTCP, si.Address.NetworkAddress()))
+	tlsL := &TLSListener{
+		TCPListener: tcpL,
+		TLSConfig:   config,
+	}
+	return tlsL, err
+}
+
+// Listen starts to listen for incoming connections and calls fn for every
+// connection-request it receives.
+// If the connection is closed, an error will be returned.
+func (t *TLSListener) Listen(fn func(Conn)) error {
+	receiver := func(tc Conn) {
+		tcpc := tc.(*TCPConn)
+		tlsC := TLSConn{tcpc}
+		log.Lvl3("Starting handshake")
+		if err := tls.Server(tcpc.conn, t.TLSConfig).Handshake(); err != nil {
+			log.Error("Couldn't complete handshake:", err)
+			return
+		}
+		log.Lvl3("Handshake done")
+		tlsC.endpoint = NewTLSAddress(tc.Remote().String())
+		go fn(tlsC)
+	}
+	return t.listen(receiver)
+}
+
+// TLSConn implements the Conn interface using TLS.
+type TLSConn struct {
+	*TCPConn
+}
+
+// NewTLSConn will open a TLSConn to the given address.
+// In case of an error it returns a nil TLSConn and the error.
+func NewTLSConn(si *ServerIdentity) (*TLSConn, error) {
+	//addr := si.Address
+	//netAddr := addr.NetworkAddress()
+	config, err := si.Cert.ConfigClient()
+	if err != nil {
+		return nil, err
+	}
+	if si.Address.ConnType() != TLS {
+		return nil, errors.New("this is not a TLS-address")
+	}
+	c, err := NewTCPConn(si.Address)
+	if err != nil {
+		return nil, err
+	}
+	config.ServerName = si.Address.Host()
+	if err = tls.Client(c.conn, config).Handshake(); err != nil {
+		return nil, err
+	}
+	return &TLSConn{c}, nil
+}
+
+// NewTLSClient returns a new client using the TLS network communication
+// layer.
+func NewTLSClient() *Client {
+	fn := func(own, remote *ServerIdentity) (Conn, error) {
+		return NewTLSConn(remote)
+	}
+	return newClient(fn)
+}
+
+// NewTLSAddress returns a new Address that has type PlainTLS with the given
+// address addr.
+func NewTLSAddress(addr string) Address {
+	return NewAddress(TLS, addr)
+}

--- a/network/tls.go
+++ b/network/tls.go
@@ -6,7 +6,7 @@ import (
 
 	"fmt"
 
-	"github.com/dedis/cothority/log"
+	"github.com/dedis/onet/log"
 )
 
 /*
@@ -131,15 +131,6 @@ func NewTLSConn(si *ServerIdentity) (*TLSConn, error) {
 		return nil, err
 	}
 	return &TLSConn{c}, nil
-}
-
-// NewTLSClient returns a new client using the TLS network communication
-// layer.
-func NewTLSClient() *Client {
-	fn := func(own, remote *ServerIdentity) (Conn, error) {
-		return NewTLSConn(remote)
-	}
-	return newClient(fn)
 }
 
 // NewTLSAddress returns a new Address that has type PlainTLS with the given

--- a/network/tls_test.go
+++ b/network/tls_test.go
@@ -1,0 +1,66 @@
+package network
+
+import (
+	"math/big"
+	"testing"
+
+	"net"
+
+	"github.com/dedis/cothority/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTLSCert(t *testing.T) {
+	c1 := NewTLSCert(big.NewInt(0), "ch", "epfl", "dedis", 10, []byte{},
+		[]net.IP{})
+	c2 := NewTLSCert(big.NewInt(1), "ch", "epfl", "lca1", 10, []byte{},
+		[]net.IP{})
+	require.Equal(t, []string{"ch"}, c2.Subject.Country)
+	require.Equal(t, []string{"ch"}, c1.Subject.Country)
+	require.Equal(t, []string{"dedis"}, c1.Subject.OrganizationalUnit)
+	require.Equal(t, []string{"lca1"}, c2.Subject.OrganizationalUnit)
+}
+
+func TestNewTLSKeyCert(t *testing.T) {
+	c1 := NewTLSCert(big.NewInt(0), "ch", "epfl", "dedis", 10, []byte{},
+		[]net.IP{})
+	c2 := NewTLSCert(big.NewInt(1), "ch", "epfl", "lca1", 10, []byte{},
+		[]net.IP{})
+	_, _, err := NewCertKey(c1, 256)
+	log.ErrFatal(err)
+	_, _, err = NewCertKey(c2, 256)
+	log.ErrFatal(err)
+}
+
+func TestNewTLSRouter(t *testing.T) {
+	si1 := NewTestServerIdentity("tls://localhost:2000")
+	si2 := NewTestServerIdentity("tls://localhost:2001")
+	ips, err := net.LookupIP("localhost")
+	log.ErrFatal(err)
+	c1 := NewTLSCert(big.NewInt(0), "ch", "epfl", "dedis", 10, []byte{}, ips)
+	c2 := NewTLSCert(big.NewInt(1), "ch", "epfl", "lca1", 10, []byte{}, ips)
+	var key1, key2 TLSKeyPEM
+	si1.Cert, key1, _ = NewCertKey(c1, 256)
+	si2.Cert, key2, _ = NewCertKey(c2, 256)
+	r1, err := NewTLSRouter(si1, key1)
+	log.ErrFatal(err)
+	r2, err := NewTLSRouter(si2, key2)
+	log.ErrFatal(err)
+
+	go r1.Start()
+	go r2.Start()
+	defer r1.Stop()
+	defer r2.Stop()
+
+	c21, err := r2.connect(si1)
+	log.ErrFatal(err)
+	msg := &BigMsg{Array: []byte{1, 2, 3}}
+	log.ErrFatal(c21.Send(msg))
+	log.ErrFatal(c21.Close())
+
+	si1_numerical := NewTestServerIdentityTLS("tls://127.0.0.1:2000", si1.Cert)
+	c21, err = r2.connect(si1_numerical)
+	log.ErrFatal(err)
+	log.ErrFatal(c21.Send(msg))
+	log.ErrFatal(c21.Close())
+}

--- a/network/tlskc.go
+++ b/network/tlskc.go
@@ -1,0 +1,128 @@
+package network
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"time"
+
+	"net"
+
+	"crypto/ecdsa"
+
+	"crypto/elliptic"
+
+	"github.com/dedis/cothority/log"
+)
+
+// TLSCertPEM is a PEM-encoded certificate for a TLS connection.
+type TLSCertPEM string
+
+// TLSKeyPEM is a PEM-encoded private key for a TLS connection.
+type TLSKeyPEM string
+
+// NewTLSCert returns a x509-certificate valid for all CommonNames.
+func NewTLSCert(serial *big.Int, country, org, orgUnit string,
+	validYear int, subjectKeyID []byte,
+	ips []net.IP) *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			Country:            []string{country},
+			Organization:       []string{org},
+			OrganizationalUnit: []string{orgUnit},
+			CommonName:         "*",
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(validYear, 0, 0),
+		SubjectKeyId: subjectKeyID,
+		// Indicates to use IsCA
+		BasicConstraintsValid: true,
+		// Is Certificate Authority - can sign keys
+		IsCA: true,
+		// The IP-addresses this certificate is valid for
+		IPAddresses: ips,
+		// Extended key usage - the certificate can be used to authenticate the
+		// server.
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		// Standard key usage - only use for signing the certificate.
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+}
+
+// NewCertKey returns a PEM-encoded certificate and key. If an error occurs,
+// both the cert and key are empty.
+func NewCertKey(ca *x509.Certificate, keyLen int) (cert TLSCertPEM, key TLSKeyPEM, err error) {
+	if keyLen < 256 {
+		log.Warn("Small key-length:", keyLen)
+	}
+	//priv, err := rsa.GenerateKey(rand.Reader, keyLen)
+	var priv *ecdsa.PrivateKey
+	switch keyLen {
+	case 224:
+		priv, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case 256:
+		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case 384:
+		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case 521:
+		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	default:
+		err = errors.New("unknown key-length - chose 224, 256, 384 or 521")
+	}
+	if err != nil {
+		return
+	}
+	pub := &priv.PublicKey
+	x509cert, err := x509.CreateCertificate(rand.Reader, ca, ca, pub, priv)
+	if err != nil {
+		return
+	}
+	cert = TLSCertPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE",
+		Bytes: x509cert}))
+	b, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return
+	}
+	key = TLSKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: b}))
+	return
+}
+
+func secureConfig(c *tls.Config) *tls.Config {
+	// This makes sure that we only get a connection with ECDHE
+	// key-exchange.
+	c.CipherSuites = []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
+	c.MinVersion = tls.VersionTLS12
+	return c
+}
+
+// ConfigClient returns a tls.Config usable for a call to tls.Dial.
+func (cert TLSCertPEM) ConfigClient() (*tls.Config, error) {
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(cert))
+	if !ok {
+		return nil, errors.New("couldn't get root cert")
+	}
+	return secureConfig(&tls.Config{
+		RootCAs:            roots,
+		InsecureSkipVerify: false,
+	}), nil
+}
+
+// ConfigServer returns a tls.Config usable for a call to tls.Listen.
+func (key TLSKeyPEM) ConfigServer(cert TLSCertPEM) (*tls.Config, error) {
+	x509cert, err := tls.X509KeyPair([]byte(cert), []byte(key))
+	if err != nil {
+		panic(err)
+	}
+	return secureConfig(&tls.Config{
+		Certificates: []tls.Certificate{x509cert},
+	}), nil
+}


### PR DESCRIPTION
Closes #83 - comments from previous, cothority-PR:

- [x] - move `TLSKC.Key` from `ServerIdentity` to `TLSHost`
- [x] - check why it doesn't work with IP-addresses (127.0.0.1 instead of 'localhost').
- [ ] - clean up `CommonName` / `IP` / `DNS`
- [ ] - enter Country, Org, ... on keyboard
- [ ] - also allow `PlainTCP` in a `TLSHost` - does that really make sense?
