### PR TITLE
Makes app.Group's Description field public

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -88,12 +88,12 @@ type ServerToml struct {
 // Group holds the Roster and the server-description.
 type Group struct {
 	Roster      *onet.Roster
-	description map[*network.ServerIdentity]string
+	Description map[*network.ServerIdentity]string
 }
 
 // GetDescription returns the description of a ServerIdentity.
 func (g *Group) GetDescription(e *network.ServerIdentity) string {
-	return g.description[e]
+	return g.Description[e]
 }
 
 // ReadGroupDescToml reads a group.toml file and returns the list of ServerIdentities

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -46,10 +46,10 @@ func TestReadGroupDescToml(t *testing.T) {
 	if !nikkoAddr.Valid() || nikkoAddr != network.NewTCPAddress("5.135.161.91:2000") {
 		t.Fatal("Address not valid " + group.Roster.List[0].Address.String())
 	}
-	if len(group.description) != 2 {
+	if len(group.Description) != 2 {
 		t.Fatal("Should have 2 descriptions")
 	}
-	if group.description[group.Roster.List[1]] != "Ismail's server" {
+	if group.Description[group.Roster.List[1]] != "Ismail's server" {
 		t.Fatal("This should be Ismail's server")
 	}
 }


### PR DESCRIPTION
Makes app.Group's Description field public. There is no constructor, and I need to set the description file for the simulations.