### PR TITLE
Correct GlobalBind to parse IPv6 correctly

### DIFF
--- a/network/struct.go
+++ b/network/struct.go
@@ -3,6 +3,7 @@ package network
 import (
 	"bytes"
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -168,13 +169,13 @@ func (si *ServerIdentityToml) ServerIdentity(suite Suite) *ServerIdentity {
 }
 
 // GlobalBind returns the global-binding address. Given any IP:PORT combination,
-// it will return 0.0.0.0:PORT.
+// it will return ":PORT".
 func GlobalBind(address string) (string, error) {
-	addr := strings.Split(address, ":")
-	if len(addr) != 2 {
-		return "", errors.New("not a host:port address")
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", err
 	}
-	return "0.0.0.0:" + addr[1], nil
+	return ":" + port, nil
 }
 
 // counterSafe is a struct that enables to update two counters Rx & Tx

--- a/network/struct_test.go
+++ b/network/struct_test.go
@@ -42,12 +42,25 @@ func TestServerIdentity(t *testing.T) {
 }
 
 func TestGlobalBind(t *testing.T) {
-	_, err := GlobalBind("127.0.0.1:2000")
+	gb, err := GlobalBind("127.0.0.1:2000")
 	if err != nil {
-		t.Error("Wrong with global bind")
+		t.Fatal("global bind err", err)
 	}
+	if gb != ":2000" {
+		t.Fatal("Wrong result", gb)
+	}
+
 	_, err = GlobalBind("127.0.0.12000")
 	if err == nil {
-		t.Error("Wrong with global bind")
+		t.Fatal("Missing error for global bind")
+	}
+
+	// IPv6
+	gb, err = GlobalBind("[::1]:2000")
+	if err != nil {
+		t.Fatal("global bind err", err)
+	}
+	if gb != ":2000" {
+		t.Fatal("Wrong result", gb)
 	}
 }

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -281,7 +281,11 @@ func NewTCPListener(addr Address, s Suite) (*TCPListener, error) {
 		quitListener: make(chan bool),
 		suite:        s,
 	}
-	global, _ := GlobalBind(addr.NetworkAddress())
+	global, err := GlobalBind(addr.NetworkAddress())
+	if err != nil {
+		return nil, err
+	}
+
 	for i := 0; i < MaxRetryConnect; i++ {
 		ln, err := net.Listen("tcp", global)
 		if err == nil {


### PR DESCRIPTION
GlobalBind was not parsing IP addresses correctly. Now it is.
Also check the error it returns in the caller.

This makes it possible for conodes to listen on IPv6 as
well as IPv4.

Fixes #390.