### PR TITLE
Fatal when calling GlobalProtocolRegister with server(s) already started

### DIFF
--- a/local.go
+++ b/local.go
@@ -176,6 +176,7 @@ func (l *LocalTest) panicClosed() {
 // CloseAll closes all the servers.
 func (l *LocalTest) CloseAll() {
 	log.Lvl3("Stopping all")
+	InformAllServersStopped()
 	// If the debug-level is 0, we copy all errors to a buffer that
 	// will be discarded at the end.
 	if log.DebugVisible() == 0 {

--- a/protocol.go
+++ b/protocol.go
@@ -124,10 +124,12 @@ func ProtocolNameToID(name string) ProtocolID {
 // protocol is tied to a service, use `Server.ProtocolRegisterName`
 func GlobalProtocolRegister(name string, protocol NewProtocol) (ProtocolID, error) {
 	protocols.Lock()
-	defer protocols.Unlock()
+	// Cannot defer the "Unlock" because "Register" is using the lock too.
 	if protocols.serverStarted {
+		protocols.Unlock()
 		panic("Cannot call 'GlobalProtocolRegister' when a server has already started.")
 	}
+	protocols.Unlock()
 	return protocols.Register(name, protocol)
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -126,7 +126,7 @@ func GlobalProtocolRegister(name string, protocol NewProtocol) (ProtocolID, erro
 	protocols.Lock()
 	defer protocols.Unlock()
 	if protocols.serverStarted {
-		log.Lvl4("Cannot call 'GlobalProtocolRegister' when a server has already started.")
+		panic("Cannot call 'GlobalProtocolRegister' when a server has already started.")
 	}
 	return protocols.Register(name, protocol)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -131,14 +131,14 @@ func GlobalProtocolRegister(name string, protocol NewProtocol) (ProtocolID, erro
 	return protocols.Register(name, protocol)
 }
 
-// The function allows to set the 'serverStarted' flag to true.
+// InformServerStarted allows to set the 'serverStarted' flag to true.
 func InformServerStarted() {
 	protocols.Lock()
 	defer protocols.Unlock()
 	protocols.serverStarted = true
 }
 
-// The function allows to set the 'serverStarted' flag to false.
+// InformAllServersStopped allows to set the 'serverStarted' flag to false.
 func InformAllServersStopped() {
 	protocols.Lock()
 	defer protocols.Unlock()

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -245,9 +245,9 @@ func TestGlobalProtocolRegisterTooLate(t *testing.T) {
 	local := NewLocalTest(tSuite)
 	defer local.CloseAll()
 	local.GenTree(2, true)
-    fnShouldPanic := func() {
-        GlobalProtocolRegister(simpleProto, fn)
-    }
+	fnShouldPanic := func() {
+		GlobalProtocolRegister(simpleProto, fn)
+	}
 	assert.Panics(t, fnShouldPanic)
 }
 

--- a/server.go
+++ b/server.go
@@ -162,6 +162,7 @@ func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) 
 // Start makes the router and the websocket listen on their respective
 // ports.
 func (c *Server) Start() {
+	InformServerStarted()
 	c.started = time.Now()
 	log.Lvlf1("Starting server at %s on address %s with public key %s",
 		c.started.Format("2006-01-02 15:04:05"),


### PR DESCRIPTION
By using a flag to `protocolStorage`, we can now check that no server has already been started while calling `GlobalProtocolRegister`, and if this is the case we `log.Fatal`.

Didn't add a test for this change. Should we? If yes, how to test it cleanly since we use `log.Fatal`?