### PR TITLE
Tune logging for production use

### DIFF
--- a/log/lvl.go
+++ b/log/lvl.go
@@ -64,7 +64,8 @@ var debugVisible = 1
 var showTime = false
 
 // If useColors is true, debug-output will be colored (defaults to monochrome
-// output).
+// output). It also controls padding, since colorful output is higly correlated
+// with humans who like their log lines padded.
 var useColors = false
 
 // outputLines can be false to suppress outputting of lines in tests.
@@ -96,13 +97,18 @@ func lvl(lvl, skip int, args ...interface{}) {
 		line = 0
 	}
 
-	if len(name) > NamePadding && NamePadding > 0 {
-		NamePadding = len(name)
+	fmtstr := ""
+	if useColors {
+		if len(name) > NamePadding && NamePadding > 0 {
+			NamePadding = len(name)
+		}
+		if len(lineStr) > LinePadding && LinePadding > 0 {
+			LinePadding = len(name)
+		}
+		fmtstr = fmt.Sprintf("%%%ds: %%%dd", NamePadding, LinePadding)
+	} else {
+		fmtstr = fmt.Sprintf("%%s: %%d")
 	}
-	if len(lineStr) > LinePadding && LinePadding > 0 {
-		LinePadding = len(name)
-	}
-	fmtstr := fmt.Sprintf("%%%ds: %%%dd", NamePadding, LinePadding)
 	caller := fmt.Sprintf(fmtstr, name, line)
 	if StaticMsg != "" {
 		caller += "@" + StaticMsg

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -131,8 +131,8 @@ func ExampleLvl2() {
 	SetDebugVisible(1)
 
 	// Output:
-	// 1 : (                         log.ExampleLvl2:   0) - Level1
-	// 2 : (                         log.ExampleLvl2:   0) - Level2
+	// 1 : (log.ExampleLvl2: 0) - Level1
+	// 2 : (log.ExampleLvl2: 0) - Level2
 }
 
 func ExampleLvl1() {
@@ -141,7 +141,7 @@ func ExampleLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                         log.ExampleLvl1:   0) - Multiple parameters
+	// 1 : (log.ExampleLvl1: 0) - Multiple parameters
 }
 
 func ExampleLLvl1() {
@@ -153,10 +153,10 @@ func ExampleLLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                        log.ExampleLLvl1:   0) - Lvl output
-	// 1!: (                        log.ExampleLLvl1:   0) - LLvl output
-	// 1 : (                        log.ExampleLLvl1:   0) - Lvlf output
-	// 1!: (                        log.ExampleLLvl1:   0) - LLvlf output
+	// 1 : (log.ExampleLLvl1: 0) - Lvl output
+	// 1!: (log.ExampleLLvl1: 0) - LLvl output
+	// 1 : (log.ExampleLLvl1: 0) - Lvlf output
+	// 1!: (log.ExampleLLvl1: 0) - LLvlf output
 }
 
 func thisIsAVeryLongFunctionNameThatWillOverflow() {
@@ -172,9 +172,9 @@ func ExampleLvlf1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                        log.ExampleLvlf1:   0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
-	// 1 : (                               log.ExampleLvlf1:   0) - After
+	// 1 : (log.ExampleLvlf1: 0) - Before
+	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
+	// 1 : (log.ExampleLvlf1: 0) - After
 }
 
 func ExampleLvl3() {
@@ -186,9 +186,9 @@ func ExampleLvl3() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLvl3:   0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
-	// 1 : (log.ExampleLvl3:   0) - After
+	// 1 : (log.ExampleLvl3: 0) - Before
+	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
+	// 1 : (log.ExampleLvl3: 0) - After
 }
 
 func clearEnv() {

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -26,9 +26,9 @@ func TestInfo(t *testing.T) {
 func TestLvl(t *testing.T) {
 	SetDebugVisible(1)
 	Info("TestLvl")
-	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.True(t, containsStdOut("I : (log.TestLvl: 0) - TestLvl\n"))
 	Print("TestLvl")
-	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.True(t, containsStdOut("I : (log.TestLvl: 0) - TestLvl\n"))
 	Warn("TestLvl")
-	assert.True(t, containsStdErr("W : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.True(t, containsStdErr("W : (log.TestLvl: 0) - TestLvl\n"))
 }

--- a/network/router.go
+++ b/network/router.go
@@ -104,13 +104,13 @@ func (r *Router) Start() {
 			return
 		}
 		if err := r.registerConnection(dst, c); err != nil {
-			log.Lvl3(r.address, "does not accept incoming connection to", c.Remote(), "because it's closed")
+			log.Lvl3(r.address, "does not accept incoming connection from", c.Remote(), "because it's closed")
 			return
 		}
 		// start handleConn in a go routine that waits for incoming messages and
 		// dispatches them.
 		if err := r.launchHandleRoutine(dst, c); err != nil {
-			log.Lvl3(r.address, "does not accept incoming connection to", c.Remote(), "because it's closed")
+			log.Lvl3(r.address, "does not accept incoming connection from", c.Remote(), "because it's closed")
 			return
 		}
 	})
@@ -246,10 +246,12 @@ func (r *Router) handleConn(remote *ServerIdentity, c Conn) {
 		if err := c.Close(); err != nil {
 			log.Lvl5(r.address, "having error closing conn to", remote.Address, ":", err)
 		}
-		r.traffic.updateRx(c.Rx())
-		r.traffic.updateTx(c.Tx())
+		rx, tx := c.Rx(), c.Tx()
+		r.traffic.updateRx(rx)
+		r.traffic.updateTx(tx)
 		r.wg.Done()
 		r.removeConnection(remote, c)
+		log.Lvl2("onet close", c.Remote(), "rx", rx, "tx", tx)
 	}()
 	address := c.Remote()
 	log.Lvl3(r.address, "Handling new connection from", remote.Address)

--- a/node_test.go
+++ b/node_test.go
@@ -280,38 +280,6 @@ func (p *ProtocolChannels) Release() {
 	p.Done()
 }
 
-type ServiceChannels struct {
-	ctx  *Context
-	path string
-	tree Tree
-}
-
-// implement services interface
-func (c *ServiceChannels) ProcessClientRequest(si *network.ServerIdentity, r interface{}) {
-
-	tni := c.ctx.NewTreeNodeInstance(&c.tree, c.tree.Root, ProtocolChannelsName)
-	pi, err := NewProtocolChannels(tni)
-	if err != nil {
-		return
-	}
-
-	if err := c.ctx.RegisterProtocolInstance(pi); err != nil {
-		return
-	}
-	pi.Start()
-}
-
-func (c *ServiceChannels) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig) (ProtocolInstance, error) {
-	log.Lvl1("Cosi Service received New Protocol event")
-	return NewProtocolChannels(tn)
-}
-
-func (c *ServiceChannels) Process(e *network.Envelope) {
-	return
-}
-
-// End: protocol/service channels
-
 type ProtocolHandlers struct {
 	*TreeNodeInstance
 }

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -149,7 +149,6 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	// add one to the channel length to indicate it's done
 	d.errChan = make(chan error, d.servers+1)
 	return nil
-
 }
 
 // Start will execute one cothority-binary for each server

--- a/websocket.go
+++ b/websocket.go
@@ -73,6 +73,10 @@ func (w *WebSocket) start() {
 // registerService stores a service to the given path. All requests to that
 // path and it's sub-endpoints will be forwarded to ProcessClientRequest.
 func (w *WebSocket) registerService(service string, s Service) error {
+	if service == "ok" {
+		return errors.New("service name \"ok\" is not allowed")
+	}
+
 	w.services[service] = s
 	h := &wsHandler{
 		service:     s,


### PR DESCRIPTION
Tune logging so that auditing and errors go out at level 2.

Also: Add an HTTP responder for "/ok" so that HTTP load balancers can detect if a conode is alive.