### PR TITLE
Allow non fqdn

### DIFF
--- a/network/address.go
+++ b/network/address.go
@@ -137,6 +137,9 @@ func (a Address) Resolve() string {
 //		https://github.com/dedis/cothority/issues/620
 // This method assumes that only the host part is passed as parameter
 // This function is integrated in the Valid() function
+//
+// For easier integration and testing, this function also returns true if the
+// string doesn't have any '.' in it.
 func validHostname(s string) bool {
 	s = strings.ToLower(s)
 
@@ -159,6 +162,11 @@ func validHostname(s string) bool {
 	}
 
 	valid, _ := regexp.MatchString("^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z]+)$", s)
+	if !valid {
+		if strings.Count(s, ".") == 0 {
+			return true
+		}
+	}
 	return valid
 }
 

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -108,6 +108,7 @@ func TestDNSNames(t *testing.T) {
 	assert.True(t, validHostname("localhost"))
 	assert.True(t, validHostname("www.asd.lol.xd"))
 	assert.True(t, validHostname("randomtext"))
+	assert.True(t, validHostname("conode1"))
 	assert.False(t, validHostname("www.asd.lol.x-d"))
 	assert.False(t, validHostname("192.168.1.1"))
 	assert.False(t, validHostname("..a"))

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -400,6 +400,8 @@ func (t *TCPHost) Connect(si *ServerIdentity) (Conn, error) {
 	case PlainTCP:
 		c, err := NewTCPConn(addr, t.suite)
 		return c, err
+	case InvalidConnType:
+		return nil, errors.New("This address is not correctly formatted: " + addr.String())
 	}
 	return nil, fmt.Errorf("TCPHost %s can't handle this type of connection: %s", addr, addr.ConnType())
 }


### PR DESCRIPTION
While testing, people sometimes want to use non-fully qualified domain names. Allow those, too.