### PR TITLE
Improve testing

### DIFF
--- a/local.go
+++ b/local.go
@@ -260,11 +260,11 @@ func (l *LocalTest) NewTreeNodeInstance(tn *TreeNode, protName string) (*TreeNod
 	return node, nil
 }
 
-// getNodes returns all Nodes that belong to a treeNode
-func (l *LocalTest) getNodes(tn *TreeNode) []*TreeNodeInstance {
+// GetTreeNodeInstances returns all TreeNodeInstances that belong to a server
+func (l *LocalTest) GetTreeNodeInstances(id network.ServerIdentityID) []*TreeNodeInstance {
 	l.panicClosed()
 	var nodes []*TreeNodeInstance
-	for _, n := range l.Overlays[tn.ServerIdentity.ID].instances {
+	for _, n := range l.Overlays[id].instances {
 		nodes = append(nodes, n)
 	}
 	return nodes

--- a/node_test.go
+++ b/node_test.go
@@ -186,8 +186,8 @@ func TestTreeNodeMsgAggregation(t *testing.T) {
 	<-Incoming
 	<-Incoming
 	log.Lvl3("Both children are up")
-	child1 := local.getNodes(tree.Root.Children[0])[0]
-	child2 := local.getNodes(tree.Root.Children[1])[0]
+	child1 := local.GetTreeNodeInstances(tree.Root.Children[0].ServerIdentity.ID)[0]
+	child2 := local.GetTreeNodeInstances(tree.Root.Children[1].ServerIdentity.ID)[0]
 
 	err = local.sendTreeNode(ProtocolChannelsName, child1, proto.TreeNodeInstance, &NodeTestAggMsg{3})
 	if err != nil {

--- a/treenode.go
+++ b/treenode.go
@@ -441,6 +441,7 @@ func (n *TreeNodeInstance) notifyDispatch() {
 }
 
 func (n *TreeNodeInstance) dispatchMsgReader() {
+	log.Lvl3("Starting node", n.Info())
 	for {
 		n.msgDispatchQueueMutex.Lock()
 		if n.closing == true {
@@ -597,7 +598,11 @@ func (n *TreeNodeInstance) Name() string {
 // (IP address and TokenID).
 func (n *TreeNodeInstance) Info() string {
 	tid := n.TokenID()
-	return fmt.Sprintf("%s (%s)", n.ServerIdentity().Address, tid.String())
+	name := protocols.ProtocolIDToName(n.token.ProtoID)
+	if name == "" {
+		name = n.overlay.server.protocols.ProtocolIDToName(n.token.ProtoID)
+	}
+	return fmt.Sprintf("%s (%s): %s", n.ServerIdentity().Address, tid.String(), name)
 }
 
 // TokenID returns the TokenID of the given node (to uniquely identify it)


### PR DESCRIPTION
- `TreeNodeInstance.Info()`: print protocol name
- `LocalTest`: allow list of all `TreeNodeInstances` in tests