### PR TITLE
show errors in message processing

### DIFF
--- a/network/struct.go
+++ b/network/struct.go
@@ -50,7 +50,7 @@ type Size uint32
 type Envelope struct {
 	// The ServerIdentity of the remote peer we are talking to.
 	// Basically, this means that when you open a new connection to someone, and
-	// / or listens to incoming connections, the network library will already
+	// or listen to incoming connections, the network library will already
 	// make some exchange between the two communicants so each knows the
 	// ServerIdentity of the others.
 	ServerIdentity *ServerIdentity

--- a/overlay.go
+++ b/overlay.go
@@ -116,7 +116,11 @@ func (o *Overlay) Process(env *network.Envelope) {
 			Msg:            inner,
 			MsgType:        typ,
 		}
-		o.TransmitMsg(protoMsg, io)
+		err := o.TransmitMsg(protoMsg, io)
+		if err != nil {
+			log.Errorf("Msg %s from %s produced error: %s", protoMsg.MsgType,
+				protoMsg.ServerIdentity, err.Error())
+		}
 	}
 }
 

--- a/treenode.go
+++ b/treenode.go
@@ -387,6 +387,13 @@ func (n *TreeNodeInstance) reflectCreate(t reflect.Type, msg *ProtocolMsg) refle
 // dispatchChannel takes a message and sends it to a channel
 func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 	mt := msgSlice[0].MsgType
+	defer func() {
+		// In rare occasions we write to a closed channel which throws a panic.
+		// Catch it here so we can find out better why this happens.
+		if r := recover(); r != nil {
+			log.Error("Shouldn't happen, please report an issue:", n.Info(), r, mt)
+		}
+	}()
 	to := reflect.TypeOf(n.channels[mt])
 	if n.hasFlag(mt, AggregateMessages) {
 		log.Lvl4("Received aggregated message of type:", mt)


### PR DESCRIPTION
When `TransmitMsg` returns error, there is a code execution pass where this error is ignored. Added an error output in that case.
In `TreeNodeInstance.dispatchChannel` there is a rare occasion of a write to a closed channel. Added a `recover` to further debug it.