### PR TITLE
adding new function to context to create a new bucket

### DIFF
--- a/context.go
+++ b/context.go
@@ -171,7 +171,7 @@ func (c *Context) Load(key string) (interface{}, error) {
 // exists, by eventually creating it, and returns the created bucket name,
 // which is the servicename + the given name.
 func (c *Context) GetAdditionalBucket(name string) (*bolt.DB, string) {
-	fullName := c.bucketName + name
+	fullName := c.bucketName + "_" + name
 	err := c.manager.db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists([]byte(fullName))
 		if err != nil {
@@ -180,7 +180,7 @@ func (c *Context) GetAdditionalBucket(name string) (*bolt.DB, string) {
 		return nil
 	})
 	if err != nil {
-		return nil, ""
+		panic(err)
 	}
 	return c.manager.db, fullName
 }

--- a/context.go
+++ b/context.go
@@ -1,6 +1,7 @@
 package onet
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path"
@@ -166,10 +167,22 @@ func (c *Context) Load(key string) (interface{}, error) {
 	return ret, err
 }
 
-// GetDbAndBucket returns the DB handler and the bucket name of the service.
-// The server should have created the database before calling this function.
-func (c *Context) GetDbAndBucket() (*bolt.DB, string) {
-	return c.manager.db, c.bucketName
+// GetAdditionalBucket makes sure that a bucket with the given name
+// exists, by eventually creating it, and returns the created bucket name,
+// which is the servicename + the given name.
+func (c *Context) GetAdditionalBucket(name string) (*bolt.DB, string) {
+	fullName := c.bucketName + name
+	err := c.manager.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(fullName))
+		if err != nil {
+			return fmt.Errorf("create bucket: %s", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, ""
+	}
+	return c.manager.db, fullName
 }
 
 // Returns the path to the file for storage/retrieval of the service-state.

--- a/context_test.go
+++ b/context_test.go
@@ -91,11 +91,11 @@ func TestContext_GetAdditionalBucket(t *testing.T) {
 	c := createContext(t)
 	db, name := c.GetAdditionalBucket("new")
 	require.NotNil(t, db)
-	require.Equal(t, "testServicenew", name)
+	require.Equal(t, "testService_new", name)
 	// Need to accept a second run with an existing bucket
 	db, name = c.GetAdditionalBucket("new")
 	require.NotNil(t, db)
-	require.Equal(t, "testServicenew", name)
+	require.Equal(t, "testService_new", name)
 }
 
 func TestContext_Path(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -82,6 +82,22 @@ func testSaveFailure(t *testing.T, c *Context) {
 	}
 }
 
+func TestContext_GetAdditionalBucket(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "conode")
+	log.ErrFatal(err)
+	defer os.RemoveAll(tmp)
+	os.Setenv("CONODE_SERVICE_PATH", tmp)
+	initContextDataPath()
+	c := createContext(t)
+	db, name := c.GetAdditionalBucket("new")
+	require.NotNil(t, db)
+	require.Equal(t, "testServicenew", name)
+	// Need to accept a second run with an existing bucket
+	db, name = c.GetAdditionalBucket("new")
+	require.NotNil(t, db)
+	require.Equal(t, "testServicenew", name)
+}
+
 func TestContext_Path(t *testing.T) {
 	setContextDataPath("")
 	c := createContext(t)


### PR DESCRIPTION
Instead of returning the existing bucket, change the method to create a new bucket, if it doesn't exist yet. It also makes sure that the names are conode-unique by prepending the name of the service to the request.