### PR TITLE
Subsets could incorrectly include the root

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -605,12 +605,12 @@ func (ro *Roster) RandomSubset(root *network.ServerIdentity, n int) *Roster {
 	if n > len(ro.List) {
 		n = len(ro.List)
 	}
-	out := make([]*network.ServerIdentity, 1)
+	out := make([]*network.ServerIdentity, 1, n+1)
 	out[0] = root
 
 	perm := rand.Perm(len(ro.List))
 	for _, p := range perm {
-		if ro.List[p] != root {
+		if !ro.List[p].ID.Equal(root.ID) {
 			out = append(out, ro.List[p])
 			if len(out) == n+1 {
 				break

--- a/tree_test.go
+++ b/tree_test.go
@@ -36,6 +36,22 @@ func TestSubset(t *testing.T) {
 		assert.Contains(t, ro.List, x)
 	}
 	assert.NotContains(t, r.List[1:], ro.List[0])
+
+	// with two nodes, if the second is the root, the first should end up
+	// in r.List[0]
+	names = genLocalhostPeerNames(2, 0)
+	ro = genRoster(tSuite, names)
+	assert.Equal(t, len(ro.List), 2)
+	r = ro.RandomSubset(ro.List[1], 1)
+	assert.Equal(t, len(r.List), 2)
+	assert.Equal(t, r.List[0], ro.List[1])
+	assert.Equal(t, r.List[1], ro.List[0])
+	// Check that the "star" topology of these two guys
+	// is root==0 -> (len(child)==1) && child[0]==1
+	tr := r.GenerateStar()
+	assert.Equal(t, tr.Root.ServerIdentity, r.List[0])
+	assert.Equal(t, len(tr.Root.Children), 1)
+	assert.Equal(t, tr.Root.Children[0].ServerIdentity, r.List[1])
 }
 
 // test the ID generation


### PR DESCRIPTION
Comparing pointers works less well than comparing things.