### PR TITLE
Status cleanup and DB status addition

### DIFF
--- a/context.go
+++ b/context.go
@@ -79,7 +79,7 @@ func (c *Context) RegisterProtocolInstance(pi ProtocolInstance) error {
 }
 
 // ReportStatus returns all status of the services.
-func (c *Context) ReportStatus() map[string]*Status {
+func (c *Context) ReportStatus() map[string]Status {
 	return c.server.statusReporterStruct.ReportStatus()
 }
 

--- a/network/struct.go
+++ b/network/struct.go
@@ -115,12 +115,15 @@ type ServerIdentityToml struct {
 // of IP-addresses where to find that entity. The Id is based on a
 // version5-UUID which can include a URL that is based on it's public key.
 func NewServerIdentity(public kyber.Point, address Address) *ServerIdentity {
-	url := NamespaceURL + "id/" + public.String()
-	return &ServerIdentity{
+	si := &ServerIdentity{
 		Public:  public,
 		Address: address,
-		ID:      ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url)),
 	}
+	if public != nil {
+		url := NamespaceURL + "id/" + public.String()
+		si.ID = ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url))
+	}
+	return si
 }
 
 // Equal tests on same public key

--- a/processor.go
+++ b/processor.go
@@ -110,7 +110,7 @@ func (p *ServiceProcessor) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig
 	return nil, nil
 }
 
-// ProcessClientRequest takes a request from a client, calculates the reply
+// ProcessClientRequest takes a request from a websocket client, calculates the reply
 // and sends it back. It uses the path to find the appropriate handler-
 // function. It implements the Server interface.
 func (p *ServiceProcessor) ProcessClientRequest(path string, buf []byte) ([]byte, error) {

--- a/server.go
+++ b/server.go
@@ -72,7 +72,7 @@ func newServer(s network.Suite, dbPath string, r *network.Router, pkey kyber.Sca
 	c.overlay = NewOverlay(c)
 	c.websocket = NewWebSocket(r.ServerIdentity)
 	c.serviceManager = newServiceManager(c, c.overlay, dbPath, delDb)
-	c.statusReporterStruct.RegisterStatusReporter("Status", c)
+	c.statusReporterStruct.RegisterStatusReporter("Generic", c)
 	for name, inst := range protocols.instantiators {
 		log.Lvl4("Registering global protocol", name)
 		c.ProtocolRegister(name, inst)
@@ -96,10 +96,10 @@ func (c *Server) Suite() network.Suite {
 }
 
 // GetStatus is a function that returns the status report of the server.
-func (c *Server) GetStatus() *Status {
+func (c *Server) GetStatus() Status {
 	a := c.serviceManager.availableServices()
 	sort.Strings(a)
-	return &Status{map[string]string{
+	return Status(map[string]string{
 		"Available_Services": strings.Join(a, ","),
 		"TX_bytes":           strconv.FormatUint(c.Router.Tx(), 10),
 		"RX_bytes":           strconv.FormatUint(c.Router.Rx(), 10),
@@ -111,7 +111,7 @@ func (c *Server) GetStatus() *Status {
 		"Port":        c.ServerIdentity.Address.Port(),
 		"Description": c.ServerIdentity.Description,
 		"ConnType":    string(c.ServerIdentity.Address.ConnType()),
-	}}
+	})
 }
 
 // Close closes the overlay and the Router

--- a/status.go
+++ b/status.go
@@ -1,13 +1,11 @@
 package onet
 
 // Status holds key/value pairs of the status to be returned to the requester.
-type Status struct {
-	Field map[string]string
-}
+type Status map[string]string
 
 // StatusReporter is the interface that all structures that want to return a status will implement.
 type StatusReporter interface {
-	GetStatus() *Status
+	GetStatus() Status
 }
 
 // statusReporterStruct holds a map of all StatusReporters.
@@ -30,19 +28,10 @@ func (s *statusReporterStruct) RegisterStatusReporter(name string, sr StatusRepo
 
 // ReportStatus gets the status of all StatusReporters within the Registry and
 // puts them in a map
-func (s *statusReporterStruct) ReportStatus() map[string]*Status {
-	m := make(map[string]*Status)
+func (s *statusReporterStruct) ReportStatus() map[string]Status {
+	m := make(map[string]Status)
 	for key, val := range s.statusReporters {
 		m[key] = val.GetStatus()
 	}
 	return m
-}
-
-// Merge will set s to contain both entries of s and s2
-// It returns s
-func (s *Status) Merge(s2 *Status) *Status {
-	for k, v := range s2.Field {
-		s.Field[k] = v
-	}
-	return s
 }

--- a/status_test.go
+++ b/status_test.go
@@ -14,9 +14,9 @@ func TestSRStruct(t *testing.T) {
 	assert.NotNil(t, srs)
 	dtr := &dummyTestReporter{5}
 	srs.RegisterStatusReporter("Dummy", dtr)
-	assert.Equal(t, srs.ReportStatus()["Dummy"].Field["Connections"], "5")
+	assert.Equal(t, srs.ReportStatus()["Dummy"]["Connections"], "5")
 	dtr.Status = 10
-	assert.Equal(t, srs.ReportStatus()["Dummy"].Field["Connections"], "10")
+	assert.Equal(t, srs.ReportStatus()["Dummy"]["Connections"], "10")
 }
 
 func TestStatusHost(t *testing.T) {
@@ -27,7 +27,7 @@ func TestStatusHost(t *testing.T) {
 	defer c.Close()
 	stats := c.GetStatus()
 	a := ServiceFactory.RegisteredServiceNames()
-	services := strings.Split(stats.Field["Available_Services"], ",")
+	services := strings.Split(stats["Available_Services"], ",")
 	assert.Equal(t, len(services), len(a))
 }
 
@@ -35,8 +35,6 @@ type dummyTestReporter struct {
 	Status int
 }
 
-func (d *dummyTestReporter) GetStatus() *Status {
-	return &Status{
-		map[string]string{"Connections": strconv.Itoa(d.Status)},
-	}
+func (d *dummyTestReporter) GetStatus() Status {
+	return Status(map[string]string{"Connections": strconv.Itoa(d.Status)})
 }


### PR DESCRIPTION
Simplify the type for the status replies. Add DB stats.

Make it possible for non-Onet packages to register
status methods.

Also: Make NewServerIdentity tolerate not having the public
key, which is needed for how scmgr calls it.

Updates dedis/cothority#940.