### PR TITLE
Adding failing test case for Roster.GenerateNaryTreeWithRoot

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -417,6 +417,9 @@ func TestRoster_GenerateNaryTreeWithRoot(t *testing.T) {
 		if !tree.UsesList() {
 			t.Fatal("Not all elements are in the tree")
 		}
+		if tree.Roster.ID != peerList.ID {
+			t.Fatal("Generated tree should be associated the receiver roster")
+		}
 	}
 }
 


### PR DESCRIPTION
There is an unexpected behavior in  `Roster.GenerateNaryTreeWithRoot` method.

It is the only one in the `Roster` to `Tree` function family to create a new `Roster` (with a new `RosterID`), which seems undesirable in most cases.