### PR TITLE
added proto2-definition

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package onet;
 
 import "network/network.proto";

--- a/network/network.proto
+++ b/network/network.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package network;
 
 message ServerIdentity{


### PR DESCRIPTION
`protoc` in its later versions complains if there is no `proto2`.