### PR TITLE
dont cut off string after second :

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -361,7 +361,7 @@ func NewClientError(e error) ClientError {
 	str := e.Error()
 	if strings.HasPrefix(str, wsPrefix) {
 		str = str[len(wsPrefix):]
-		errMsg := strings.Split(str, ":")
+		errMsg := strings.SplitN(str, ":", 2)
 		if len(errMsg) > 1 && len(errMsg[1]) > 0 {
 			errMsg[1] = errMsg[1][1:]
 		} else {


### PR DESCRIPTION
worst thing is that I knew about this one. For `v2` I really need to kill `ClientError` - what a bad idea...