### PR TITLE
Log.Error to log.Lvl5 for late message to overlay

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -137,7 +137,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 	done := o.instancesInfo[onetMsg.To.ID()]
 	o.instancesLock.Unlock()
 	if done {
-		log.Error("Message for TreeNodeInstance that is already finished")
+		log.Lvl5("Message for TreeNodeInstance that is already finished")
 		return nil
 	}
 	// if the TreeNodeInstance is not there, creates it


### PR DESCRIPTION
This PR is a quick fix to remove the annoying log.Error output from overlay message.