### PR TITLE
Use sha256(pk) as the database name

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package onet
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -104,7 +105,9 @@ func TestContext_Path(t *testing.T) {
 
 	c := createContext(t, tmp)
 	pub, _ := c.ServerIdentity().Public.MarshalBinary()
-	dbPath := path.Join(tmp, fmt.Sprintf("%x.db", pub))
+	h := sha256.New()
+	h.Write(pub)
+	dbPath := path.Join(tmp, fmt.Sprintf("%x.db", h.Sum(nil)))
 	_, err = os.Stat(dbPath)
 	if err != nil {
 		t.Error(err)
@@ -120,7 +123,9 @@ func TestContext_Path(t *testing.T) {
 	_, err = os.Stat(tmp)
 	log.ErrFatal(err)
 	pub, _ = c.ServerIdentity().Public.MarshalBinary()
-	_, err = os.Stat(path.Join(tmp, fmt.Sprintf("%x.db", pub)))
+	h = sha256.New()
+	h.Write(pub)
+	_, err = os.Stat(path.Join(tmp, fmt.Sprintf("%x.db", h.Sum(nil))))
 	log.ErrFatal(err)
 }
 

--- a/onet_test.go
+++ b/onet_test.go
@@ -8,6 +8,5 @@ import (
 
 // To avoid setting up testing-verbosity in all tests
 func TestMain(m *testing.M) {
-
 	log.MainTest(m)
 }

--- a/service.go
+++ b/service.go
@@ -289,7 +289,7 @@ func (s *serviceManager) dbFileName() string {
 	return path.Join(s.dbPath, fmt.Sprintf("%x.db", h.Sum(nil)))
 }
 
-// updateDbFileName checks if the old database file name exists, it does, it
+// updateDbFileName checks if the old database file name exists, if it does, it
 // will rename it to the new file name.
 func (s *serviceManager) updateDbFileName() {
 	if _, err := os.Stat(s.dbFileNameOld()); err == nil {

--- a/service.go
+++ b/service.go
@@ -1,13 +1,13 @@
 package onet
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path"
 	"strconv"
-
 	"sync"
 
 	bolt "github.com/coreos/bbolt"
@@ -227,6 +227,8 @@ func newServiceManager(svr *Server, o *Overlay, dbPath string, delDb bool) *serv
 		Dispatcher: network.NewRoutineDispatcher(),
 	}
 
+	s.updateDbFileName()
+
 	db, err := openDb(s.dbFileName())
 	if err != nil {
 		log.Panic("Failed to create new database: " + err.Error())
@@ -275,9 +277,28 @@ func createBucketForService(db *bolt.DB, bucketName string) error {
 	})
 }
 
-func (s *serviceManager) dbFileName() string {
+func (s *serviceManager) dbFileNameOld() string {
 	pub, _ := s.server.ServerIdentity.Public.MarshalBinary()
 	return path.Join(s.dbPath, fmt.Sprintf("%x.db", pub))
+}
+
+func (s *serviceManager) dbFileName() string {
+	pub, _ := s.server.ServerIdentity.Public.MarshalBinary()
+	h := sha256.New()
+	h.Write(pub)
+	return path.Join(s.dbPath, fmt.Sprintf("%x.db", h.Sum(nil)))
+}
+
+// updateDbFileName checks if the old database file name exists, it does, it
+// will rename it to the new file name.
+func (s *serviceManager) updateDbFileName() {
+	if _, err := os.Stat(s.dbFileNameOld()); err == nil {
+		// we assume the new name does not exist
+		log.Lvl2("Renaming database from", s.dbFileNameOld(), "to", s.dbFileName())
+		if err := os.Rename(s.dbFileNameOld(), s.dbFileName()); err != nil {
+			log.Error(err)
+		}
+	}
 }
 
 // Process implements the Processor interface: service manager will relay


### PR DESCRIPTION
We do this because, depending on the suites, public keys may be very
long, too long for filesystems. This commit uses the sha256 of the
public key as the database file name and automatically converts old
filenames to the new one.

This feature is a bit difficult to test by unit tests. We have integration
test in cothority/conode. 

Fixes #399 
