### PR TITLE
[Crypto] Moving to v0

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/crypto"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // CothorityConfig is the configuration structure of the cothority daemon.

--- a/app/server.go
+++ b/app/server.go
@@ -22,8 +22,8 @@ import (
 	// CoSi-protocol is not part of the cothority.
 
 	// For the moment, the server only serves CoSi requests
-	"github.com/dedis/crypto/abstract"
-	crypconf "github.com/dedis/crypto/config"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	crypconf "gopkg.in/dedis/crypto.v0/config"
 )
 
 // DefaultServerConfig is the default server configuration file-name.

--- a/context_test.go
+++ b/context_test.go
@@ -11,10 +11,10 @@ import (
 
 	"strings"
 
-	"github.com/dedis/crypto/random"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/dedis/crypto.v0/random"
 )
 
 type ContextData struct {

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -10,8 +10,8 @@ import (
 	"encoding"
 	"reflect"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/log"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // Hash simply returns the Hash of the slice of bytes given

--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -10,10 +10,10 @@ import (
 
 	"encoding"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/ed25519"
 	"github.com/dedis/onet/log"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/ed25519"
 )
 
 var hashSuite = ed25519.NewAES128SHA256Ed25519(false)

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"io"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // Read64Pub a public point to a base64 representation

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -5,9 +5,9 @@ import (
 
 	"bytes"
 
-	"github.com/dedis/crypto/edwards"
 	"github.com/dedis/onet/log"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/dedis/crypto.v0/edwards"
 )
 
 var s = edwards.NewAES128SHA256Ed25519(false)

--- a/crypto/schnorr.go
+++ b/crypto/schnorr.go
@@ -3,8 +3,8 @@ package crypto
 import (
 	"errors"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/random"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/random"
 )
 
 // SchnorrSig is a signature created using the Schnorr Signature scheme.

--- a/crypto/schnorr_test.go
+++ b/crypto/schnorr_test.go
@@ -3,8 +3,8 @@ package crypto
 import (
 	"testing"
 
-	"github.com/dedis/crypto/config"
-	"github.com/dedis/crypto/ed25519"
+	"gopkg.in/dedis/crypto.v0/config"
+	"gopkg.in/dedis/crypto.v0/ed25519"
 )
 
 func TestSchnorrSignature(t *testing.T) {

--- a/local.go
+++ b/local.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/satori/go.uuid"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
 )
 
 // LocalTest represents all that is needed for a local test-run

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -7,11 +7,11 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/ed25519"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/protobuf"
 	"github.com/satori/go.uuid"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/ed25519"
 )
 
 /// Encoding part ///

--- a/network/struct.go
+++ b/network/struct.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/crypto"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/protobuf"
 	"github.com/satori/go.uuid"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // MaxRetryConnect defines how many times we should try to connect.

--- a/network/struct_test.go
+++ b/network/struct_test.go
@@ -3,8 +3,8 @@ package network
 import (
 	"testing"
 
-	"github.com/dedis/crypto/config"
 	"github.com/dedis/onet/log"
+	"gopkg.in/dedis/crypto.v0/config"
 )
 
 func TestServerIdentity(t *testing.T) {

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dedis/crypto/config"
 	"github.com/dedis/onet/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/dedis/crypto.v0/config"
 )
 
 func init() {

--- a/overlay.go
+++ b/overlay.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/satori/go.uuid"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // Overlay keeps all trees and entity-lists for a given Server. It creates

--- a/server.go
+++ b/server.go
@@ -16,9 +16,9 @@ import (
 
 	"fmt"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // Server connects the Router, the Overlay, and the Services together. It sets

--- a/simulation.go
+++ b/simulation.go
@@ -10,10 +10,10 @@ import (
 	"net"
 
 	"github.com/BurntSushi/toml"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
 )
 
 type simulationCreate func(string) (Simulation, error)
@@ -264,7 +264,7 @@ func (s *SimulationBFTree) CreateRoster(sc *SimulationConfig, addresses []string
 		if sc.PrivateKeys[entities[0].Address].Equal(
 			sc.PrivateKeys[entities[1].Address]) {
 			log.Fatal("Please update dedis/crypto with\n" +
-				"go get -u github.com/dedis/crypto")
+				"go get -u gopkg.in/dedis/crypto.v0")
 		}
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -6,10 +6,10 @@ import (
 
 	"math/rand"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/satori/go.uuid"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // In this file we define the main structures used for a running protocol

--- a/tree_test.go
+++ b/tree_test.go
@@ -6,12 +6,12 @@ import (
 
 	"strings"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
 )
 
 var tSuite = network.Suite

--- a/treenode.go
+++ b/treenode.go
@@ -8,9 +8,9 @@ import (
 
 	"strings"
 
-	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
 // TreeNodeInstance represents a protocol-instance in a given TreeNode. It embeds an


### PR DESCRIPTION
This PR fixes #106 : it moves all dependencies from `github.com/dedis/crypto` to `gopkg.in/dedis/crypto.v0`.