### PR TITLE
Added a standard ed25519 as the suite for apps

### DIFF
--- a/app/libtest.sh
+++ b/app/libtest.sh
@@ -210,10 +210,10 @@ buildConode(){
 	done
 	echo "Found: $incl"
     fi
-    
+
     local cotdir=$( mktemp -d )/conode
     mkdir -p $cotdir
-    
+
     ( echo -e "package main\nimport ("
     for i in $incl; do
     	echo -e "\t_ \"$i\""
@@ -222,10 +222,13 @@ buildConode(){
     cat - > $cotdir/main.go << EOF
 package main
 
-import "github.com/dedis/onet/app"
+import (
+  "github.com/dedis/onet/app"
+  "github.com/dedis/kyber/group"
+)
 
 func main(){
-	app.Server()
+	app.Server(group.MustSuite("Ed25519"))
 }
 EOF
     build $cotdir


### PR DESCRIPTION
While porting, `libtest.sh` wasn't tested. This adds a standard ed25519 suite for the apps. Of course this will change once we have a more configurable service/protocol structure.