### PR TITLE
unifying Server and Context with regard to Service-method

### DIFF
--- a/server.go
+++ b/server.go
@@ -112,9 +112,15 @@ func (c *Server) Address() network.Address {
 	return c.ServerIdentity.Address
 }
 
-// GetService returns the service with the given name.
-func (c *Server) GetService(name string) Service {
+// Service returns the service with the given name.
+func (c *Server) Service(name string) Service {
 	return c.serviceManager.service(name)
+}
+
+// GetService is kept for backward-compatibility.
+func (c *Server) GetService(name string) Service {
+	log.Warn("This method is deprecated - use `Server.Service` instead")
+	return c.Service(name)
 }
 
 // ProtocolRegister will sign up a new protocol to this Server.

--- a/server_test.go
+++ b/server_test.go
@@ -27,7 +27,7 @@ func TestServer_ProtocolRegisterName(t *testing.T) {
 func TestServer_GetService(t *testing.T) {
 	c := NewLocalServer(0)
 	defer c.Close()
-	s := c.GetService("nil")
+	s := c.Service("nil")
 	require.Nil(t, s)
 }
 


### PR DESCRIPTION
`Server` and `Context` both have a method to retrieve a given service. Unfortunately they are not called the same, so this patch unifies the naming, while keeping backwards-compatibility (`prifi` uses the `Server.GetService`) and printing out a warning that `Server.GetService` is deprecated.