### PR TITLE
compatibility for mac and more than one user

### DIFF
--- a/app/libtest.sh
+++ b/app/libtest.sh
@@ -17,7 +17,7 @@ APP=${APP:-$(basename $APPDIR)}
 # Name of conode-log
 COLOG=conode
 
-RUNOUT=/tmp/run.out
+RUNOUT=$( mktemp )
 
 startTest(){
     set +m


### PR DESCRIPTION
Instead of using a constant temp-file, use `mktemp`.