### PR TITLE
adding all missing functions

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -5,10 +5,12 @@ import (
 	"encoding/hex"
 	"io"
 
+	"errors"
+
 	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
-// Read64Pub a public point to a base64 representation
+// Read64Pub reads a public point from a base64 representation
 func Read64Pub(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
 	public := suite.Point()
 	dec := base64.NewDecoder(base64.StdEncoding, r)
@@ -22,12 +24,6 @@ func Write64Pub(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 	return write64(suite, enc, point)
 }
 
-// Write64Scalar converts a scalar key to a Base64-string
-func Write64Scalar(suite abstract.Suite, w io.Writer, scalar abstract.Scalar) error {
-	enc := base64.NewEncoder(base64.StdEncoding, w)
-	return write64(suite, enc, scalar)
-}
-
 // Read64Scalar takes a Base64-encoded scalar and returns that scalar,
 // optionally an error
 func Read64Scalar(suite abstract.Suite, r io.Reader) (abstract.Scalar, error) {
@@ -35,6 +31,57 @@ func Read64Scalar(suite abstract.Suite, r io.Reader) (abstract.Scalar, error) {
 	dec := base64.NewDecoder(base64.StdEncoding, r)
 	err := suite.Read(dec, &s)
 	return s, err
+}
+
+// Write64Scalar converts a scalar key to a Base64-string
+func Write64Scalar(suite abstract.Suite, w io.Writer, scalar abstract.Scalar) error {
+	enc := base64.NewEncoder(base64.StdEncoding, w)
+	return write64(suite, enc, scalar)
+}
+
+// ReadHexPub reads a public point from a hex representation
+func ReadHexPub(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
+	public := suite.Point()
+	buf, err := getHex(r, public.MarshalSize())
+	if err != nil {
+		return nil, err
+	}
+	public.UnmarshalBinary(buf)
+	return public, err
+}
+
+// WriteHexPub writes a public point to a hex representation
+func WriteHexPub(suite abstract.Suite, w io.Writer, point abstract.Point) error {
+	buf, err := point.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	out := hex.EncodeToString(buf)
+	_, err = w.Write([]byte(out))
+	return err
+}
+
+// ReadHexScalar takes a hex-encoded scalar and returns that scalar,
+// optionally an error
+func ReadHexScalar(suite abstract.Suite, r io.Reader) (abstract.Scalar, error) {
+	s := suite.Scalar()
+	buf, err := getHex(r, s.MarshalSize())
+	if err != nil {
+		return nil, err
+	}
+	s.UnmarshalBinary(buf)
+	return s, nil
+}
+
+// WriteHexScalar converts a scalar key to a hex-string
+func WriteHexScalar(suite abstract.Suite, w io.Writer, scalar abstract.Scalar) error {
+	buf, err := scalar.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	out := hex.EncodeToString(buf)
+	_, err = w.Write([]byte(out))
+	return err
 }
 
 // PubToStringHex converts a Public point to a hexadecimal representation
@@ -47,6 +94,24 @@ func PubToStringHex(suite abstract.Suite, point abstract.Point) (string, error) 
 // right struct
 func StringHexToPub(suite abstract.Suite, s string) (abstract.Point, error) {
 	encoded, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	point := suite.Point()
+	err = point.UnmarshalBinary(encoded)
+	return point, err
+}
+
+// PubToString64 converts a Public point to a base64 representation
+func PubToString64(suite abstract.Suite, point abstract.Point) (string, error) {
+	pbuf, err := point.MarshalBinary()
+	return base64.StdEncoding.EncodeToString(pbuf), err
+}
+
+// String64ToPub reads a base64 representation of a public point and converts it
+// back to a point.
+func String64ToPub(suite abstract.Suite, s string) (abstract.Point, error) {
+	encoded, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +137,48 @@ func StringHexToScalar(suite abstract.Suite, str string) (abstract.Scalar, error
 	return s, err
 }
 
+// ScalarToString64 encodes a scalar to a base64
+func ScalarToString64(suite abstract.Suite, scalar abstract.Scalar) (string, error) {
+	sbuf, err := scalar.MarshalBinary()
+	return base64.StdEncoding.EncodeToString(sbuf), err
+}
+
+// String64ToScalar reads a scalar in base64 from a string
+func String64ToScalar(suite abstract.Suite, str string) (abstract.Scalar, error) {
+	enc, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return nil, err
+	}
+	s := suite.Scalar()
+	err = s.UnmarshalBinary(enc)
+	return s, err
+}
+
 func write64(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
+	if err := suite.Write(wc, data); err != nil {
+		return err
+	}
+	return wc.Close()
+}
+
+func getHex(r io.Reader, len int) ([]byte, error) {
+	bufHex := make([]byte, len*2)
+	bufByte := make([]byte, len)
+	l, err := r.Read(bufHex)
+	if err != nil {
+		return nil, err
+	}
+	if l < len {
+		return nil, errors.New("didn't get enough bytes from stream")
+	}
+	_, err = hex.Decode(bufByte, bufHex)
+	if err != nil {
+		return nil, err
+	}
+	return bufByte, nil
+}
+
+func writeHex(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
 	if err := suite.Write(wc, data); err != nil {
 		return err
 	}

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -7,6 +7,8 @@ import (
 
 	"errors"
 
+	"strings"
+
 	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
@@ -93,13 +95,7 @@ func PubToStringHex(suite abstract.Suite, point abstract.Point) (string, error) 
 // StringHexToPub reads a hexadecimal representation of a public point and convert it to the
 // right struct
 func StringHexToPub(suite abstract.Suite, s string) (abstract.Point, error) {
-	encoded, err := hex.DecodeString(s)
-	if err != nil {
-		return nil, err
-	}
-	point := suite.Point()
-	err = point.UnmarshalBinary(encoded)
-	return point, err
+	return ReadHexPub(suite, strings.NewReader(s))
 }
 
 // PubToString64 converts a Public point to a base64 representation
@@ -111,13 +107,7 @@ func PubToString64(suite abstract.Suite, point abstract.Point) (string, error) {
 // String64ToPub reads a base64 representation of a public point and converts it
 // back to a point.
 func String64ToPub(suite abstract.Suite, s string) (abstract.Point, error) {
-	encoded, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		return nil, err
-	}
-	point := suite.Point()
-	err = point.UnmarshalBinary(encoded)
-	return point, err
+	return Read64Pub(suite, strings.NewReader(s))
 }
 
 // ScalarToStringHex encodes a scalar to hexadecimal
@@ -128,13 +118,7 @@ func ScalarToStringHex(suite abstract.Suite, scalar abstract.Scalar) (string, er
 
 // StringHexToScalar reads a scalar in hexadecimal from string
 func StringHexToScalar(suite abstract.Suite, str string) (abstract.Scalar, error) {
-	enc, err := hex.DecodeString(str)
-	if err != nil {
-		return nil, err
-	}
-	s := suite.Scalar()
-	err = s.UnmarshalBinary(enc)
-	return s, err
+	return ReadHexScalar(suite, strings.NewReader(str))
 }
 
 // ScalarToString64 encodes a scalar to a base64
@@ -145,13 +129,7 @@ func ScalarToString64(suite abstract.Suite, scalar abstract.Scalar) (string, err
 
 // String64ToScalar reads a scalar in base64 from a string
 func String64ToScalar(suite abstract.Suite, str string) (abstract.Scalar, error) {
-	enc, err := base64.StdEncoding.DecodeString(str)
-	if err != nil {
-		return nil, err
-	}
-	s := suite.Scalar()
-	err = s.UnmarshalBinary(enc)
-	return s, err
+	return Read64Scalar(suite, strings.NewReader(str))
 }
 
 func write64(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
@@ -176,11 +154,4 @@ func getHex(r io.Reader, len int) ([]byte, error) {
 		return nil, err
 	}
 	return bufByte, nil
-}
-
-func writeHex(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
-	if err := suite.Write(wc, data); err != nil {
-		return err
-	}
-	return wc.Close()
 }

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -21,7 +21,11 @@ func TestPub64(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
 	log.ErrFatal(Write64Pub(s, b, p))
+	log.ErrFatal(Write64Pub(s, b, p))
 	p2, err := Read64Pub(s, b)
+	log.ErrFatal(err)
+	require.Equal(t, p, p2)
+	p2, err = Read64Pub(s, b)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
 }
@@ -31,12 +35,44 @@ func TestScalar64(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	sc := s.Scalar().Pick(rand)
 	log.ErrFatal(Write64Scalar(s, b, sc))
+	log.ErrFatal(Write64Scalar(s, b, sc))
 	s2, err := Read64Scalar(s, b)
+	log.ErrFatal(err)
+	require.True(t, sc.Equal(s2))
+	s2, err = Read64Scalar(s, b)
 	log.ErrFatal(err)
 	require.True(t, sc.Equal(s2))
 }
 
-func TestPubHex(t *testing.T) {
+func TestPubHexStream(t *testing.T) {
+	b := &bytes.Buffer{}
+	rand := s.Cipher([]byte("example"))
+	p, _ := s.Point().Pick(nil, rand)
+	log.ErrFatal(WriteHexPub(s, b, p))
+	log.ErrFatal(WriteHexPub(s, b, p))
+	p2, err := ReadHexPub(s, b)
+	log.ErrFatal(err)
+	require.Equal(t, p, p2)
+	p2, err = ReadHexPub(s, b)
+	log.ErrFatal(err)
+	require.Equal(t, p, p2)
+}
+
+func TestScalarHexStream(t *testing.T) {
+	b := &bytes.Buffer{}
+	rand := s.Cipher([]byte("example"))
+	sc := s.Scalar().Pick(rand)
+	log.ErrFatal(WriteHexScalar(s, b, sc))
+	log.ErrFatal(WriteHexScalar(s, b, sc))
+	s2, err := ReadHexScalar(s, b)
+	log.ErrFatal(err)
+	require.True(t, sc.Equal(s2))
+	s2, err = ReadHexScalar(s, b)
+	log.ErrFatal(err)
+	require.True(t, sc.Equal(s2))
+}
+
+func TestPubHexString(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
 	pstr, err := PubToStringHex(s, p)
@@ -46,12 +82,32 @@ func TestPubHex(t *testing.T) {
 	require.Equal(t, p, p2)
 }
 
-func TestScalarHex(t *testing.T) {
+func TestPub64String(t *testing.T) {
+	rand := s.Cipher([]byte("example"))
+	p, _ := s.Point().Pick(nil, rand)
+	pstr, err := PubToString64(s, p)
+	log.ErrFatal(err)
+	p2, err := String64ToPub(s, pstr)
+	log.ErrFatal(err)
+	require.Equal(t, p, p2)
+}
+
+func TestScalarHexString(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	sc := s.Scalar().Pick(rand)
 	scstr, err := ScalarToStringHex(s, sc)
 	log.ErrFatal(err)
 	s2, err := StringHexToScalar(s, scstr)
+	log.ErrFatal(err)
+	require.True(t, sc.Equal(s2))
+}
+
+func TestScalar64String(t *testing.T) {
+	rand := s.Cipher([]byte("example"))
+	sc := s.Scalar().Pick(rand)
+	scstr, err := ScalarToString64(s, sc)
+	log.ErrFatal(err)
+	s2, err := String64ToScalar(s, scstr)
 	log.ErrFatal(err)
 	require.True(t, sc.Equal(s2))
 }


### PR DESCRIPTION
Now we have all of
`(Read|Write)(64|Hex)(Scalar|Pub)`
and
`String(64|Hex)To(Scalar|Pub)`
and
`(Scalar|Pub)ToString(64|Hex)`

For V2: replace `Pub` with `Point`, see #116 