### PR TITLE
Simulations using TCP by default, with flag for TLS

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -39,7 +39,7 @@ func TestReadGroupDescToml(t *testing.T) {
 		t.Fatal("Should have 2 ServerIdentities")
 	}
 	nikkoAddr := group.Roster.List[0].Address
-	if !nikkoAddr.Valid() || nikkoAddr != network.NewAddress(network.PlainTCP, "5.135.161.91:2000") {
+	if !nikkoAddr.Valid() || nikkoAddr != network.NewTCPAddress("5.135.161.91:2000") {
 		t.Fatal("Address not valid " + group.Roster.List[0].Address.String())
 	}
 	if len(group.Description) != 2 {

--- a/local.go
+++ b/local.go
@@ -339,7 +339,7 @@ func NewPrivIdentity(suite network.Suite, port int) (kyber.Scalar, *network.Serv
 // address.
 func newTCPServer(s network.Suite, port int, path string) *Server {
 	priv, id := NewPrivIdentity(s, port)
-	addr := network.NewAddress(network.PlainTCP, id.Address.NetworkAddress())
+	addr := network.NewTCPAddress(id.Address.NetworkAddress())
 	id2 := network.NewServerIdentity(id.Public, addr)
 	var tcpHost *network.TCPHost
 	// For the websocket we need a port at the address one higher than the

--- a/network/big_test.go
+++ b/network/big_test.go
@@ -49,7 +49,7 @@ func TestTCPHugeConnections(t *testing.T) {
 	var err error
 	// Create all hosts and open the connections
 	for i := 0; i < nbrHosts; i++ {
-		addr := NewAddress(PlainTCP, "localhost:"+strconv.Itoa(2000+i))
+		addr := NewTCPAddress("localhost:"+strconv.Itoa(2000+i))
 		ids[i] = NewTestServerIdentity(addr)
 		hosts[i], err = NewTCPListener(addr, tSuite)
 		if err != nil {

--- a/network/big_test.go
+++ b/network/big_test.go
@@ -49,7 +49,7 @@ func TestTCPHugeConnections(t *testing.T) {
 	var err error
 	// Create all hosts and open the connections
 	for i := 0; i < nbrHosts; i++ {
-		addr := NewTCPAddress("localhost:"+strconv.Itoa(2000+i))
+		addr := NewTCPAddress("localhost:" + strconv.Itoa(2000+i))
 		ids[i] = NewTestServerIdentity(addr)
 		hosts[i], err = NewTCPListener(addr, tSuite)
 		if err != nil {

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestLocalRouter(t *testing.T) {
 	addr := &ServerIdentity{Address: NewLocalAddress("127.0.0.1:2000")}
-	wrongAddr1 := &ServerIdentity{Address: NewAddress(PlainTCP, addr.Address.NetworkAddress())}
+	wrongAddr1 := &ServerIdentity{Address: NewTCPAddress(addr.Address.NetworkAddress())}
 	_, err := NewLocalRouter(wrongAddr1, tSuite)
 	if err == nil {
 		t.Error("Should have returned something..")
@@ -26,7 +26,7 @@ func TestLocalRouter(t *testing.T) {
 
 func TestLocalListener(t *testing.T) {
 	addr := NewLocalAddress("127.0.0.1:2000")
-	wrongAddr1 := NewAddress(PlainTCP, addr.NetworkAddress())
+	wrongAddr1 := NewTCPAddress(addr.NetworkAddress())
 	listener, err := NewLocalListener(wrongAddr1, tSuite)
 	if err == nil {
 		t.Error("Create listener with wrong address should fail")

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -23,6 +23,12 @@ var readTimeout = 1 * time.Minute
 // packets, increase this value.
 var MaxPacketSize = Size(10 * 1024 * 1024)
 
+// NewTCPAddress returns a new Address that has type PlainTCP with the given
+// address addr.
+func NewTCPAddress(addr string) Address {
+	return NewAddress(PlainTCP, addr)
+}
+
 // NewTCPRouter returns a new Router using TCPHost as the underlying Host.
 func NewTCPRouter(sid *ServerIdentity, suite Suite) (*Router, error) {
 	h, err := NewTCPHost(sid, suite)
@@ -187,7 +193,7 @@ func (c *TCPConn) Remote() Address {
 
 // Local returns the local address and port.
 func (c *TCPConn) Local() Address {
-	return NewAddress(PlainTCP, c.conn.LocalAddr().String())
+	return NewTCPAddress(c.conn.LocalAddr().String())
 }
 
 // Type returns PlainTCP.

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -196,7 +196,7 @@ func TestTCPConnReceiveRaw(t *testing.T) {
 
 	// get addr
 	listeningAddr := <-addr
-	c, err := NewTCPConn(NewAddress(PlainTCP, listeningAddr), tSuite)
+	c, err := NewTCPConn(NewTCPAddress(listeningAddr), tSuite)
 	require.Nil(t, err)
 
 	buffRaw, err := c.receiveRaw()
@@ -215,7 +215,7 @@ func TestTCPConnReceiveRaw(t *testing.T) {
 	go listen(fnBad)
 
 	listeningAddr = <-addr
-	c, err = NewTCPConn(NewAddress(PlainTCP, listeningAddr), tSuite)
+	c, err = NewTCPConn(NewTCPAddress(listeningAddr), tSuite)
 	require.Nil(t, err)
 
 	_, err = c.receiveRaw()
@@ -235,7 +235,7 @@ func TestTCPConn(t *testing.T) {
 	addr := make(chan string)
 	done := make(chan bool)
 
-	_, err := NewTCPConn(NewAddress(PlainTCP, "127.0.0.1:7878"), tSuite)
+	_, err := NewTCPConn(NewTCPAddress("127.0.0.1:7878"), tSuite)
 	if err == nil {
 		t.Fatal("Should not be able to connect here")
 	}
@@ -253,7 +253,7 @@ func TestTCPConn(t *testing.T) {
 
 	// get addr
 	listeningAddr := <-addr
-	c, err := NewTCPConn(NewAddress(PlainTCP, listeningAddr), tSuite)
+	c, err := NewTCPConn(NewTCPAddress(listeningAddr), tSuite)
 	require.Nil(t, err)
 	require.Equal(t, c.Local().NetworkAddress(), c.conn.LocalAddr().String())
 	require.Equal(t, c.Type(), PlainTCP)
@@ -269,7 +269,7 @@ func TestTCPConnTimeout(t *testing.T) {
 	readTimeout = 100 * time.Millisecond
 	defer func() { readTimeout = tmp }()
 
-	addr := NewAddress(PlainTCP, "127.0.0.1:5678")
+	addr := NewTCPAddress("127.0.0.1:5678")
 	ln, err := NewTCPListener(addr, tSuite)
 	if err != nil {
 		t.Fatal("error setup listener", err)
@@ -317,7 +317,7 @@ func TestTCPConnTimeout(t *testing.T) {
 }
 
 func TestTCPConnWithListener(t *testing.T) {
-	addr := NewAddress(PlainTCP, "127.0.0.1:5678")
+	addr := NewTCPAddress("127.0.0.1:5678")
 	ln, err := NewTCPListener(addr, tSuite)
 	if err != nil {
 		t.Fatal("error setup listener", err)
@@ -365,7 +365,7 @@ func TestTCPConnWithListener(t *testing.T) {
 
 // will create a TCPListener & open a golang net.TCPConn to it
 func TestTCPListener(t *testing.T) {
-	addr := NewAddress(PlainTCP, "127.0.0.1:5678")
+	addr := NewTCPAddress("127.0.0.1:5678")
 	ln, err := NewTCPListener(addr, tSuite)
 	if err != nil {
 		t.Fatal("Error setup listener:", err)
@@ -405,7 +405,7 @@ func TestTCPRouter(t *testing.T) {
 	if err == nil {
 		t.Fatal("Should not setup Router with local address")
 	}
-	addr := &ServerIdentity{Address: NewAddress(PlainTCP, "127.0.0.1:2000")}
+	addr := &ServerIdentity{Address: NewTCPAddress("127.0.0.1:2000")}
 	h1, err := NewTCPRouter(addr, tSuite)
 	if err != nil {
 		t.Fatal("Could not setup host")
@@ -495,7 +495,7 @@ func TestHandleError(t *testing.T) {
 }
 
 func NewTestTCPHost(port int) (*TCPHost, error) {
-	addr := NewAddress(PlainTCP, "127.0.0.1:"+strconv.Itoa(port))
+	addr := NewTCPAddress("127.0.0.1:"+strconv.Itoa(port))
 	kp := key.NewKeyPair(tSuite)
 	e := NewServerIdentity(kp.Public, addr)
 	e.SetPrivate(kp.Private)

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -495,7 +495,7 @@ func TestHandleError(t *testing.T) {
 }
 
 func NewTestTCPHost(port int) (*TCPHost, error) {
-	addr := NewTCPAddress("127.0.0.1:"+strconv.Itoa(port))
+	addr := NewTCPAddress("127.0.0.1:" + strconv.Itoa(port))
 	kp := key.NewKeyPair(tSuite)
 	e := NewServerIdentity(kp.Public, addr)
 	e.SetPrivate(kp.Private)

--- a/simulation.go
+++ b/simulation.go
@@ -74,7 +74,7 @@ type SimulationConfigFile struct {
 	TreeMarshal *TreeMarshal
 	Roster      *Roster
 	PrivateKeys map[network.Address]kyber.Scalar
-	TLS 		bool
+	TLS         bool
 	Config      string
 }
 
@@ -102,7 +102,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 	sc := &SimulationConfig{
 		Roster:      scf.Roster,
 		PrivateKeys: scf.PrivateKeys,
-		TLS:		 scf.TLS,
+		TLS:         scf.TLS,
 		Config:      scf.Config,
 	}
 	sc.Tree, err = scf.TreeMarshal.MakeTree(sc.Roster)
@@ -140,9 +140,9 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 			_, port, _ := net.SplitHostPort(sc.Roster.List[i].Address.NetworkAddress())
 			// put 127.0.0.1 because 127.0.0.X is not reachable on Mac OS X
 			if sc.TLS {
-				sc.Roster.List[i].Address = network.NewTLSAddress("127.0.0.1:"+port)
+				sc.Roster.List[i].Address = network.NewTLSAddress("127.0.0.1:" + port)
 			} else {
-				sc.Roster.List[i].Address = network.NewTCPAddress("127.0.0.1:"+port)
+				sc.Roster.List[i].Address = network.NewTCPAddress("127.0.0.1:" + port)
 			}
 		}
 	}
@@ -157,7 +157,7 @@ func (sc *SimulationConfig) Save(dir string) error {
 		TreeMarshal: sc.Tree.MakeTreeMarshal(),
 		Roster:      sc.Roster,
 		PrivateKeys: sc.PrivateKeys,
-		TLS:		 sc.TLS,
+		TLS:         sc.TLS,
 		Config:      sc.Config,
 	}
 	buf, err := network.Marshal(scf)
@@ -215,7 +215,7 @@ type SimulationBFTree struct {
 	Depth      int
 	Suite      string
 	PreScript  string // executable script to run before the simulation on each machine
-	TLS        bool // tells if using TLS or PlainTCP addresses
+	TLS        bool   // tells if using TLS or PlainTCP addresses
 }
 
 // CreateRoster creates an Roster with the host-names in 'addresses'.

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSimulationBF(t *testing.T) {
-	sc, _, err := createBFTree(7, 2, []string{"test1", "test2"})
+	sc, _, err := createBFTree(7, 2, false, []string{"test1", "test2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestSimulationBF(t *testing.T) {
 		t.Fatal("Created tree is not binary")
 	}
 
-	sc, _, err = createBFTree(13, 3, []string{"test1", "test2"})
+	sc, _, err = createBFTree(13, 3, false, []string{"test1", "test2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestSimulationBigTree(t *testing.T) {
 		t.Skip()
 	}
 	for i := uint(4); i < 8; i++ {
-		_, _, err := createBFTree(1<<i-1, 2, []string{"test1", "test2"})
+		_, _, err := createBFTree(1<<i-1, 2, false, []string{"test1", "test2"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,7 +61,7 @@ func TestSimulationBigTree(t *testing.T) {
 }
 
 func TestSimulationLoadSave(t *testing.T) {
-	sc, _, err := createBFTree(7, 2, []string{"127.0.0.1", "127.0.0.2"})
+	sc, _, err := createBFTree(7, 2, false, []string{"127.0.0.1", "127.0.0.2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestSimulationLoadSave(t *testing.T) {
 }
 
 func TestSimulationMultipleInstances(t *testing.T) {
-	sc, _, err := createBFTree(7, 2, []string{"127.0.0.1", "127.0.0.2"})
+	sc, _, err := createBFTree(7, 2, false, []string{"127.0.0.1", "127.0.0.2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,12 +114,13 @@ func closeAll(scs []*SimulationConfig) {
 	}
 }
 
-func createBFTree(hosts, bf int, addresses []string) (*SimulationConfig, *SimulationBFTree, error) {
+func createBFTree(hosts, bf int, tls bool, addresses []string) (*SimulationConfig, *SimulationBFTree, error) {
 	sc := &SimulationConfig{}
 	sb := &SimulationBFTree{
 		Hosts: hosts,
 		BF:    bf,
 		Suite: "Ed25519",
+		TLS:   tls,
 	}
 	sb.CreateRoster(sc, addresses, 2000)
 	if len(sc.Roster.List) != hosts {

--- a/tree_test.go
+++ b/tree_test.go
@@ -586,7 +586,7 @@ func genLocalhostPeerNames(n, p int) []network.Address {
 func genLocalDiffPeerNames(n, p int) []network.Address {
 	names := make([]network.Address, n)
 	for i := range names {
-		names[i] = network.NewAddress(network.PlainTCP, "127.0.0."+strconv.Itoa(i)+":2000")
+		names[i] = network.NewTCPAddress("127.0.0."+strconv.Itoa(i)+":2000")
 	}
 	return names
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -586,7 +586,7 @@ func genLocalhostPeerNames(n, p int) []network.Address {
 func genLocalDiffPeerNames(n, p int) []network.Address {
 	names := make([]network.Address, n)
 	for i := range names {
-		names[i] = network.NewTCPAddress("127.0.0."+strconv.Itoa(i)+":2000")
+		names[i] = network.NewTCPAddress("127.0.0." + strconv.Itoa(i) + ":2000")
 	}
 	return names
 }


### PR DESCRIPTION
- Created `NewTCPAddress` function in `network/tcp.go`.
- Changed a maximum of TCP `Address` creation with this new function.
- By default, using `PlainTCP` addresses in simulations, instead of `TLS`.
- Added a `TLS` flag `SimulationConfig`, `SimulationConfigFile` and `SimulationBFTree` structures to let the user decide if `TLS` should be used instead of the default `PlainTCP`.

It seems to me that it is necessary to add the `TLS` flag to those 3 structures, maybe it's good if you check that this is indeed the case.

Also, the current tests in `simulation_test.go` can all be run using `PlainTCP`, right?