### PR TITLE
First try at removing some overlay memory leaks.

### DIFF
--- a/local.go
+++ b/local.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/dedis/kyber"
@@ -33,9 +34,10 @@ type LocalTest struct {
 	ctx   *network.LocalManager
 	Suite network.Suite
 	path  string
-	// Once closed is set, do not allow further operation on it,
+	// Once closed is set, do not allow further operations on it,
 	// since now the temp directory is gone.
 	closed bool
+	T      *testing.T
 }
 
 const (
@@ -171,7 +173,7 @@ func (l *LocalTest) panicClosed() {
 	}
 }
 
-// CloseAll takes a list of servers that will be closed
+// CloseAll closes all the servers.
 func (l *LocalTest) CloseAll() {
 	log.Lvl3("Stopping all")
 	// If the debug-level is 0, we copy all errors to a buffer that
@@ -179,6 +181,20 @@ func (l *LocalTest) CloseAll() {
 	if log.DebugVisible() == 0 {
 		log.OutputToBuf()
 	}
+
+	if l.T != nil {
+		ct := 0
+		for _, o := range l.Overlays {
+			for _, pi := range o.protocolInstances {
+				l.T.Logf("Lingering protocol instance: %T", pi)
+				ct++
+			}
+		}
+		if ct > 0 {
+			l.T.Fatal("Protocols lingering.")
+		}
+	}
+
 	l.ctx.Stop()
 	for _, server := range l.Servers {
 		log.Lvl3("Closing server", server.ServerIdentity.Address)

--- a/overlay.go
+++ b/overlay.go
@@ -512,26 +512,28 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message,
 // ressources can be released
 func (o *Overlay) nodeDone(tok *Token) {
 	o.instancesLock.Lock()
-	defer o.instancesLock.Unlock()
 	o.nodeDelete(tok)
+	o.instancesLock.Unlock()
 }
 
 // nodeDelete needs to be separated from nodeDone, as it is also called from
 // Close, but due to locking-issues here we don't lock.
-func (o *Overlay) nodeDelete(tok *Token) {
-	tni, ok := o.instances[tok.ID()]
+func (o *Overlay) nodeDelete(token *Token) {
+	tok := token.ID()
+	tni, ok := o.instances[tok]
 	if !ok {
-		log.Lvlf2("Node %s already gone", tok.ID())
+		log.Lvlf2("Node %s already gone", tok)
 		return
 	}
-	log.Lvl4("Closing node", tok.ID())
+	log.Lvl4("Closing node", tok)
 	err := tni.closeDispatch()
 	if err != nil {
 		log.Error("Error while closing node:", err)
 	}
-	delete(o.instances, tok.ID())
+	delete(o.protocolInstances, tok)
+	delete(o.instances, tok)
 	// mark it done !
-	o.instancesInfo[tok.ID()] = true
+	o.instancesInfo[tok] = true
 }
 
 func (o *Overlay) suite() network.Suite {

--- a/server.go
+++ b/server.go
@@ -165,6 +165,7 @@ func (c *Server) Start() {
 	c.started = time.Now()
 	go c.Router.Start()
 	c.websocket.start()
-	log.Lvl1("Started server at %s on address %s with public key %s",
-		c.started, c.ServerIdentity.Address, c.ServerIdentity.Public)
+	log.Lvlf1("Started server at %s on address %s with public key %s",
+		c.started.Format("2006-01-02 15:04:05"),
+		c.ServerIdentity.Address, c.ServerIdentity.Public)
 }

--- a/tree.go
+++ b/tree.go
@@ -543,13 +543,12 @@ func (ro *Roster) GenerateBigNaryTree(N, nodes int) *Tree {
 func (ro *Roster) NewRosterWithRoot(root *network.ServerIdentity) *Roster {
 	list := make([]*network.ServerIdentity, len(ro.List))
 	copy(list, ro.List)
-	roster := NewRoster(list)
-	rootIndex, _ := roster.Search(root.ID)
+	rootIndex, _ := ro.Search(root.ID)
 	if rootIndex < 0 {
 		return nil
 	}
-	roster.List[0], roster.List[rootIndex] = roster.List[rootIndex], roster.List[0]
-	return roster
+	list[0], list[rootIndex] = list[rootIndex], list[0]
+	return NewRoster(list)
 }
 
 // GenerateNaryTreeWithRoot creates a tree where each node has N children.

--- a/tree.go
+++ b/tree.go
@@ -1,6 +1,8 @@
 package onet
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -65,7 +67,24 @@ func (tId TreeID) IsNil() bool {
 // NewTree creates a new tree using the given roster and root. It
 // also generates the id.
 func NewTree(roster *Roster, root *TreeNode) *Tree {
-	url := network.NamespaceURL + "tree/" + roster.ID.String() + root.ID.String()
+	// walk the tree with DFS to build a unique hash
+	h := sha256.New()
+	root.Visit(0, func(d int, tn *TreeNode) {
+		_, err := tn.ServerIdentity.Public.MarshalTo(h)
+		if err != nil {
+			log.Error(err)
+		}
+		if tn.IsLeaf() {
+			// to prevent generating the same hash for tree with
+			// the same nodes but with a different structure
+			_, err = h.Write([]byte{1})
+			if err != nil {
+				log.Error(err)
+			}
+		}
+	})
+
+	url := network.NamespaceURL + "tree/" + roster.ID.String() + hex.EncodeToString(h.Sum(nil))
 	t := &Tree{
 		Roster: roster,
 		Root:   root,
@@ -382,9 +401,18 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 		return nil
 	}
 
-	r := &Roster{
-		ID: RosterID(uuid.NewV4()),
+	h := sha256.New()
+	for _, id := range ids {
+		_, err := id.Public.MarshalTo(h)
+		if err != nil {
+			log.Error(err)
+		}
 	}
+
+	r := &Roster{
+		ID: RosterID(uuid.NewV5(uuid.NamespaceURL, hex.EncodeToString(h.Sum(nil)))),
+	}
+
 	// Take a copy of ids, in case the caller tries to change it later.
 	r.List = append(r.List, ids...)
 
@@ -687,7 +715,7 @@ func NewTreeNode(entityIdx int, ni *network.ServerIdentity) *TreeNode {
 		RosterIndex:    entityIdx,
 		Parent:         nil,
 		Children:       make([]*TreeNode, 0),
-		ID:             TreeNodeID(uuid.NewV4()),
+		ID:             TreeNodeID(uuid.NewV5(uuid.NamespaceURL, ni.Public.String())),
 	}
 	return tn
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -447,7 +447,7 @@ func TestRoster_GenerateNaryTreeWithRoot_NewRoster(t *testing.T) {
 	peerList := genRoster(tSuite, names)
 	tree := NewRoster(peerList.List[1:10]).GenerateNaryTreeWithRoot(2, peerList.List[0])
 	assert.Nil(t, tree)
-	for _, e := range peerList.List {
+	for _, e := range peerList.List[1:len(peerList.List)] {
 		tree := peerList.NewRosterWithRoot(e).GenerateNaryTree(4)
 		for i := 0; i <= 9; i++ {
 			if !strings.Contains(peerList.List[i].Address.String(),


### PR DESCRIPTION
@kc1212 and @ineiti found that trees and rosters were very badly set up:
- every time `NewRosterWithRoot` is called, the roster gets a new, random ID
- every time `GenerateNaryTreeWithRoot` is called, even for the same tree, it gets a random ID

-> every call for a new skipchain-block will create a new roster/tree - and they are not cleaned up!

Now we changed it so that rosters depend on the order of the ServerIdentities, and trees depend on the roster and the order of the nodes in the tree. But no random IDs anymore.