### PR TITLE
Add CounterIO interface to TreeNodeInstance and Overlay

### DIFF
--- a/context.go
+++ b/context.go
@@ -38,7 +38,8 @@ func (c *Context) NewTreeNodeInstance(t *Tree, tn *TreeNode, protoName string) *
 
 // SendRaw sends a message to the ServerIdentity.
 func (c *Context) SendRaw(si *network.ServerIdentity, msg interface{}) error {
-	return c.server.Send(si, msg)
+	_, err := c.server.Send(si, msg)
+	return err
 }
 
 // ServerIdentity returns this server's identity.

--- a/network/big_test.go
+++ b/network/big_test.go
@@ -78,9 +78,12 @@ func TestTCPHugeConnections(t *testing.T) {
 
 				go func(h int) {
 					log.Lvl3(h, "Sending back")
-					err := c.Send(&big)
+					sentLen, err := c.Send(&big)
 					if err != nil {
 						t.Fatal(h, "couldn't send message:", err)
+					}
+					if sentLen == 0 {
+						t.Fatal("sentLen is zero")
 					}
 				}(h)
 				log.Lvl3(h, "done sending messages")
@@ -111,8 +114,12 @@ func TestTCPHugeConnections(t *testing.T) {
 			go func(conn Conn, i, j int) {
 				defer wg.Done()
 				log.Lvl3("Sending from", i, "to", j, ":")
-				if err := conn.Send(&big); err != nil {
+				sentLen, err := conn.Send(&big)
+				if err != nil {
 					t.Fatal(i, j, "Couldn't send:", err)
+				}
+				if sentLen == 0 {
+					t.Fatal("sentLen is zero")
 				}
 				nm, err := conn.Receive()
 				if err != nil {

--- a/network/local.go
+++ b/network/local.go
@@ -273,7 +273,7 @@ func (lc *LocalConn) start(wg *sync.WaitGroup) {
 func (lc *LocalConn) Send(msg Message) (uint64, error) {
 	buff, err := Marshal(msg)
 	if err != nil {
-		return uint64(len(buff)), err
+		return 0, err
 	}
 	sentLen := uint64(len(buff))
 	lc.updateTx(sentLen)

--- a/network/local.go
+++ b/network/local.go
@@ -270,13 +270,14 @@ func (lc *LocalConn) start(wg *sync.WaitGroup) {
 // Send takes a context (that is not used in any way) and a message that
 // will be sent to the remote endpoint.
 // If there is an error in the connection, it will be returned.
-func (lc *LocalConn) Send(msg Message) error {
+func (lc *LocalConn) Send(msg Message) (uint64, error) {
 	buff, err := Marshal(msg)
 	if err != nil {
-		return err
+		return uint64(len(buff)), err
 	}
-	lc.updateTx(uint64(len(buff)))
-	return lc.manager.send(lc.remote, buff)
+	sentLen := uint64(len(buff))
+	lc.updateTx(sentLen)
+	return sentLen, lc.manager.send(lc.remote, buff)
 }
 
 // Receive takes a context (that is not used) and waits for a packet to

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -148,7 +148,7 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 	// make the listener send and receive a struct that only they can know (this
 	// listener + conn
 	handshake := func(c Conn, sending, receiving Address) error {
-		err := c.Send(&AddressTest{sending, secret})
+		_, err := c.Send(&AddressTest{sending, secret})
 		if err != nil {
 			return err
 		}
@@ -243,8 +243,9 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 			assert.Equal(t, 3, nm.Msg.(*SimpleMessage).I)
 			// acknoledge the message
 			incomingConn <- true
-			err = c.Send(&SimpleMessage{3})
+			sentLen, err := c.Send(&SimpleMessage{3})
 			assert.Nil(t, err)
+			assert.NotZero(t, sentLen)
 			//wait ack
 			<-outgoingConn
 			assert.Equal(t, 2, listener.manager.count())
@@ -265,7 +266,9 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 	// check if connection is opened on the listener
 	<-incomingConn
 	// send stg and wait for ack
-	assert.Nil(t, outgoing.Send(&SimpleMessage{3}))
+	sentLen, err := outgoing.Send(&SimpleMessage{3})
+	assert.Nil(t, err)
+	assert.NotZero(t, sentLen)
 	<-incomingConn
 
 	// receive stg and send ack
@@ -298,8 +301,9 @@ func TestLocalManyConn(t *testing.T) {
 		listener.Listen(func(c Conn) {
 			_, err := c.Receive()
 			assert.Nil(t, err)
-
-			assert.Nil(t, c.Send(&SimpleMessage{3}))
+			sentLen, err := c.Send(&SimpleMessage{3})
+			assert.Nil(t, err)
+			assert.NotZero(t, sentLen)
 		})
 	}()
 
@@ -314,7 +318,9 @@ func TestLocalManyConn(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Nil(t, c.Send(&SimpleMessage{3}))
+			sentLen, err := c.Send(&SimpleMessage{3})
+			assert.Nil(t, err)
+			assert.NotZero(t, sentLen)
 			nm, err := c.Receive()
 			assert.Nil(t, err)
 			assert.Equal(t, 3, nm.Msg.(*SimpleMessage).I)

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -148,10 +148,14 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 	// make the listener send and receive a struct that only they can know (this
 	// listener + conn
 	handshake := func(c Conn, sending, receiving Address) error {
-		_, err := c.Send(&AddressTest{sending, secret})
+		sentLen, err := c.Send(&AddressTest{sending, secret})
 		if err != nil {
 			return err
 		}
+		if sentLen == 0 {
+			return fmt.Errorf("sentLen is zero")
+		}
+
 		p, err := c.Receive()
 		if err != nil {
 			return err

--- a/network/network.go
+++ b/network/network.go
@@ -5,6 +5,7 @@ type Conn interface {
 	// Send a message through the connection.
 	// obj should be a POINTER to the actual struct to send, or an interface.
 	// It should not be a Golang type.
+	// Returns the number of bytes sent and an error if any.
 	Send(Message) (uint64, error)
 	// Receive any message through the connection. It is a blocking call that
 	// returns either when a message arrived or when Close() has been called, or

--- a/network/network.go
+++ b/network/network.go
@@ -5,7 +5,7 @@ type Conn interface {
 	// Send a message through the connection.
 	// obj should be a POINTER to the actual struct to send, or an interface.
 	// It should not be a Golang type.
-	Send(Message) error
+	Send(Message) (uint64, error)
 	// Receive any message through the connection. It is a blocking call that
 	// returns either when a message arrived or when Close() has been called, or
 	// when a network error occurred.

--- a/network/router.go
+++ b/network/router.go
@@ -156,60 +156,66 @@ func (r *Router) Stop() error {
 }
 
 // Send sends to an ServerIdentity without wrapping the msg into a ProtocolMsg
-func (r *Router) Send(e *ServerIdentity, msg Message) error {
+func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 	if msg == nil {
-		return errors.New("Can't send nil-packet")
+		return 0, errors.New("Can't send nil-packet")
 	}
 
+	var totSentLen uint64
 	c := r.connection(e.ID)
 	if c == nil {
+		var sentLen uint64
 		var err error
-		c, err = r.connect(e)
+		c, sentLen, err = r.connect(e)
+		totSentLen += sentLen
 		if err != nil {
-			return err
+			return totSentLen, err
 		}
 	}
 
 	log.Lvlf4("%s sends to %s msg: %+v", r.address, e, msg)
-	var err error
-	err = c.Send(msg)
+	sentLen, err := c.Send(msg)
+	totSentLen += sentLen
 	if err != nil {
 		log.Lvl2(r.address, "Couldn't send to", e, ":", err, "trying again")
-		c, err := r.connect(e)
+		c, sentLen, err := r.connect(e)
+		totSentLen += sentLen
 		if err != nil {
-			return err
+			return totSentLen, err
 		}
-		err = c.Send(msg)
+		sentLen, err = c.Send(msg)
+		totSentLen += sentLen
 		if err != nil {
-			return err
+			return totSentLen, err
 		}
 	}
 	log.Lvl5("Message sent")
-	return nil
+	return totSentLen, nil
 }
 
 // connect starts a new connection and launches the listener for incoming
 // messages.
-func (r *Router) connect(si *ServerIdentity) (Conn, error) {
+func (r *Router) connect(si *ServerIdentity) (Conn, uint64, error) {
 	log.Lvl3(r.address, "Connecting to", si.Address)
 	c, err := r.host.Connect(si)
 	if err != nil {
 		log.Lvl3("Could not connect to", si.Address, err)
-		return nil, err
+		return nil, 0, err
 	}
 	log.Lvl3(r.address, "Connected to", si.Address)
-	if err := c.Send(r.ServerIdentity); err != nil {
-		return nil, err
+	var sentLen uint64
+	if sentLen, err = c.Send(r.ServerIdentity); err != nil {
+		return nil, sentLen, err
 	}
 
-	if err := r.registerConnection(si, c); err != nil {
-		return nil, err
+	if err = r.registerConnection(si, c); err != nil {
+		return nil, sentLen, err
 	}
 
-	if err := r.launchHandleRoutine(si, c); err != nil {
-		return nil, err
+	if err = r.launchHandleRoutine(si, c); err != nil {
+		return nil, sentLen, err
 	}
-	return c, nil
+	return c, sentLen, nil
 
 }
 

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/dedis/onet/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,11 +100,14 @@ func TestRouterErrorHandling(t *testing.T) {
 	h2.RegisterProcessor(proc, SimpleMessageType)
 
 	msgSimple := &SimpleMessage{3}
-	err := h1.Send(h2.ServerIdentity, msgSimple)
+	sentLen, err := h1.Send(h2.ServerIdentity, msgSimple)
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 	decoded := <-proc.relay
-	assert.Equal(t, 3, decoded.I)
-	assert.Nil(t, h2.Send(h1.ServerIdentity, msgSimple))
+	require.Equal(t, 3, decoded.I)
+	sentLen, err = h2.Send(h1.ServerIdentity, msgSimple)
+	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 	decoded = <-proc.relay
 
 	//stop node 2
@@ -130,7 +132,9 @@ func testRouterRemoveConnection(t *testing.T) {
 	go r1.Start()
 	go r2.Start()
 
-	require.NotNil(t, r1.Send(r2.ServerIdentity, nil))
+	sentLen, err := r1.Send(r2.ServerIdentity, nil)
+	require.NotNil(t, err)
+	require.Zero(t, sentLen)
 
 	r1.Lock()
 	require.Equal(t, 1, len(r1.connections[r2.ServerIdentity.ID]))
@@ -156,16 +160,15 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = h1.Send(&ServerIdentity{Address: NewLocalAddress("127.1.2.3:2890")}, &SimpleMessage{12})
-	if err == nil {
-		t.Fatal("Should not be able to send")
-	}
+	_, err = h1.Send(&ServerIdentity{Address: NewLocalAddress("127.1.2.3:2890")}, &SimpleMessage{12})
+	require.NotNil(t, err, "Should not be able to send")
+
 	h2, err := fac(2008)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = h1.Send(h2.ServerIdentity, nil)
+	_, err = h1.Send(h2.ServerIdentity, nil)
 	require.NotNil(t, err)
 
 	go h2.Start()
@@ -174,8 +177,8 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	}
 
 	clean := func() {
-		assert.Nil(t, h1.Stop())
-		assert.Nil(t, h2.Stop())
+		require.Nil(t, h1.Stop())
+		require.Nil(t, h2.Stop())
 	}
 	defer clean()
 
@@ -183,8 +186,9 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	h2.RegisterProcessor(proc, SimpleMessageType)
 	h1.RegisterProcessor(proc, SimpleMessageType)
 
-	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
+	sentLen, err := h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 
 	// Receive the message
 	msg := <-proc.relay
@@ -194,19 +198,20 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 
 	h12 := h1.connection(h2.ServerIdentity.ID)
 	h21 := h2.connection(h1.ServerIdentity.ID)
-	assert.NotNil(t, h12)
+	require.NotNil(t, h12)
 	require.NotNil(t, h21)
-	assert.Nil(t, h21.Close())
+	require.Nil(t, h21.Close())
 	time.Sleep(100 * time.Millisecond)
 
-	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
+	sentLen, err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 	<-proc.relay
 
 	if err := h2.Stop(); err != nil {
 		t.Fatal("Should be able to stop h2")
 	}
-	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
+	_, err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	if err == nil {
 		// This should not happen, but it can due to a race in
 		// the kernel between closing and writing to the
@@ -240,17 +245,22 @@ func TestRouterMessaging(t *testing.T) {
 	h2.RegisterProcessor(proc, SimpleMessageType)
 
 	msgSimple := &SimpleMessage{3}
-	err := h1.Send(h2.ServerIdentity, msgSimple)
+	sentLen, err := h1.Send(h2.ServerIdentity, msgSimple)
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
+
 	decoded := <-proc.relay
-	assert.Equal(t, 3, decoded.I)
+	require.Equal(t, 3, decoded.I)
 
 	// make sure the connection is registered in host1 (because it's launched in
 	// a go routine). Since we try to avoid random timeout, let's send a msg
 	// from host2 -> host1.
-	assert.Nil(t, h2.Send(h1.ServerIdentity, msgSimple))
+	sentLen, err = h2.Send(h1.ServerIdentity, msgSimple)
+	require.Nil(t, err)
+	require.NotZero(t, sentLen)
+
 	decoded = <-proc.relay
-	assert.Equal(t, 3, decoded.I)
+	require.Equal(t, 3, decoded.I)
 
 	written := h1.Tx()
 	read := h2.Rx()
@@ -305,7 +315,7 @@ func (p *nSquareProc) Process(env *Envelope) {
 	}
 
 	p.firstRound[remote] = true
-	if err := p.r.Send(env.ServerIdentity, &SimpleMessage{3}); err != nil {
+	if _, err := p.r.Send(env.ServerIdentity, &SimpleMessage{3}); err != nil {
 		p.t.Fatal("Could not send to first round dest.")
 	}
 
@@ -348,7 +358,7 @@ func testRouterLotsOfConn(t *testing.T, fac routerFactory, nbrRouter int) {
 					continue
 				}
 				// send to everyone else
-				if err := r.Send(routers[k].ServerIdentity, &SimpleMessage{3}); err != nil {
+				if _, err := r.Send(routers[k].ServerIdentity, &SimpleMessage{3}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -395,17 +405,17 @@ func testRouterSendMsgDuplex(t *testing.T, fac routerFactory) {
 	h2.RegisterProcessor(proc, SimpleMessageType)
 
 	msgSimple := &SimpleMessage{5}
-	err := h1.Send(h2.ServerIdentity, msgSimple)
-	if err != nil {
-		t.Fatal("Couldn't send message from h1 to h2", err)
-	}
+	sentLen, err := h1.Send(h2.ServerIdentity, msgSimple)
+	require.Nil(t, err, "Couldn't send message from h1 to h2")
+	require.NotZero(t, sentLen)
+
 	msg := <-proc.relay
 	log.Lvl2("Received msg h1 -> h2", msg)
 
-	err = h2.Send(h1.ServerIdentity, msgSimple)
-	if err != nil {
-		t.Fatal("Couldn't send message from h2 to h1", err)
-	}
+	sentLen, err = h2.Send(h1.ServerIdentity, msgSimple)
+	require.Nil(t, err, "Couldn't send message from h2 to h1")
+	require.NotZero(t, sentLen)
+
 	msg = <-proc.relay
 	log.Lvl2("Received msg h2 -> h1", msg)
 }
@@ -431,14 +441,15 @@ func TestRouterExchange(t *testing.T) {
 	if err != nil {
 		t.Fatal("Couldn't connect to host1:", err)
 	}
-	if err := c.Send(router2.ServerIdentity); err != nil {
-		t.Fatal("Wrong negotiation")
-	}
+	sentLen, err := c.Send(router2.ServerIdentity)
+	require.Nil(t, err, "Wrong negotiation")
+	require.NotZero(t, sentLen)
+
 	// triggers the dispatching conditional branch error router.go:
 	//  `log.Lvl3("Error dispatching:", err)`
-	if err := router2.Send(router1.ServerIdentity, &SimpleMessage{12}); err != nil {
-		t.Fatal("Could not send")
-	}
+	sentLen, err = router2.Send(router1.ServerIdentity, &SimpleMessage{12})
+	require.Nil(t, err, "Could not send")
+	require.NotZero(t, sentLen)
 	c.Close()
 
 	// try messing with the connections here
@@ -448,9 +459,8 @@ func TestRouterExchange(t *testing.T) {
 	}
 	// closing before sending
 	c.Close()
-	if err := c.Send(router2.ServerIdentity); err == nil {
-		t.Fatal("negotiation should have aborted")
-	}
+	_, err = c.Send(router2.ServerIdentity)
+	require.NotNil(t, err, "negotiation should have aborted")
 
 	// stop everything
 	log.Lvl4("Closing connections")
@@ -474,14 +484,16 @@ func TestRouterRxTx(t *testing.T) {
 	addr := NewAddress(router1.address.ConnType(), "127.0.0.1:"+router1.address.Port())
 	si1 := NewServerIdentity(Suite.Point(tSuite).Null(), addr)
 
-	log.ErrFatal(router2.Send(si1, si1))
+	sentLen, err := router2.Send(si1, si1)
+	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 
 	// Wait for the message to be sent and received
 	waitTimeout(time.Second, 10, func() bool {
 		return router1.Rx() > 0 && router1.Rx() == router2.Tx()
 	})
 	rx := router1.Rx()
-	assert.Equal(t, 1, len(router1.connections))
+	require.Equal(t, 1, len(router1.connections))
 	router1.Lock()
 	var si2 ServerIdentityID
 	for si2 = range router1.connections {
@@ -494,7 +506,7 @@ func TestRouterRxTx(t *testing.T) {
 		defer router1.Unlock()
 		return len(router1.connections[si2]) == 0
 	})
-	assert.Equal(t, rx, router1.Rx())
+	require.Equal(t, rx, router1.Rx())
 	defer router1.Stop()
 }
 

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -140,13 +140,13 @@ func (c *TCPConn) receiveRaw() ([]byte, error) {
 // Send converts the NetworkMessage into an ApplicationMessage
 // and sends it using send().
 // It returns an error if anything was wrong.
-func (c *TCPConn) Send(msg Message) error {
+func (c *TCPConn) Send(msg Message) (uint64, error) {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
 
 	b, err := Marshal(msg)
 	if err != nil {
-		return fmt.Errorf("Error marshaling  message: %s", err.Error())
+		return 0, fmt.Errorf("Error marshaling  message: %s", err.Error())
 	}
 	return c.sendRaw(b)
 }
@@ -154,11 +154,11 @@ func (c *TCPConn) Send(msg Message) error {
 // sendRaw writes the number of bytes of the message to the network then the
 // whole message b in slices of size maxChunkSize.
 // In case of an error it aborts and returns error.
-func (c *TCPConn) sendRaw(b []byte) error {
+func (c *TCPConn) sendRaw(b []byte) (uint64, error) {
 	// First write the size
 	packetSize := Size(len(b))
 	if err := binary.Write(c.conn, globalOrder, packetSize); err != nil {
-		return err
+		return 0, err
 	}
 	// Then send everything through the connection
 	// Send chunk by chunk
@@ -167,14 +167,16 @@ func (c *TCPConn) sendRaw(b []byte) error {
 	for sent < packetSize {
 		n, err := c.conn.Write(b[sent:])
 		if err != nil {
-			c.updateTx(4 + uint64(sent))
-			return handleError(err)
+			sentLen := 4 + uint64(sent)
+			c.updateTx(sentLen)
+			return sentLen, handleError(err)
 		}
 		sent += Size(n)
 	}
 	// update stats on the connection. Plus 4 for the uint32 for the frame size.
-	c.updateTx(4 + uint64(sent))
-	return nil
+	sentLen := 4 + uint64(sent)
+	c.updateTx(sentLen)
+	return sentLen, nil
 }
 
 // Remote returns the name of the peer at the end point of

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -139,7 +139,7 @@ func (c *TCPConn) receiveRaw() ([]byte, error) {
 
 // Send converts the NetworkMessage into an ApplicationMessage
 // and sends it using send().
-// It returns an error if anything was wrong.
+// It returns the number of bytes sent and an error if anything was wrong.
 func (c *TCPConn) Send(msg Message) (uint64, error) {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
@@ -153,7 +153,7 @@ func (c *TCPConn) Send(msg Message) (uint64, error) {
 
 // sendRaw writes the number of bytes of the message to the network then the
 // whole message b in slices of size maxChunkSize.
-// In case of an error it aborts and returns error.
+// In case of an error it aborts.
 func (c *TCPConn) sendRaw(b []byte) (uint64, error) {
 	// First write the size
 	packetSize := Size(len(b))

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -109,7 +109,7 @@ func TestTCPsendRaw(t *testing.T) {
 		tcp := &TCPConn{
 			conn: test.conn,
 		}
-		err := tcp.sendRaw(test.msg)
+		_, err := tcp.sendRaw(test.msg)
 		if test.errExpected {
 			if err == nil {
 				t.Error("Should have had an error here")
@@ -176,7 +176,7 @@ func TestTCPConnReceiveRaw(t *testing.T) {
 		check <- true
 	}
 
-	fn_bad := func(c net.Conn) {
+	fnBad := func(c net.Conn) {
 		// send the size first
 		binary.Write(c, globalOrder, Size(MaxPacketSize+1))
 	}
@@ -212,7 +212,7 @@ func TestTCPConnReceiveRaw(t *testing.T) {
 	// wait until it is closed
 	<-done
 
-	go listen(fn_bad)
+	go listen(fnBad)
 
 	listeningAddr = <-addr
 	c, err = NewTCPConn(NewAddress(PlainTCP, listeningAddr), tSuite)
@@ -295,7 +295,9 @@ func TestTCPConnTimeout(t *testing.T) {
 	c, err := NewTCPConn(addr, tSuite)
 	require.Nil(t, err, "Could not open connection")
 	// Test bandwitdth measurements also
-	require.Nil(t, c.Send(&SimpleMessage{3}))
+	sentLen, err := c.Send(&SimpleMessage{3})
+	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 	select {
 	case received := <-connStat:
 		assert.Nil(t, received)
@@ -342,13 +344,15 @@ func TestTCPConnWithListener(t *testing.T) {
 	// Test bandwitdth measurements also
 	rx1 := <-connStat
 	tx1 := c.Tx()
-	require.Nil(t, c.Send(&SimpleMessage{3}))
+	sentLen, err := c.Send(&SimpleMessage{3})
+	require.Nil(t, err)
 	tx2 := c.Tx()
 	rx2 := <-connStat
 
 	if (tx2 - tx1) != (rx2 - rx1) {
 		t.Errorf("Connections did see same bytes? %d tx vs %d rx", (tx2 - tx1), (rx2 - rx1))
 	}
+	require.Equal(t, tx2-tx1, sentLen)
 
 	require.Nil(t, ln.Stop(), "Error stopping listener")
 	select {
@@ -481,7 +485,7 @@ func TestHandleError(t *testing.T) {
 	require.Equal(t, ErrCanceled, handleError(errors.New("canceled")))
 	require.Equal(t, ErrEOF, handleError(errors.New("EOF")))
 
-	require.Equal(t, ErrUnknown, handleError(errors.New("Random error!")))
+	require.Equal(t, ErrUnknown, handleError(errors.New("random error")))
 
 	de := dummyErr{true, true}
 	de.temporary = false
@@ -562,7 +566,7 @@ func sendrcvProc(from, to *Router) error {
 	sp := newSimpleProcessor()
 	// new processing
 	to.RegisterProcessor(sp, statusMsgID)
-	if err := from.Send(to.ServerIdentity, &statusMessage{true, 10}); err != nil {
+	if _, err := from.Send(to.ServerIdentity, &statusMessage{true, 10}); err != nil {
 		return err
 	}
 	var err error

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -566,10 +566,14 @@ func sendrcvProc(from, to *Router) error {
 	sp := newSimpleProcessor()
 	// new processing
 	to.RegisterProcessor(sp, statusMsgID)
-	if _, err := from.Send(to.ServerIdentity, &statusMessage{true, 10}); err != nil {
+	sentLen, err := from.Send(to.ServerIdentity, &statusMessage{true, 10})
+	if err != nil {
 		return err
 	}
-	var err error
+	if sentLen == 0 {
+		return errors.New("sentLen is zero")
+	}
+
 	select {
 	case <-sp.relay:
 		err = nil

--- a/network/tls_test.go
+++ b/network/tls_test.go
@@ -83,8 +83,9 @@ func TestTLS(t *testing.T) {
 	}()
 
 	// now send a message from r2 to r1
-	err = r2.Send(r1.ServerIdentity, aHello)
+	sentLen, err := r2.Send(r1.ServerIdentity, aHello)
 	require.Nil(t, err, "Could not router.Send")
+	require.NotZero(t, sentLen)
 
 	<-rcv
 }
@@ -135,7 +136,7 @@ func benchmarkMsg(b *testing.B, r1, r2 *Router) {
 
 	// Send one message from r2 to r1.
 	for i := 0; i < b.N; i++ {
-		err := r2.Send(r1.ServerIdentity, aHello)
+		_, err := r2.Send(r1.ServerIdentity, aHello)
 		if err != nil {
 			b.Log("Could not router.Send")
 		}

--- a/overlay.go
+++ b/overlay.go
@@ -264,6 +264,7 @@ func (o *Overlay) requestTree(si *network.ServerIdentity, onetMsg *ProtocolMsg, 
 		return err
 	}
 
+	// no need to record sentLen because Overlay uses Server's CounterIO
 	_, err = o.server.Send(si, msg)
 	return err
 }

--- a/overlay.go
+++ b/overlay.go
@@ -264,7 +264,7 @@ func (o *Overlay) requestTree(si *network.ServerIdentity, onetMsg *ProtocolMsg, 
 		return err
 	}
 
-	err = o.server.Send(si, msg)
+	_, err = o.server.Send(si, msg)
 	return err
 }
 
@@ -332,6 +332,16 @@ func (o *Overlay) TreeNodeFromToken(t *Token) (*TreeNode, error) {
 	return tn, nil
 }
 
+// Rx implements the CounterIO interface, should be the same as the server
+func (o *Overlay) Rx() uint64 {
+	return o.server.Rx()
+}
+
+// Tx implements the CounterIO interface, should be the same as the server
+func (o *Overlay) Tx() uint64 {
+	return o.server.Tx()
+}
+
 func (o *Overlay) handleRequestTree(si *network.ServerIdentity, req *RequestTree, io MessageProxy) {
 	tid := req.TreeID
 	tree := o.Tree(tid)
@@ -355,7 +365,7 @@ func (o *Overlay) handleRequestTree(si *network.ServerIdentity, req *RequestTree
 		return
 	}
 
-	err = o.server.Send(si, msg)
+	_, err = o.server.Send(si, msg)
 	if err != nil {
 		log.Error("Couldn't send tree:", err)
 	}
@@ -375,7 +385,7 @@ func (o *Overlay) handleSendTree(si *network.ServerIdentity, tm *TreeMarshal, io
 		if err != nil {
 			log.Error("could not wrap RequestRoster:", err)
 		}
-		if err := o.server.Send(si, msg); err != nil {
+		if _, err := o.server.Send(si, msg); err != nil {
 			log.Error("Requesting Roster in SendTree failed", err)
 		}
 		// put the tree marshal into pending queue so when we receive the
@@ -413,7 +423,7 @@ func (o *Overlay) handleRequestRoster(si *network.ServerIdentity, req *RequestRo
 		return
 	}
 
-	err = o.server.Send(si, msg)
+	_, err = o.server.Send(si, msg)
 	if err != nil {
 		log.Error("Couldn't send empty entity list from host:",
 			o.server.ServerIdentity.String(),
@@ -466,14 +476,17 @@ func (o *Overlay) getConfig(id TokenID) *GenericConfig {
 // c is the generic config that should be sent beforehand in order to get passed
 // in the `NewProtocol` method if a Service has created the protocol and set the
 // config with `SetConfig`. It can be nil.
-func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message, io MessageProxy, c *GenericConfig) error {
+func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message, io MessageProxy, c *GenericConfig) (uint64, error) {
 	tokenTo := from.ChangeTreeNodeID(to.ID)
+	var totSentLen uint64
 
 	// first send the config if present
 	if c != nil {
-		if err := o.server.Send(to.ServerIdentity, &ConfigMsg{*c, tokenTo.ID()}); err != nil {
+		sentLen, err := o.server.Send(to.ServerIdentity, &ConfigMsg{*c, tokenTo.ID()})
+		totSentLen += sentLen
+		if err != nil {
 			log.Error("sending config failed:", err)
-			return err
+			return totSentLen, err
 		}
 	}
 	// then send the message
@@ -486,9 +499,12 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message,
 	}
 	final, err := io.Wrap(msg, info)
 	if err != nil {
-		return err
+		return totSentLen, err
 	}
-	return o.server.Send(to.ServerIdentity, final)
+
+	sentLen, err := o.server.Send(to.ServerIdentity, final)
+	totSentLen += sentLen
+	return totSentLen, err
 }
 
 // nodeDone is called by node to signify that its work is finished and its

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -188,11 +188,11 @@ func TestOverlayRosterPropagation(t *testing.T) {
 	h1.RegisterProcessor(proc, proc.Types()...)
 
 	// Check that h2 sends back an empty list if it is unknown
-	err := h1.Send(h2.ServerIdentity, &RequestRoster{
+	sentLen, err := h1.Send(h2.ServerIdentity, &RequestRoster{
 		RosterID: el.ID})
-	if err != nil {
-		t.Fatal("Couldn't send message to h2:", err)
-	}
+	require.Nil(t, err, "Couldn't send message to h1")
+	require.NotZero(t, sentLen)
+
 	roster := <-proc.sendRoster
 	if !roster.ID.IsNil() {
 		t.Fatal("List should be empty")
@@ -200,19 +200,19 @@ func TestOverlayRosterPropagation(t *testing.T) {
 
 	// Now add the list to h2 and try again
 	h2.AddRoster(el)
-	err = h1.Send(h2.ServerIdentity, &RequestRoster{RosterID: el.ID})
-	if err != nil {
-		t.Fatal("Couldn't send message to h2:", err)
-	}
+	sentLen, err = h1.Send(h2.ServerIdentity, &RequestRoster{RosterID: el.ID})
+	require.Nil(t, err, "Couldn't send message to h2")
+	require.NotZero(t, sentLen)
+
 	msg := <-proc.sendRoster
 	if !msg.ID.Equal(el.ID) {
 		t.Fatal("List should be equal to original list")
 	}
 
-	err = h1.Send(h2.ServerIdentity, &RequestRoster{RosterID: el.ID})
-	if err != nil {
-		t.Fatal("Couldn't send message to h2:", err)
-	}
+	sentLen, err = h1.Send(h2.ServerIdentity, &RequestRoster{RosterID: el.ID})
+	require.Nil(t, err, "Couldn't send message to h2")
+	require.NotZero(t, sentLen)
+
 	// check if we receive the Roster then
 	ros := <-proc.sendRoster
 	packet := network.Envelope{
@@ -242,10 +242,10 @@ func TestOverlayTreePropagation(t *testing.T) {
 	//h2.RegisterProcessor(proc, proc.Types()...)
 
 	// Check that h2 sends back an empty tree if it is unknown
-	err := h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
-	if err != nil {
-		t.Fatal("Couldn't send message to h2:", err)
-	}
+	sentLen, err := h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
+	require.Nil(t, err, "Couldn't send message to h2")
+	require.NotZero(t, sentLen)
+
 	msg := <-proc.treeMarshal
 	if !msg.RosterID.IsNil() {
 		t.Fatal("List should be empty")
@@ -253,14 +253,17 @@ func TestOverlayTreePropagation(t *testing.T) {
 
 	// Now add the list to h2 and try again
 	h2.AddTree(tree)
-	err = h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
+	sentLen, err = h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
 
 	msg = <-proc.treeMarshal
 	assert.Equal(t, msg.TreeID, tree.ID)
 
-	err = h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
+	sentLen, err = h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
 	require.Nil(t, err)
+	require.NotZero(t, sentLen)
+
 	// check if we receive the tree then
 	var tm *TreeMarshal
 	tm = <-proc.treeMarshal
@@ -297,9 +300,9 @@ func TestOverlayRosterTreePropagation(t *testing.T) {
 	// and the tree
 	h2.AddTree(tree)
 	// make the communcation happen
-	if err := h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID}); err != nil {
-		t.Fatal("Could not send tree request to host2", err)
-	}
+	sentLen, err := h1.Send(h2.ServerIdentity, &RequestTree{TreeID: tree.ID})
+	require.Nil(t, err, "Could not send tree request to host2")
+	require.NotZero(t, sentLen)
 
 	proc := newOverlayProc()
 	h1.RegisterProcessor(proc, SendRosterMsgID)

--- a/service_test.go
+++ b/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/dedis/protobuf"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -136,7 +135,7 @@ func TestServiceRequestNewProtocol(t *testing.T) {
 	// Now resend the value so we instantiate using the same treenode
 	log.Lvl1("Sending request again to service...")
 	err := client.SendProtobuf(server.ServerIdentity, &DummyMsg{10}, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	// this should fail
 	waitOrFatalValue(ds.link, false, t)
 }
@@ -229,7 +228,9 @@ func TestServiceProcessor(t *testing.T) {
 	log.Lvl1("Host created and listening")
 	// create request
 	log.Lvl1("Sending request to service...")
-	assert.Nil(t, server2.Send(server1.ServerIdentity, &DummyMsg{10}))
+	sentLen, err := server2.Send(server1.ServerIdentity, &DummyMsg{10})
+	require.Nil(t, err)
+	require.NotNil(t, sentLen)
 
 	// wait for the link from the Service on server 1
 	waitOrFatalValue(ds1.link, true, t)
@@ -262,7 +263,7 @@ func TestServiceBackForthProtocol(t *testing.T) {
 	sr := &SimpleResponse{}
 	err = client.SendProtobuf(servers[0].ServerIdentity, r, sr)
 	log.ErrFatal(err)
-	assert.Equal(t, sr.Val, 10)
+	require.Equal(t, sr.Val, 10)
 }
 
 func TestServiceManager_Service(t *testing.T) {
@@ -271,10 +272,10 @@ func TestServiceManager_Service(t *testing.T) {
 	servers, _, _ := local.GenTree(2, true)
 
 	services := servers[0].serviceManager.availableServices()
-	assert.NotEqual(t, 0, len(services), "no services available")
+	require.NotEqual(t, 0, len(services), "no services available")
 
 	service := servers[0].serviceManager.service("testService")
-	assert.NotNil(t, service, "Didn't find service testService")
+	require.NotNil(t, service, "Didn't find service testService")
 }
 
 func TestServiceMessages(t *testing.T) {
@@ -283,7 +284,7 @@ func TestServiceMessages(t *testing.T) {
 	servers, _, _ := local.GenTree(2, true)
 
 	service := servers[0].serviceManager.service(ismServiceName)
-	assert.NotNil(t, service, "Didn't find service ISMService")
+	require.NotNil(t, service, "Didn't find service ISMService")
 	ism := service.(*ServiceMessages)
 	ism.SendRaw(servers[0].ServerIdentity, &SimpleResponse{})
 	require.True(t, <-ism.GotResponse, "Didn't get response")

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -28,8 +28,8 @@ var global struct {
 // Usage:
 // 		measure := monitor.SingleMeasure("bandwidth")
 // or
-//		 measure := monitor.NewTimeMeasure("round")
-// 		 measure.Record()
+//		measure := monitor.NewTimeMeasure("round")
+// 		measure.Record()
 type Measure interface {
 	// Record must be called when you want to send the value
 	// over the monitor listening.

--- a/treenode_test.go
+++ b/treenode_test.go
@@ -85,11 +85,16 @@ func TestConfigPropagation(t *testing.T) {
 
 	network.RegisterMessage(dummyMsg{})
 	rootInstance, _ := local.NewTreeNodeInstance(tree.Root, spawnName)
+	require.Zero(t, rootInstance.Tx())
+	require.Zero(t, rootInstance.Rx())
+
 	err = rootInstance.SetConfig(&GenericConfig{serviceConfig})
 	assert.Nil(t, err)
 	err = rootInstance.SetConfig(&GenericConfig{serviceConfig})
 	assert.NotNil(t, err)
+
 	err = rootInstance.SendToChildren(&dummyMsg{})
+	assert.NotZero(t, rootInstance.Tx())
 	log.ErrFatal(err)
 	// wait until the processor has processed the expected number of config messages
 	select {
@@ -97,7 +102,6 @@ func TestConfigPropagation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Didn't receive response in time")
 	}
-
 }
 
 func TestTreeNodeInstance_RegisterChannel(t *testing.T) {


### PR DESCRIPTION
This PR changes the `Conn` interface where `Send() error` is now `Send (uint64, error)`, and adds the CounterIO interface to TreeNodeInstance and Overlay.

It makes https://github.com/dedis/onet/pull/265 and https://github.com/dedis/onet/pull/264 redundant as it should be an accurate way to count tx/rx. However, I did not add a CounterIO interface to Context because there wasn't an obvious way to do it and Crux only needs it on TreeNodeInstance. Further, since Crux is a long-term project and should be eventually be ported to onet.v2, I do not plan to backport this change to onet.v1. 