### PR TITLE
Attempt to add dispatch failure message

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -539,7 +539,12 @@ func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolI
 	if err = o.RegisterProtocolInstance(pi); err != nil {
 		return nil, err
 	}
-	go pi.Dispatch()
+	go func() {
+		err := pi.Dispatch()
+		if err != nil {
+			log.Error(err)
+		}
+	}()
 	return pi, err
 }
 


### PR DESCRIPTION
Fixes #237 

The `TestOverlayDispatchFailure` test passes with `go test -v .`, but fails when using `go test .`. This issue is most likely due to how `go test` changes the stderr, needs further investigation.

