### PR TITLE
Removed double call to 'Shutdown()' inside 'TreeNodeInstance.Done()'

### DIFF
--- a/treenode.go
+++ b/treenode.go
@@ -558,7 +558,6 @@ func (n *TreeNodeInstance) Done() {
 		}
 	}
 	log.Lvl3(n.Info(), "has finished. Deleting its resources")
-	n.closeDispatch()
 	n.overlay.nodeDone(n.token)
 }
 


### PR DESCRIPTION
- Removed what seems to be a useless call to `TreeNodeInstance.closeDispatch()` inside `TreeNodeInstance.Done()`, since it's already called (on the same instance) when calling `Instance.nodeDone()` inside the same function.