### PR TITLE
Rename every 'Public' in abstract 'Point' instead

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -53,7 +53,7 @@ func ParseCothority(file string) (*CothorityConfig, *onet.Server, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	point, err := crypto.StringHexToPub(network.Suite, hc.Public)
+	point, err := crypto.StringHexToPoint(network.Suite, hc.Public)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func (gt *GroupToml) String() string {
 // toServerIdentity converts this ServerToml struct to a ServerIdentity.
 func (s *ServerToml) toServerIdentity(suite abstract.Suite) (*network.ServerIdentity, error) {
 	pubR := strings.NewReader(s.Public)
-	public, err := crypto.Read64Pub(suite, pubR)
+	public, err := crypto.Read64Point(suite, pubR)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (s *ServerToml) toServerIdentity(suite abstract.Suite) (*network.ServerIden
 func NewServerToml(suite abstract.Suite, public abstract.Point, addr network.Address,
 	desc string) *ServerToml {
 	var buff bytes.Buffer
-	if err := crypto.Write64Pub(suite, &buff, public); err != nil {
+	if err := crypto.Write64Point(suite, &buff, public); err != nil {
 		log.Error("Error writing public key")
 		return nil
 	}

--- a/app/server.go
+++ b/app/server.go
@@ -166,7 +166,7 @@ func InteractiveConfig(binaryName string) {
 		}
 	}
 
-	public, err := crypto.StringHexToPub(network.Suite, pubStr)
+	public, err := crypto.StringHexToPoint(network.Suite, pubStr)
 	if err != nil {
 		log.Fatal("Impossible to parse public key:", err)
 	}
@@ -210,7 +210,7 @@ func createKeyPair() (string, string) {
 	// use the transformation for EdDSA signatures
 	//point = cosi.Ed25519Public(network.Suite, kp.Secret)
 	point = kp.Public
-	pubStr, err := crypto.PubToStringHex(network.Suite, point)
+	pubStr, err := crypto.PointToStringHex(network.Suite, point)
 	if err != nil {
 		log.Fatal("Could not parse public key. Abort.")
 	}

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -12,16 +12,16 @@ import (
 	"gopkg.in/dedis/crypto.v0/abstract"
 )
 
-// Read64Pub reads a public point from a base64 representation
-func Read64Pub(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
-	public := suite.Point()
+// Read64Point reads a point from a base64 representation
+func Read64Point(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
+	point := suite.Point()
 	dec := base64.NewDecoder(base64.StdEncoding, r)
-	err := suite.Read(dec, &public)
-	return public, err
+	err := suite.Read(dec, &point)
+	return point, err
 }
 
-// Write64Pub writes a public point to a base64 representation
-func Write64Pub(suite abstract.Suite, w io.Writer, point abstract.Point) error {
+// Write64Point writes a point to a base64 representation
+func Write64Point(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 	enc := base64.NewEncoder(base64.StdEncoding, w)
 	return write64(suite, enc, point)
 }
@@ -41,19 +41,19 @@ func Write64Scalar(suite abstract.Suite, w io.Writer, scalar abstract.Scalar) er
 	return write64(suite, enc, scalar)
 }
 
-// ReadHexPub reads a public point from a hex representation
-func ReadHexPub(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
-	public := suite.Point()
-	buf, err := getHex(r, public.MarshalSize())
+// ReadHexPoint reads a point from a hex representation
+func ReadHexPoint(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
+	point := suite.Point()
+	buf, err := getHex(r, point.MarshalSize())
 	if err != nil {
 		return nil, err
 	}
-	public.UnmarshalBinary(buf)
-	return public, err
+	point.UnmarshalBinary(buf)
+	return point, err
 }
 
-// WriteHexPub writes a public point to a hex representation
-func WriteHexPub(suite abstract.Suite, w io.Writer, point abstract.Point) error {
+// WriteHexPoint writes a point to a hex representation
+func WriteHexPoint(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 	buf, err := point.MarshalBinary()
 	if err != nil {
 		return err
@@ -86,28 +86,28 @@ func WriteHexScalar(suite abstract.Suite, w io.Writer, scalar abstract.Scalar) e
 	return err
 }
 
-// PubToStringHex converts a Public point to a hexadecimal representation
-func PubToStringHex(suite abstract.Suite, point abstract.Point) (string, error) {
+// PointToStringHex converts a point to a hexadecimal representation
+func PointToStringHex(suite abstract.Suite, point abstract.Point) (string, error) {
 	pbuf, err := point.MarshalBinary()
 	return hex.EncodeToString(pbuf), err
 }
 
-// StringHexToPub reads a hexadecimal representation of a public point and convert it to the
+// StringHexToPoint reads a hexadecimal representation of a point and convert it to the
 // right struct
-func StringHexToPub(suite abstract.Suite, s string) (abstract.Point, error) {
-	return ReadHexPub(suite, strings.NewReader(s))
+func StringHexToPoint(suite abstract.Suite, s string) (abstract.Point, error) {
+	return ReadHexPoint(suite, strings.NewReader(s))
 }
 
-// PubToString64 converts a Public point to a base64 representation
-func PubToString64(suite abstract.Suite, point abstract.Point) (string, error) {
+// PointToString64 converts a point to a base64 representation
+func PointToString64(suite abstract.Suite, point abstract.Point) (string, error) {
 	pbuf, err := point.MarshalBinary()
 	return base64.StdEncoding.EncodeToString(pbuf), err
 }
 
-// String64ToPub reads a base64 representation of a public point and converts it
+// String64ToPoint reads a base64 representation of a point and converts it
 // back to a point.
-func String64ToPub(suite abstract.Suite, s string) (abstract.Point, error) {
-	return Read64Pub(suite, strings.NewReader(s))
+func String64ToPoint(suite abstract.Suite, s string) (abstract.Point, error) {
+	return Read64Point(suite, strings.NewReader(s))
 }
 
 // ScalarToStringHex encodes a scalar to hexadecimal

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -20,12 +20,12 @@ func TestPub64(t *testing.T) {
 	b := &bytes.Buffer{}
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
-	log.ErrFatal(Write64Pub(s, b, p))
-	log.ErrFatal(Write64Pub(s, b, p))
-	p2, err := Read64Pub(s, b)
+	log.ErrFatal(Write64Point(s, b, p))
+	log.ErrFatal(Write64Point(s, b, p))
+	p2, err := Read64Point(s, b)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
-	p2, err = Read64Pub(s, b)
+	p2, err = Read64Point(s, b)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
 }
@@ -48,12 +48,12 @@ func TestPubHexStream(t *testing.T) {
 	b := &bytes.Buffer{}
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
-	log.ErrFatal(WriteHexPub(s, b, p))
-	log.ErrFatal(WriteHexPub(s, b, p))
-	p2, err := ReadHexPub(s, b)
+	log.ErrFatal(WriteHexPoint(s, b, p))
+	log.ErrFatal(WriteHexPoint(s, b, p))
+	p2, err := ReadHexPoint(s, b)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
-	p2, err = ReadHexPub(s, b)
+	p2, err = ReadHexPoint(s, b)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
 }
@@ -75,9 +75,9 @@ func TestScalarHexStream(t *testing.T) {
 func TestPubHexString(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
-	pstr, err := PubToStringHex(s, p)
+	pstr, err := PointToStringHex(s, p)
 	log.ErrFatal(err)
-	p2, err := StringHexToPub(s, pstr)
+	p2, err := StringHexToPoint(s, pstr)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
 }
@@ -85,9 +85,9 @@ func TestPubHexString(t *testing.T) {
 func TestPub64String(t *testing.T) {
 	rand := s.Cipher([]byte("example"))
 	p, _ := s.Point().Pick(nil, rand)
-	pstr, err := PubToString64(s, p)
+	pstr, err := PointToString64(s, p)
 	log.ErrFatal(err)
-	p2, err := String64ToPub(s, pstr)
+	p2, err := String64ToPoint(s, pstr)
 	log.ErrFatal(err)
 	require.Equal(t, p, p2)
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -121,7 +121,7 @@ func (si *ServerIdentity) Equal(e2 *ServerIdentity) bool {
 // Toml converts an ServerIdentity to a Toml-structure
 func (si *ServerIdentity) Toml(suite abstract.Suite) *ServerIdentityToml {
 	var buf bytes.Buffer
-	if err := crypto.Write64Pub(suite, &buf, si.Public); err != nil {
+	if err := crypto.Write64Point(suite, &buf, si.Public); err != nil {
 		log.Error("Error while writing public key:", err)
 	}
 	return &ServerIdentityToml{
@@ -132,7 +132,7 @@ func (si *ServerIdentity) Toml(suite abstract.Suite) *ServerIdentityToml {
 
 // ServerIdentity converts an ServerIdentityToml structure back to an ServerIdentity
 func (si *ServerIdentityToml) ServerIdentity(suite abstract.Suite) *ServerIdentity {
-	pub, err := crypto.Read64Pub(suite, strings.NewReader(si.Public))
+	pub, err := crypto.Read64Point(suite, strings.NewReader(si.Public))
 	if err != nil {
 		log.Error("Error while reading public key:", err)
 	}


### PR DESCRIPTION
A lot of these functions contains a abstract.Suite as first argument, which is unused. Why is so?
Solved #116 