### PR TITLE
allow log-padding even without colors

### DIFF
--- a/log/lvl.go
+++ b/log/lvl.go
@@ -99,16 +99,15 @@ func lvl(lvl, skip int, args ...interface{}) {
 
 	fmtstr := ""
 	if useColors {
+		// Only adjust the name and line padding if we also have color.
 		if len(name) > NamePadding && NamePadding > 0 {
 			NamePadding = len(name)
 		}
 		if len(lineStr) > LinePadding && LinePadding > 0 {
 			LinePadding = len(name)
 		}
-		fmtstr = fmt.Sprintf("%%%ds: %%%dd", NamePadding, LinePadding)
-	} else {
-		fmtstr = fmt.Sprintf("%%s: %%d")
 	}
+	fmtstr = fmt.Sprintf("%%%ds: %%%dd", NamePadding, LinePadding)
 	caller := fmt.Sprintf(fmtstr, name, line)
 	if StaticMsg != "" {
 		caller += "@" + StaticMsg

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -131,8 +131,8 @@ func ExampleLvl2() {
 	SetDebugVisible(1)
 
 	// Output:
-	// 1 : (log.ExampleLvl2: 0) - Level1
-	// 2 : (log.ExampleLvl2: 0) - Level2
+	// 1 : (                         log.ExampleLvl2:   0) - Level1
+	// 2 : (                         log.ExampleLvl2:   0) - Level2
 }
 
 func ExampleLvl1() {
@@ -141,7 +141,7 @@ func ExampleLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLvl1: 0) - Multiple parameters
+	// 1 : (                         log.ExampleLvl1:   0) - Multiple parameters
 }
 
 func ExampleLLvl1() {
@@ -153,10 +153,10 @@ func ExampleLLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLLvl1: 0) - Lvl output
-	// 1!: (log.ExampleLLvl1: 0) - LLvl output
-	// 1 : (log.ExampleLLvl1: 0) - Lvlf output
-	// 1!: (log.ExampleLLvl1: 0) - LLvlf output
+	// 1 : (                        log.ExampleLLvl1:   0) - Lvl output
+	// 1!: (                        log.ExampleLLvl1:   0) - LLvl output
+	// 1 : (                        log.ExampleLLvl1:   0) - Lvlf output
+	// 1!: (                        log.ExampleLLvl1:   0) - LLvlf output
 }
 
 func thisIsAVeryLongFunctionNameThatWillOverflow() {
@@ -172,9 +172,9 @@ func ExampleLvlf1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLvlf1: 0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
-	// 1 : (log.ExampleLvlf1: 0) - After
+	// 1 : (                        log.ExampleLvlf1:   0) - Before
+	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
+	// 1 : (                        log.ExampleLvlf1:   0) - After
 }
 
 func ExampleLvl3() {
@@ -186,9 +186,9 @@ func ExampleLvl3() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLvl3: 0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
-	// 1 : (log.ExampleLvl3: 0) - After
+	// 1 : (log.ExampleLvl3:   0) - Before
+	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
+	// 1 : (log.ExampleLvl3:   0) - After
 }
 
 func clearEnv() {

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -26,9 +26,9 @@ func TestInfo(t *testing.T) {
 func TestLvl(t *testing.T) {
 	SetDebugVisible(1)
 	Info("TestLvl")
-	assert.True(t, containsStdOut("I : (log.TestLvl: 0) - TestLvl\n"))
+	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
 	Print("TestLvl")
-	assert.True(t, containsStdOut("I : (log.TestLvl: 0) - TestLvl\n"))
+	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
 	Warn("TestLvl")
-	assert.True(t, containsStdErr("W : (log.TestLvl: 0) - TestLvl\n"))
+	assert.True(t, containsStdErr("W : (                             log.TestLvl:   0) - TestLvl\n"))
 }


### PR DESCRIPTION
Logging: align method-names and description always, but only adjust the alignment when in color-mode.