### PR TITLE
Count bytes more correctly

### DIFF
--- a/network/router_test.go
+++ b/network/router_test.go
@@ -196,6 +196,7 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	require.NotNil(t, h21)
 	assert.Nil(t, h21.Close())
 	time.Sleep(100 * time.Millisecond)
+
 	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	require.Nil(t, err)
 	<-proc.relay
@@ -204,8 +205,10 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 		t.Fatal("Should be able to stop h2")
 	}
 	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
+	if err == nil {
+		t.Error("h1 let us send still")
+	}
 	require.NotNil(t, err)
-
 }
 
 // Test connection of multiple Hosts and sending messages back and forth

--- a/network/struct.go
+++ b/network/struct.go
@@ -173,29 +173,31 @@ type counterSafe struct {
 }
 
 // Rx returns the rx counter
-func (c *counterSafe) Rx() uint64 {
+func (c *counterSafe) Rx() (out uint64) {
 	c.Lock()
-	defer c.Unlock()
-	return c.rx
+	out = c.rx
+	c.Unlock()
+	return
 }
 
 // Tx returns the tx counter
-func (c *counterSafe) Tx() uint64 {
+func (c *counterSafe) Tx() (out uint64) {
 	c.Lock()
-	defer c.Unlock()
-	return c.tx
+	out = c.tx
+	c.Unlock()
+	return
 }
 
 // updateRx adds delta to the rx counter
 func (c *counterSafe) updateRx(delta uint64) {
 	c.Lock()
-	defer c.Unlock()
 	c.rx += delta
+	c.Unlock()
 }
 
 // updateTx adds delta to the tx counter
 func (c *counterSafe) updateTx(delta uint64) {
 	c.Lock()
-	defer c.Unlock()
 	c.tx += delta
+	c.Unlock()
 }


### PR DESCRIPTION
Count all the bytes, and also count them if there's an error.
Also: defer costs a memory allocation, don't use them when not needed.

Fixes #292.