### PR TITLE
Give ProcessClientRequest the HTTP Request

### DIFF
--- a/network/struct.go
+++ b/network/struct.go
@@ -63,8 +63,6 @@ type Envelope struct {
 	Msg Message
 	// which constructors are used
 	Constructors protobuf.Constructors
-	// possible error during unmarshalling so that upper layer can know it
-	err error
 }
 
 // ServerIdentity is used to represent a Server in the whole internet.

--- a/processor.go
+++ b/processor.go
@@ -2,6 +2,7 @@ package onet
 
 import (
 	"errors"
+	"net/http"
 	"reflect"
 
 	"strings"
@@ -113,7 +114,7 @@ func (p *ServiceProcessor) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig
 // ProcessClientRequest takes a request from a websocket client, calculates the reply
 // and sends it back. It uses the path to find the appropriate handler-
 // function. It implements the Server interface.
-func (p *ServiceProcessor) ProcessClientRequest(path string, buf []byte) ([]byte, error) {
+func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
 	mh, ok := p.handlers[path]
 	reply, err := func() (interface{}, error) {
 		if !ok {

--- a/processor_test.go
+++ b/processor_test.go
@@ -66,7 +66,7 @@ func TestServiceProcessor_ProcessClientRequest(t *testing.T) {
 
 	buf, err := protobuf.Encode(&testMsg{11})
 	log.ErrFatal(err)
-	rep, err := p.ProcessClientRequest("testMsg", buf)
+	rep, err := p.ProcessClientRequest(nil, "testMsg", buf)
 	require.Equal(t, nil, err)
 	val := &testMsg{}
 	log.ErrFatal(protobuf.Decode(rep, val))
@@ -76,12 +76,12 @@ func TestServiceProcessor_ProcessClientRequest(t *testing.T) {
 
 	buf, err = protobuf.Encode(&testMsg{42})
 	log.ErrFatal(err)
-	rep, err = p.ProcessClientRequest("testMsg", buf)
+	rep, err = p.ProcessClientRequest(nil, "testMsg", buf)
 	assert.NotNil(t, err)
 
 	buf, err = protobuf.Encode(&testMsg2{42})
 	log.ErrFatal(err)
-	rep, err = p.ProcessClientRequest("testMsg2", buf)
+	rep, err = p.ProcessClientRequest(nil, "testMsg2", buf)
 	assert.NotNil(t, err)
 }
 

--- a/service.go
+++ b/service.go
@@ -3,6 +3,7 @@ package onet
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"strconv"
@@ -37,7 +38,7 @@ type Service interface {
 	// service. It returns a message that will be sent back to the
 	// client. The returned error will be formatted as a websocket
 	// error code 4000, using the string form of the error as the message.
-	ProcessClientRequest(handler string, msg []byte) (reply []byte, err error)
+	ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, err error)
 	// Processor makes a Service being able to handle any kind of packets
 	// directly from the network. It is used for inter service communications,
 	// which are mostly single packets with no or little interactions needed. If

--- a/service_test.go
+++ b/service_test.go
@@ -3,6 +3,7 @@ package onet
 import (
 	"bytes"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -450,7 +451,7 @@ type simpleService struct {
 	ctx *Context
 }
 
-func (s *simpleService) ProcessClientRequest(path string, buf []byte) ([]byte, error) {
+func (s *simpleService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
 	msg := &SimpleRequest{}
 	err := protobuf.DecodeWithConstructors(buf, msg, network.DefaultConstructors(tSuite))
 	if err != nil {
@@ -536,7 +537,7 @@ type DummyService struct {
 	Config   DummyConfig
 }
 
-func (ds *DummyService) ProcessClientRequest(path string, buf []byte) ([]byte, error) {
+func (ds *DummyService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
 	log.Lvl2("Got called with path", path, buf)
 	msg := &DummyMsg{}
 	err := protobuf.Decode(buf, msg)
@@ -606,7 +607,7 @@ func newDummyService2(c *Context) (Service, error) {
 	return &dummyService2{Context: c}, nil
 }
 
-func (ds *dummyService2) ProcessClientRequest(path string, buf []byte) ([]byte, error) {
+func (ds *dummyService2) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
 	panic("should not be called")
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -129,7 +129,7 @@ func (t wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var reply []byte
 		path := strings.TrimPrefix(r.URL.Path, "/"+t.serviceName+"/")
 		log.Lvl3("Got request for", t.serviceName, path)
-		reply, err = s.ProcessClientRequest(path, buf)
+		reply, err = s.ProcessClientRequest(r, path, buf)
 		if err == nil {
 			err := ws.WriteMessage(mt, reply)
 			if err != nil {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,6 +1,7 @@
 package onet
 
 import (
+	"net/http"
 	"testing"
 
 	"fmt"
@@ -180,7 +181,7 @@ const dummyService3Name = "dummyService3"
 type DummyService3 struct {
 }
 
-func (ds *DummyService3) ProcessClientRequest(path string, buf []byte) ([]byte, error) {
+func (ds *DummyService3) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
 	log.Lvl2("Got called with path", path, buf)
 	return []byte(path), nil
 }


### PR DESCRIPTION
So that it can make decisions based on who the
remote client is, or what the state of TLS is, etc.

Fixes #331.