### PR TITLE
V1.0 merge

### DIFF
--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -28,7 +28,7 @@ func TestHash(t *testing.T) {
 	hasher.Write(buf)
 	b := hasher.Sum(nil)
 	if !bytes.Equal(b, hashed) {
-		t.Fatal("Hashes are not equals")
+		t.Fatal("Hashes are not equal")
 	}
 }
 
@@ -150,7 +150,7 @@ func TestHashSuite(t *testing.T) {
 		t.Fatal("error hashing" + err.Error() + err2.Error())
 	}
 	if !bytes.Equal(hashed, hashedSuite) {
-		t.Fatal("hashes not equals")
+		t.Fatal("hashes not equal")
 	}
 }
 

--- a/local.go
+++ b/local.go
@@ -237,7 +237,7 @@ func (l *LocalTest) getNodes(tn *TreeNode) []*TreeNodeInstance {
 // sendTreeNode injects a message directly in the Overlay-layer, bypassing
 // Host and Network
 func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg network.Message) error {
-	if from.Tree().ID != to.Tree().ID {
+	if !from.Tree().ID.Equal(to.Tree().ID) {
 		return errors.New("Can't send from one tree to another")
 	}
 	onetMsg := &ProtocolMsg{

--- a/local.go
+++ b/local.go
@@ -237,7 +237,7 @@ func (l *LocalTest) getNodes(tn *TreeNode) []*TreeNodeInstance {
 // sendTreeNode injects a message directly in the Overlay-layer, bypassing
 // Host and Network
 func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg network.Message) error {
-	if !from.Tree().ID.Equals(to.Tree().ID) {
+	if !from.Tree().ID.Equal(to.Tree().ID) {
 		return errors.New("Can't send from one tree to another")
 	}
 	onetMsg := &ProtocolMsg{

--- a/local.go
+++ b/local.go
@@ -237,7 +237,7 @@ func (l *LocalTest) getNodes(tn *TreeNode) []*TreeNodeInstance {
 // sendTreeNode injects a message directly in the Overlay-layer, bypassing
 // Host and Network
 func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg network.Message) error {
-	if !from.Tree().ID.Equal(to.Tree().ID) {
+	if !from.Tree().ID.Equals(to.Tree().ID) {
 		return errors.New("Can't send from one tree to another")
 	}
 	onetMsg := &ProtocolMsg{

--- a/messages.go
+++ b/messages.go
@@ -58,12 +58,33 @@ func (rId RoundID) String() string {
 	return uuid.UUID(rId).String()
 }
 
+// Equal returns true if and only if rID2 equals this RoundID.
+func (rId RoundID) Equal(rID2 RoundID) bool {
+	return uuid.Equal(uuid.UUID(rId), uuid.UUID(rID2))
+}
+
+// IsNil returns true iff the RoundID is Nil
+func (rId RoundID) IsNil() bool {
+	return rId.Equal(RoundID(uuid.Nil))
+}
+
 // TokenID uniquely identifies the start and end-point of a message by an ID
 // (see Token struct)
 type TokenID uuid.UUID
 
-func (t *TokenID) String() string {
-	return uuid.UUID(*t).String()
+// String returns the canonical representation of the TokenID (wrapper around // uuid.UUID.String())
+func (t TokenID) String() string {
+	return uuid.UUID(t).String()
+}
+
+// Equal returns true if and only if t2 equals this TokenID.
+func (t TokenID) Equal(t2 TokenID) bool {
+	return uuid.Equal(uuid.UUID(t), uuid.UUID(t2))
+}
+
+// IsNil returns true iff the TokenID is Nil
+func (t TokenID) IsNil() bool {
+	return t.Equal(TokenID(uuid.Nil))
 }
 
 // A Token contains all identifiers needed to uniquely identify one protocol
@@ -91,7 +112,7 @@ var tokenMutex sync.Mutex
 func (t *Token) ID() TokenID {
 	tokenMutex.Lock()
 	defer tokenMutex.Unlock()
-	if t.cacheID == TokenID(uuid.Nil) {
+	if t.cacheID.IsNil() {
 		url := network.NamespaceURL + "token/" + t.RosterID.String() +
 			t.RoundID.String() + t.ServiceID.String() + t.ProtoID.String() + t.TreeID.String() +
 			t.TreeNodeID.String()

--- a/network/big_test.go
+++ b/network/big_test.go
@@ -63,7 +63,7 @@ func TestTCPHugeConnections(t *testing.T) {
 				if err != nil {
 					t.Fatal("Couldn't receive msg:", err)
 				}
-				if nm.MsgType != bigMessageType {
+				if !nm.MsgType.Equal(bigMessageType) {
 					t.Fatal("Received message type is wrong")
 				}
 				bigCopy := nm.Msg.(*bigMessage)

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -44,9 +44,14 @@ func (mId MessageTypeID) String() string {
 	return uuid.UUID(mId).String()
 }
 
-// Equal returns true if pId is equal to t
-func (mId MessageTypeID) Equal(t MessageTypeID) bool {
-	return bytes.Compare(uuid.UUID(mId).Bytes(), uuid.UUID(t).Bytes()) == 0
+// Equal returns true if and only if mID2 equals this MessageTypeID
+func (mId MessageTypeID) Equal(mID2 MessageTypeID) bool {
+	return uuid.Equal(uuid.UUID(mId), uuid.UUID(mID2))
+}
+
+// IsNil returns true iff the MessageTypeID is Nil
+func (mId MessageTypeID) IsNil() bool {
+	return mId.Equal(MessageTypeID(uuid.Nil))
 }
 
 // NamespaceURL is the basic namespace used for uuid

--- a/network/encoding_test.go
+++ b/network/encoding_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,19 +13,19 @@ type TestRegisterS struct {
 }
 
 func TestRegister(t *testing.T) {
-	if MessageType(&TestRegisterS{}) != ErrorType {
+	if !MessageType(&TestRegisterS{}).Equal(ErrorType) {
 		t.Fatal("TestRegister should not yet be there")
 	}
 
 	trType := RegisterMessage(&TestRegisterS{})
-	if uuid.Equal(uuid.UUID(trType), uuid.Nil) {
+	if trType.IsNil() {
 		t.Fatal("Couldn't register TestRegister-struct")
 	}
 
-	if MessageType(&TestRegisterS{}) != trType {
+	if !MessageType(&TestRegisterS{}).Equal(trType) {
 		t.Fatal("TestRegister is different now")
 	}
-	if MessageType(TestRegisterS{}) != trType {
+	if !MessageType(TestRegisterS{}).Equal(trType) {
 		t.Fatal("TestRegister is different now")
 	}
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -83,9 +83,19 @@ type ServerIdentity struct {
 // ServerIdentityID uniquely identifies an ServerIdentity struct
 type ServerIdentityID uuid.UUID
 
+// String returns a canonical representation of the ServerIdentityID.
+func (eId ServerIdentityID) String() string {
+	return uuid.UUID(eId).String()
+}
+
 // Equal returns true if both ServerIdentityID are equal or false otherwise.
-func (eid ServerIdentityID) Equal(other ServerIdentityID) bool {
-	return uuid.Equal(uuid.UUID(eid), uuid.UUID(other))
+func (eId ServerIdentityID) Equal(other ServerIdentityID) bool {
+	return uuid.Equal(uuid.UUID(eId), uuid.UUID(other))
+}
+
+// IsNil returns true iff the ServerIdentityID is Nil
+func (eId ServerIdentityID) IsNil() bool {
+	return eId.Equal(ServerIdentityID(uuid.Nil))
 }
 
 func (si *ServerIdentity) String() string {

--- a/node_test.go
+++ b/node_test.go
@@ -155,7 +155,7 @@ func TestTreeNodeProtocolHandlers(t *testing.T) {
 	log.Lvl2("Waiting for response from child 2/2")
 	child2 := <-IncomingHandlers
 
-	if child1.ServerIdentity().ID == child2.ServerIdentity().ID {
+	if child1.ServerIdentity().ID.Equal(child2.ServerIdentity().ID) {
 		t.Fatal("Both entities should be different")
 	}
 
@@ -168,7 +168,7 @@ func TestTreeNodeProtocolHandlers(t *testing.T) {
 	}
 	child2.SendTo(tni.TreeNode(), &NodeTestAggMsg{})
 	final := <-IncomingHandlers
-	if final.ServerIdentity().ID != tni.ServerIdentity().ID {
+	if !final.ServerIdentity().ID.Equal(tni.ServerIdentity().ID) {
 		t.Fatal("This should be the same ID")
 	}
 }

--- a/overlay.go
+++ b/overlay.go
@@ -529,7 +529,7 @@ func (o *Overlay) Close() {
 // CreateProtocol creates a ProtocolInstance, registers it to the Overlay.
 // Additionally, if sid is different than NilServiceID, sid is added to the token
 // so the protocol will be picked up by the correct service and handled by its
-// NewProtocol method. If the sid is NilServiceID, then the protoocol is handled by onet alone.
+// NewProtocol method. If the sid is NilServiceID, then the protocol is handled by onet alone.
 func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolInstance, error) {
 	io := o.protoIO.getByName(name)
 	tni := o.NewTreeNodeInstanceFromService(t, t.Root, ProtocolNameToID(name), sid, io)

--- a/overlay.go
+++ b/overlay.go
@@ -195,7 +195,7 @@ func (o *Overlay) checkPendingMessages(t *Tree) {
 		o.pendingMsgLock.Lock()
 		var newPending []pendingMsg
 		for _, pending := range o.pendingMsg {
-			if t.ID.Equals(pending.ProtocolMsg.To.TreeID) {
+			if t.ID.Equal(pending.ProtocolMsg.To.TreeID) {
 				// if this message references t, instantiate it and go
 				err := o.TransmitMsg(pending.ProtocolMsg, pending.MessageProxy)
 				if err != nil {

--- a/overlay.go
+++ b/overlay.go
@@ -195,7 +195,7 @@ func (o *Overlay) checkPendingMessages(t *Tree) {
 		o.pendingMsgLock.Lock()
 		var newPending []pendingMsg
 		for _, pending := range o.pendingMsg {
-			if t.ID.Equal(pending.ProtocolMsg.To.TreeID) {
+			if t.ID.Equals(pending.ProtocolMsg.To.TreeID) {
 				// if this message references t, instantiate it and go
 				err := o.TransmitMsg(pending.ProtocolMsg, pending.MessageProxy)
 				if err != nil {

--- a/overlay.go
+++ b/overlay.go
@@ -81,7 +81,7 @@ func NewOverlay(c *Server) *Overlay {
 // wants.
 func (o *Overlay) Process(env *network.Envelope) {
 	// Messages handled by the overlay directly without any messageProxyIO
-	if env.MsgType == ConfigMsgID {
+	if env.MsgType.Equal(ConfigMsgID) {
 		o.handleConfigMessage(env)
 		return
 	}
@@ -195,7 +195,7 @@ func (o *Overlay) checkPendingMessages(t *Tree) {
 		o.pendingMsgLock.Lock()
 		var newPending []pendingMsg
 		for _, pending := range o.pendingMsg {
-			if t.ID.Equals(pending.ProtocolMsg.To.TreeID) {
+			if t.ID.Equal(pending.ProtocolMsg.To.TreeID) {
 				// if this message references t, instantiate it and go
 				err := o.TransmitMsg(pending.ProtocolMsg, pending.MessageProxy)
 				if err != nil {
@@ -357,7 +357,7 @@ func (o *Overlay) handleRequestTree(si *network.ServerIdentity, req *RequestTree
 }
 
 func (o *Overlay) handleSendTree(si *network.ServerIdentity, tm *TreeMarshal, io MessageProxy) {
-	if tm.TreeID == TreeID(uuid.Nil) {
+	if tm.TreeID.IsNil() {
 		log.Error("Received an empty Tree")
 		return
 	}
@@ -418,7 +418,7 @@ func (o *Overlay) handleRequestRoster(si *network.ServerIdentity, req *RequestRo
 }
 
 func (o *Overlay) handleSendRoster(si *network.ServerIdentity, roster *Roster) {
-	if roster.ID == RosterID(uuid.Nil) {
+	if roster.ID.IsNil() {
 		log.Lvl2("Received an empty Roster")
 	} else {
 		o.RegisterRoster(roster)

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -135,7 +135,7 @@ func TestOverlayRosterPropagation(t *testing.T) {
 		t.Fatal("Couldn't send message to h2:", err)
 	}
 	roster := <-proc.sendRoster
-	if roster.ID != RosterID(uuid.Nil) {
+	if !roster.ID.IsNil() {
 		t.Fatal("List should be empty")
 	}
 
@@ -146,7 +146,7 @@ func TestOverlayRosterPropagation(t *testing.T) {
 		t.Fatal("Couldn't send message to h2:", err)
 	}
 	msg := <-proc.sendRoster
-	if msg.ID != el.ID {
+	if !msg.ID.Equal(el.ID) {
 		t.Fatal("List should be equal to original list")
 	}
 
@@ -188,7 +188,7 @@ func TestOverlayTreePropagation(t *testing.T) {
 		t.Fatal("Couldn't send message to h2:", err)
 	}
 	msg := <-proc.treeMarshal
-	if msg.RosterID != RosterID(uuid.Nil) {
+	if !msg.RosterID.IsNil() {
 		t.Fatal("List should be empty")
 	}
 
@@ -295,10 +295,10 @@ func TestTokenId(t *testing.T) {
 		RoundID:  RoundID(uuid.NewV1()),
 	}
 	id2 := t2.ID()
-	if uuid.Equal(uuid.UUID(id1), uuid.UUID(id2)) {
+	if id1.Equal(id2) {
 		t.Fatal("Both token are the same")
 	}
-	if !uuid.Equal(uuid.UUID(id1), uuid.UUID(t1.ID())) {
+	if !id1.Equal(t1.ID()) {
 		t.Fatal("Twice the Id of the same token should be equal")
 	}
 	t3 := t1.ChangeTreeNodeID(TreeNodeID(uuid.NewV1()))

--- a/processor_test.go
+++ b/processor_test.go
@@ -29,7 +29,7 @@ func TestProcessor_AddMessage(t *testing.T) {
 		t.Fatal("Should have registered one function")
 	}
 	mt := network.MessageType(&testMsg{})
-	if mt == network.ErrorType {
+	if mt.Equal(network.ErrorType) {
 		t.Fatal("Didn't register message-type correctly")
 	}
 	var wrongFunctions = []interface{}{

--- a/protocol.go
+++ b/protocol.go
@@ -17,6 +17,16 @@ func (pid ProtocolID) String() string {
 	return uuid.UUID(pid).String()
 }
 
+// Equal returns true if and only if pid2 equals this ProtocolID.
+func (pid ProtocolID) Equal(pid2 ProtocolID) bool {
+	return uuid.Equal(uuid.UUID(pid), uuid.UUID(pid2))
+}
+
+// IsNil returns true iff the ProtocolID is Nil
+func (pid ProtocolID) IsNil() bool {
+	return pid.Equal(ProtocolID(uuid.Nil))
+}
+
 // NewProtocol is the function-signature needed to instantiate a new protocol
 type NewProtocol func(*TreeNodeInstance) (ProtocolInstance, error)
 
@@ -60,7 +70,7 @@ func newProtocolStorage() *protocolStorage {
 // ProtocolIDToName returns the name to the corresponding protocolID.
 func (ps *protocolStorage) ProtocolIDToName(id ProtocolID) string {
 	for n := range ps.instantiators {
-		if id == ProtocolNameToID(n) {
+		if id.Equal(ProtocolNameToID(n)) {
 			return n
 		}
 	}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -106,7 +106,7 @@ func TestProtocolRegistration(t *testing.T) {
 	if !protocols.ProtocolExists(testProtoID) {
 		t.Fatal("Test should exist now")
 	}
-	if ProtocolNameToID(testProtoName) != testProtoID {
+	if !ProtocolNameToID(testProtoName).Equal(testProtoID) {
 		t.Fatal("Not correct translation from string to ID")
 	}
 	require.Equal(t, "", protocols.ProtocolIDToName(ProtocolID(uuid.Nil)))

--- a/service_test.go
+++ b/service_test.go
@@ -544,7 +544,7 @@ func (ds *DummyService) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig) (
 }
 
 func (ds *DummyService) Process(env *network.Envelope) {
-	if env.MsgType != dummyMsgType {
+	if !env.MsgType.Equal(dummyMsgType) {
 		ds.link <- false
 		return
 	}

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -88,7 +88,7 @@ func Simulate(serverAddress, simul, monitorAddress string) error {
 		server.RegisterProcessorFunc(simulInitDoneID, func(env *network.Envelope) {
 			wgSimulInit.Done()
 		})
-		if server.ServerIdentity.ID == sc.Tree.Root.ServerIdentity.ID {
+		if server.ServerIdentity.ID.Equal(sc.Tree.Root.ServerIdentity.ID) {
 			log.Lvl2(serverAddress, "is root-node, will start protocol")
 			rootSim = sim
 			rootSC = sc

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -73,7 +73,7 @@ func TestSimulationLoadSave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !sc2[0].Tree.ID.Equal(sc.Tree.ID) {
+	if !sc2[0].Tree.ID.Equals(sc.Tree.ID) {
 		t.Fatal("Tree-id is not correct")
 	}
 	closeAll(sc2)

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -73,7 +73,7 @@ func TestSimulationLoadSave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sc2[0].Tree.ID != sc.Tree.ID {
+	if !sc2[0].Tree.ID.Equal(sc.Tree.ID) {
 		t.Fatal("Tree-id is not correct")
 	}
 	closeAll(sc2)
@@ -96,7 +96,7 @@ func TestSimulationMultipleInstances(t *testing.T) {
 	if len(sc2) != 4 {
 		t.Fatal("We should have 4 local1-hosts but have", len(sc2))
 	}
-	if sc2[0].Server.ServerIdentity.ID == sc2[1].Server.ServerIdentity.ID {
+	if sc2[0].Server.ServerIdentity.ID.Equal(sc2[1].Server.ServerIdentity.ID) {
 		t.Fatal("Hosts are not copies")
 	}
 }

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -73,7 +73,7 @@ func TestSimulationLoadSave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !sc2[0].Tree.ID.Equals(sc.Tree.ID) {
+	if !sc2[0].Tree.ID.Equal(sc.Tree.ID) {
 		t.Fatal("Tree-id is not correct")
 	}
 	closeAll(sc2)

--- a/tree.go
+++ b/tree.go
@@ -39,8 +39,8 @@ type Tree struct {
 // TreeID uniquely identifies a Tree struct in the onet framework.
 type TreeID uuid.UUID
 
-// Equal returns true if and only if tID2 equals this TreeID.
-func (tId TreeID) Equal(tID2 TreeID) bool {
+// Equals returns true if and only if tID2 equals this TreeID.
+func (tId TreeID) Equals(tID2 TreeID) bool {
 	return uuid.Equal(uuid.UUID(tId), uuid.UUID(tID2))
 }
 
@@ -51,7 +51,7 @@ func (tId TreeID) String() string {
 
 // IsNil returns true iff the TreeID is Nil
 func (tId TreeID) IsNil() bool {
-	return tId.Equal(TreeID(uuid.Nil))
+	return tId.Equals(TreeID(uuid.Nil))
 }
 
 // NewTree creates a new tree using the entityList and the root-node. It
@@ -147,7 +147,7 @@ func (t *Tree) BinaryUnmarshaler(b []byte) error {
 
 // Equal verifies if the given tree is equal
 func (t *Tree) Equal(t2 *Tree) bool {
-	if !t.ID.Equal(t2.ID) || !t.Roster.ID.Equal(t2.Roster.ID) {
+	if !t.ID.Equals(t2.ID) || !t.Roster.ID.Equal(t2.Roster.ID) {
 		log.Lvl4("Ids of trees don't match")
 		return false
 	}

--- a/tree.go
+++ b/tree.go
@@ -39,9 +39,15 @@ type Tree struct {
 // TreeID uniquely identifies a Tree struct in the onet framework.
 type TreeID uuid.UUID
 
-// Equals returns true if and only if tID2 equals this TreeID.
-func (tId TreeID) Equals(tID2 TreeID) bool {
+// Equal returns true if and only if tID2 equals this TreeID.
+func (tId TreeID) Equal(tID2 TreeID) bool {
 	return uuid.Equal(uuid.UUID(tId), uuid.UUID(tID2))
+}
+
+// Equals will be removed!
+func (tId TreeID) Equals(tID2 TreeID) bool {
+	log.Warn("Deprecated: TreeID.Equals will be removed in onet.v2")
+	return tId.Equal(tID2)
 }
 
 // String returns a canonical representation of the TreeID.
@@ -51,7 +57,7 @@ func (tId TreeID) String() string {
 
 // IsNil returns true iff the TreeID is Nil
 func (tId TreeID) IsNil() bool {
-	return tId.Equals(TreeID(uuid.Nil))
+	return tId.Equal(TreeID(uuid.Nil))
 }
 
 // NewTree creates a new tree using the entityList and the root-node. It
@@ -147,7 +153,7 @@ func (t *Tree) BinaryUnmarshaler(b []byte) error {
 
 // Equal verifies if the given tree is equal
 func (t *Tree) Equal(t2 *Tree) bool {
-	if !t.ID.Equals(t2.ID) || !t.Roster.ID.Equal(t2.Roster.ID) {
+	if !t.ID.Equal(t2.ID) || !t.Roster.ID.Equal(t2.Roster.ID) {
 		log.Lvl4("Ids of trees don't match")
 		return false
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -8,7 +8,6 @@ import (
 
 	"strings"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/crypto.v0/config"
@@ -64,7 +63,7 @@ func TestRosterNew(t *testing.T) {
 	if len(pl.List) != 2 {
 		t.Fatalf("Expected two peers in PeerList. Instead got %d", len(pl.List))
 	}
-	if pl.ID == RosterID(uuid.Nil) {
+	if pl.ID.IsNil() {
 		t.Fatal("PeerList without ID is not allowed")
 	}
 	if len(pl.ID.String()) != 36 {
@@ -92,7 +91,7 @@ func TestInitPeerListFromConfigFile(t *testing.T) {
 	if len(decodedList.List) != 3 {
 		t.Fatalf("Expected two identities in Roster. Instead got %d", len(decodedList.List))
 	}
-	if decodedList.ID == RosterID(uuid.Nil) {
+	if decodedList.ID.IsNil() {
 		t.Fatal("PeerList without ID is not allowed")
 	}
 	if len(decodedList.ID.String()) != 36 {
@@ -118,7 +117,7 @@ func TestTreeParent(t *testing.T) {
 	// Generate two example topology
 	tree := peerList.GenerateBinaryTree()
 	child := tree.Root.Children[0]
-	if child.Parent.ID != tree.Root.ID {
+	if !child.Parent.ID.Equal(tree.Root.ID) {
 		t.Fatal("Parent of child of root is not the root...")
 	}
 }
@@ -130,7 +129,7 @@ func TestTreeChildren(t *testing.T) {
 	// Generate two example topology
 	tree := peerList.GenerateBinaryTree()
 	child := tree.Root.Children[0]
-	if child.ServerIdentity.ID != peerList.List[1].ID {
+	if !child.ServerIdentity.ID.Equal(peerList.List[1].ID) {
 		t.Fatal("Parent of child of root is not the root...")
 	}
 }
@@ -261,11 +260,11 @@ func TestBigNaryTree(t *testing.T) {
 		t.Fatal("Tree should be 3-ary")
 	}
 	for _, child := range root.Children {
-		if child.ServerIdentity.ID == root.ServerIdentity.ID {
+		if child.ServerIdentity.ID.Equal(root.ServerIdentity.ID) {
 			t.Fatal("Child should not have same identity as parent")
 		}
 		for _, c := range child.Children {
-			if c.ServerIdentity.ID == child.ServerIdentity.ID {
+			if c.ServerIdentity.ID.Equal(child.ServerIdentity.ID) {
 				t.Fatal("Child should not have same identity as parent")
 			}
 		}
@@ -417,7 +416,7 @@ func TestRoster_GenerateNaryTreeWithRoot(t *testing.T) {
 				t.Fatal("Missing port:", 2000+i, peerList.List)
 			}
 		}
-		if tree.Root.ServerIdentity.ID != e.ID {
+		if !tree.Root.ServerIdentity.ID.Equal(e.ID) {
 			t.Fatal("ServerIdentity", e, "is not root", tree.Dump())
 		}
 		if len(tree.List()) != 10 {

--- a/treenode.go
+++ b/treenode.go
@@ -52,6 +52,7 @@ type TreeNodeInstance struct {
 	// config is to be passed down in the first message of what the protocol is
 	// sending if it is non nil. Set with `tni.SetConfig()`.
 	config    *GenericConfig
+	sentTo    map[TreeNodeID]bool
 	configMut sync.Mutex
 }
 
@@ -77,6 +78,7 @@ func newTreeNodeInstance(o *Overlay, tok *Token, tn *TreeNode, io MessageProxy) 
 		msgDispatchQueue:     make([]*ProtocolMsg, 0, 1),
 		msgDispatchQueueWait: make(chan bool, 1),
 		protoIO:              io,
+		sentTo:               make(map[TreeNodeID]bool),
 	}
 	go n.dispatchMsgReader()
 	return n
@@ -126,9 +128,9 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 	var c *GenericConfig
 	// only sends the config once
 	n.configMut.Lock()
-	if n.config != nil {
+	if !n.sentTo[to.ID] {
 		c = n.config
-		n.config = nil
+		n.sentTo[to.ID] = true
 	}
 	n.configMut.Unlock()
 
@@ -675,10 +677,14 @@ func (n *TreeNodeInstance) TreeNodeInstance() *TreeNodeInstance {
 // SetConfig sets the GenericConfig c to be passed down in the first message
 // alongside with the protocol if it is non nil. This config can later be read
 // by Services in the NewProtocol method.
-func (n *TreeNodeInstance) SetConfig(c *GenericConfig) {
+func (n *TreeNodeInstance) SetConfig(c *GenericConfig) error {
 	n.configMut.Lock()
 	defer n.configMut.Unlock()
+	if n.config != nil {
+		return errors.New("Can't set config twice")
+	}
 	n.config = c
+	return nil
 }
 
 func (n *TreeNodeInstance) isBound() bool {

--- a/treenode_test.go
+++ b/treenode_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/onet/network"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/treenode_test.go
+++ b/treenode_test.go
@@ -2,6 +2,7 @@ package onet
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/dedis/onet.v1/log"
@@ -39,6 +40,62 @@ func TestHandlerReturn(t *testing.T) {
 	assert.NotNil(t, p.RegisterHandler(p.HandlerError1))
 	assert.Nil(t, p.RegisterHandler(p.HandlerError2))
 	assert.NotNil(t, p.RegisterHandler(p.HandlerError3))
+}
+
+type dummyMsg struct{}
+
+type configProcessor struct {
+	configCount int
+	expected    int
+	done        chan<- bool
+}
+
+func (p *configProcessor) Process(env *network.Envelope) {
+	if env.MsgType == ConfigMsgID {
+		p.configCount++
+		if p.configCount == p.expected {
+			p.done <- true
+		}
+	}
+}
+
+func TestConfigPropagation(t *testing.T) {
+	local := NewLocalTest()
+	defer local.CloseAll()
+	const treeSize = 3
+	var serviceConfig = []byte{0x01, 0x02, 0x03, 0x04}
+	hosts, _, tree := local.GenTree(treeSize, true)
+	_, err := hosts[0].overlay.CreateProtocol(spawnName, tree, NilServiceID)
+	log.ErrFatal(err)
+
+	done := make(chan bool)
+	pr := &configProcessor{expected: treeSize - 1, done: done}
+
+	for _, host := range hosts {
+		host.RegisterProcessor(pr,
+			ProtocolMsgID,
+			RequestTreeMsgID,
+			SendTreeMsgID,
+			RequestRosterMsgID,
+			SendRosterMsgID,
+			ConfigMsgID)
+	}
+
+	network.RegisterMessage(dummyMsg{})
+	rootInstance, _ := local.NewTreeNodeInstance(tree.Root, spawnName)
+	err = rootInstance.SetConfig(&GenericConfig{serviceConfig})
+	assert.Nil(t, err)
+	err = rootInstance.SetConfig(&GenericConfig{serviceConfig})
+	assert.NotNil(t, err)
+	err = rootInstance.SendToChildren(&dummyMsg{})
+	log.ErrFatal(err)
+	// wait until the processor has processed the expected number of config messages
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive response in time")
+	}
+
 }
 
 // spawnCh is used to dispatch information from a spawnProto to the test


### PR DESCRIPTION
Merging things from master back into v1.0

One question: are the changes to the IDs too much of an API-change? There is one incompatible change: `Tree.Equals` got changed to `Tree.Equal`.

- change it back to `Tree.Equals`?
- prepare it for v1.1/v2.0?