### PR TITLE
Add roster.RandomSubset

### DIFF
--- a/local.go
+++ b/local.go
@@ -165,6 +165,7 @@ func (l *LocalTest) GenRosterFromHost(servers ...*Server) *Roster {
 
 // CloseAll takes a list of servers that will be closed
 func (l *LocalTest) CloseAll() {
+	l.ctx.Stop()
 	for _, server := range l.Servers {
 		log.Lvl3("Closing server", server.ServerIdentity.Address)
 		err := server.Close()

--- a/network/local.go
+++ b/network/local.go
@@ -40,6 +40,7 @@ type LocalManager struct {
 	counter uint64
 	// close on this channel indicates that connection retries should stop
 	stopping chan bool
+	stopOnce sync.Once
 }
 
 // NewLocalManager returns a fresh new manager that can be used by LocalConn,
@@ -173,7 +174,7 @@ func (lm *LocalManager) count() int {
 // Stop tells any connections that are sleeping on retry
 // to stop sleeping and return an error.
 func (lm *LocalManager) Stop() {
-	close(lm.stopping)
+	lm.stopOnce.Do(func() { close(lm.stopping) })
 }
 
 // LocalConn is a connection that sends and receives messages to other

--- a/network/local.go
+++ b/network/local.go
@@ -38,6 +38,8 @@ type LocalManager struct {
 
 	// connection-counter for giving unique IDs to each connection.
 	counter uint64
+	// close on this channel indicates that connection retries should stop
+	stopping chan bool
 }
 
 // NewLocalManager returns a fresh new manager that can be used by LocalConn,
@@ -46,6 +48,7 @@ func NewLocalManager() *LocalManager {
 	return &LocalManager{
 		conns:     make(map[endpoint]*LocalConn),
 		listening: make(map[Address]func(Conn)),
+		stopping:  make(chan bool),
 	}
 }
 
@@ -161,10 +164,16 @@ func (lm *LocalManager) close(conn *LocalConn) error {
 }
 
 // len returns how many local connections are open.
-func (lm *LocalManager) len() int {
+func (lm *LocalManager) count() int {
 	lm.Lock()
 	defer lm.Unlock()
 	return len(lm.conns)
+}
+
+// Stop tells any connections that are sleeping on retry
+// to stop sleeping and return an error.
+func (lm *LocalManager) Stop() {
+	close(lm.stopping)
 }
 
 // LocalConn is a connection that sends and receives messages to other
@@ -462,7 +471,13 @@ func (lh *LocalHost) Connect(si *ServerIdentity) (Conn, error) {
 			return c, nil
 		}
 		finalErr = err
-		time.Sleep(WaitRetry)
+		select {
+		case <-time.After(WaitRetry):
+			// sleep done, go try again
+		case <-lh.lm.stopping:
+			// stop sleeping and return immediately
+			return nil, finalErr
+		}
 	}
 	return nil, finalErr
 

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -247,7 +247,7 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 			assert.Nil(t, err)
 			//wait ack
 			<-outgoingConn
-			assert.Equal(t, 2, listener.manager.len())
+			assert.Equal(t, 2, listener.manager.count())
 			// close connection
 			assert.Nil(t, c.Close())
 			incomingConn <- true

--- a/network/router.go
+++ b/network/router.go
@@ -252,7 +252,7 @@ func (r *Router) handleConn(remote *ServerIdentity, c Conn) {
 		r.removeConnection(remote, c)
 	}()
 	address := c.Remote()
-	log.Lvl3(r.address, "Handling new connection to", remote.Address)
+	log.Lvl3(r.address, "Handling new connection from", remote.Address)
 	for {
 		packet, err := c.Receive()
 

--- a/tree.go
+++ b/tree.go
@@ -591,18 +591,22 @@ func (ro *Roster) RandomServerIdentity() *network.ServerIdentity {
 }
 
 // RandomSubset returns a new Roster which starts with root and is
-// followed by a random subset of n elements of ro.
+// followed by a random subset of n elements of ro, not including root.
 func (ro *Roster) RandomSubset(root *network.ServerIdentity, n int) *Roster {
 	if n > len(ro.List) {
 		n = len(ro.List)
 	}
-	out := make([]*network.ServerIdentity, n+1)
+	out := make([]*network.ServerIdentity, 1)
 	out[0] = root
 
 	perm := rand.Perm(len(ro.List))
-	log.Lvl3("perm is", perm)
-	for i := 0; i < n; i++ {
-		out[i+1] = ro.List[perm[i]]
+	for _, p := range perm {
+		if ro.List[p] != root {
+			out = append(out, ro.List[p])
+			if len(out) == n+1 {
+				break
+			}
+		}
 	}
 	return NewRoster(out)
 }

--- a/tree.go
+++ b/tree.go
@@ -576,12 +576,35 @@ func (ro *Roster) GenerateBinaryTree() *Tree {
 	return ro.GenerateNaryTree(2)
 }
 
+// GenerateStar creates a star topology with the first element
+// of Roster as root, and all other elements as children of the root.
+func (ro *Roster) GenerateStar() *Tree {
+	return ro.GenerateNaryTree(len(ro.List) - 1)
+}
+
 // RandomServerIdentity returns a random element of the Roster.
 func (ro *Roster) RandomServerIdentity() *network.ServerIdentity {
 	if ro.List == nil || len(ro.List) == 0 {
 		return nil
 	}
 	return ro.List[rand.Int()%len(ro.List)]
+}
+
+// RandomSubset returns a new Roster which starts with root and is
+// followed by a random subset of n elements of ro.
+func (ro *Roster) RandomSubset(root *network.ServerIdentity, n int) *Roster {
+	if n > len(ro.List) {
+		n = len(ro.List)
+	}
+	out := make([]*network.ServerIdentity, n+1)
+	out[0] = root
+
+	perm := rand.Perm(len(ro.List))
+	log.Lvl3("perm is", perm)
+	for i := 0; i < n; i++ {
+		out[i+1] = ro.List[perm[i]]
+	}
+	return NewRoster(out)
 }
 
 // addNary is a recursive function to create the binary tree.

--- a/tree_test.go
+++ b/tree_test.go
@@ -16,6 +16,28 @@ import (
 
 var prefix = "127.0.0.1:"
 
+func TestSubset(t *testing.T) {
+	// subset of 10 from roster of 1: degenerate case
+	names := genLocalhostPeerNames(1, 0)
+	ro := genRoster(tSuite, names)
+	r := ro.RandomSubset(ro.List[0], 10)
+	// (return just the root)
+	assert.Equal(t, len(r.List), 1)
+	assert.Equal(t, r.List[0], ro.List[0])
+	assert.NotContains(t, r.List[1:], ro.List[0])
+
+	// subset of 4 from a roster of 20: all returned should be in orig
+	// roster.
+	names = genLocalhostPeerNames(20, 0)
+	ro = genRoster(tSuite, names)
+	r = ro.RandomSubset(ro.List[0], 4)
+	assert.Equal(t, len(r.List), 5)
+	for _, x := range r.List {
+		assert.Contains(t, ro.List, x)
+	}
+	assert.NotContains(t, r.List[1:], ro.List[0])
+}
+
 // test the ID generation
 func TestTreeId(t *testing.T) {
 	names := genLocalhostPeerNames(3, 0)


### PR DESCRIPTION
RandomSubset is used to choose some of the nodes in a roster
to contact. It is used when we want at least one answer from a set
of conodes, but we don't care which one we contact, and we want
to tolerate some of the nodes being down.

GenerateStar makes a star-shaped tree, which causes the root to
send the request to all children.

Closing local tests is now more reliable with respect to leaving
goroutines running.