### PR TITLE
changing the way the hash is calculated

### DIFF
--- a/crypto/schnorr.go
+++ b/crypto/schnorr.go
@@ -6,40 +6,14 @@ import (
 )
 
 // SchnorrSig is a signature created using the Schnorr Signature scheme.
-type SchnorrSig struct {
-	Challenge abstract.Point
-	Response  abstract.Scalar
-}
+type SchnorrSig []byte
 
 // SignSchnorr creates a Schnorr signature from a msg and a private key
 func SignSchnorr(suite abstract.Suite, private abstract.Scalar, msg []byte) (SchnorrSig, error) {
-	ss := SchnorrSig{
-		Challenge: suite.Point(),
-		Response:  suite.Scalar(),
-	}
-	buf, err := sign.Schnorr(suite, private, msg)
-	if err != nil {
-		return ss, err
-	}
-	scalarLen := suite.ScalarLen()
-	if err := ss.Challenge.UnmarshalBinary(buf[0:scalarLen]); err != nil {
-		return ss, err
-	}
-	if err := ss.Response.UnmarshalBinary(buf[scalarLen:]); err != nil {
-		return ss, err
-	}
-	return ss, nil
+	return sign.Schnorr(suite, private, msg)
 }
 
 // VerifySchnorr verifies a given Schnorr signature. It returns nil iff the given signature is valid.
 func VerifySchnorr(suite abstract.Suite, public abstract.Point, msg []byte, sig SchnorrSig) error {
-	ch, err := sig.Challenge.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	re, err := sig.Response.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	return sign.VerifySchnorr(suite, public, msg, append(ch, re...))
+	return sign.VerifySchnorr(suite, public, msg, sig)
 }

--- a/crypto/schnorr.go
+++ b/crypto/schnorr.go
@@ -64,14 +64,13 @@ func VerifySchnorr(suite abstract.Suite, public abstract.Point, msg []byte, sig 
 }
 
 func hash(suite abstract.Suite, r abstract.Point, msg []byte) (abstract.Scalar, error) {
-	rBuf, err := r.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	cipher := suite.Cipher(rBuf)
-	cipher.Message(nil, nil, msg)
+	// Calculate H(r || msg)
+	h := suite.Hash()
+	r.MarshalTo(h)
+	h.Write(msg)
+
 	// (re)compute challenge (e)
-	e := suite.Scalar().Pick(cipher)
+	e := suite.Scalar().SetBytes(h.Sum(nil))
 
 	return e, nil
 }


### PR DESCRIPTION
The onet-schnorr-signature is a not-eddsa-compatible schnorr signature. For v2 we'll have to remove it. For previous versions, I propose we change the hash to the below function, so that the javascript-implementation from the epfl e-voting project can easily interact with the cothority.