### PR TITLE
fixing a bug in LocalTest cleanup

### DIFF
--- a/local.go
+++ b/local.go
@@ -181,6 +181,13 @@ func (l *LocalTest) panicClosed() {
 
 // CloseAll takes a list of servers that will be closed
 func (l *LocalTest) CloseAll() {
+	log.Lvl3("Stopping all")
+	// If the debug-level is 0, we copy all errors to a buffer that
+	// will be discarded at the end.
+	if log.DebugVisible() == 0 {
+		log.OutputToBuf()
+	}
+	l.ctx.Stop()
 	for _, server := range l.Servers {
 		log.Lvl3("Closing server", server.ServerIdentity.Address)
 		err := server.Close()
@@ -199,10 +206,12 @@ func (l *LocalTest) CloseAll() {
 		log.Lvl3("Closing node", node)
 		node.closeDispatch()
 	}
-	l.ctx.Stop()
 	l.Nodes = make([]*TreeNodeInstance, 0)
 	os.RemoveAll(l.path)
 	l.closed = true
+	if log.DebugVisible() == 0 {
+		log.OutputToOs()
+	}
 }
 
 // getTree returns the tree of the given TreeNode

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -85,7 +85,7 @@ func TestLocalConnCloseReceive(t *testing.T) {
 	}()
 	<-ready
 
-	outgoing, err := NewLocalConn(addr, addr, tSuite)
+	outgoing, err := NewLocalConnWithManager(defaultLocalManager, addr, addr, tSuite)
 	if err != nil {
 		t.Fatal("erro NewLocalConn:", err)
 	}
@@ -257,7 +257,7 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 	}()
 	<-ready
 
-	outgoing, err := NewLocalConn(addr2, addr1, tSuite)
+	outgoing, err := NewLocalConnWithManager(defaultLocalManager, addr2, addr1, tSuite)
 	if err != nil {
 		t.Fatal("erro NewLocalConn:", err)
 	}
@@ -310,7 +310,7 @@ func TestLocalManyConn(t *testing.T) {
 	for i := 1; i <= nbrConn; i++ {
 		go func(j int) {
 			a := NewLocalAddress("127.0.0.1:" + strconv.Itoa(2000+j))
-			c, err := NewLocalConn(a, addr, tSuite)
+			c, err := NewLocalConnWithManager(defaultLocalManager, a, addr, tSuite)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
The `LocalTest.Stop` function was misbehaving in that it supposed all connections were closed before it got called, which is not always the case.

This PR also changes the way `local.CloseAll` behaves: if `go test` is called without `-v`, `local.CloseAll` reroutes all logging to `/dev/null` while closing, as there might be quite some error messages due to late packets arriving.