### PR TITLE
remove service_storage directory after each test

### DIFF
--- a/app/libtest.sh
+++ b/app/libtest.sh
@@ -273,6 +273,7 @@ cleanup(){
     sleep .5
     rm -f co*/*bin
     rm -f cl*/*bin
+    rm -rf service_storage
 }
 
 stopTest(){

--- a/app/libtest.sh
+++ b/app/libtest.sh
@@ -75,7 +75,7 @@ testGrep(){
     runOutFile "$@"
     doGrep "$S"
     if [ ! "$EGREP" ]; then
-        fail "Didn't find '$S' in output of '$@': $GRP"
+        fail "Didn't find '$S' in output of '$@': $GREP"
     fi
 }
 

--- a/app/libtest.sh
+++ b/app/libtest.sh
@@ -273,7 +273,7 @@ cleanup(){
     sleep .5
     rm -f co*/*bin
     rm -f cl*/*bin
-    rm -rf service_storage
+    rm -rf $CONODE_SERVICE_PATH
 }
 
 stopTest(){


### PR DESCRIPTION
One liner to remove the storage directory between each integration test.