### PR TITLE
starting simulation.Node only once all conodes are started

### DIFF
--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -117,7 +117,7 @@ func Simulate(serverAddress, simul, monitorAddress string) error {
 		syncWait := monitor.NewTimeMeasure("SimulSyncWait")
 		wgSimulInit.Add(len(rootSC.Tree.Roster.List))
 		for _, conode := range rootSC.Tree.Roster.List {
-			rootSC.Server.Send(conode, &simulInit{})
+			go rootSC.Server.Send(conode, &simulInit{})
 		}
 		wgSimulInit.Wait()
 		syncWait.Record()


### PR DESCRIPTION
In simulation-mode, this adds a listener to all servers, so that it can receive a broadcast-message and then start the `simulation.Node`. This makes sure that all nodes are up before `simulation.Node` is called.