### PR TITLE
Added TLS to WebSocket

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-    "os"
+	"os"
 	"strings"
 	"testing"
 
@@ -133,19 +133,19 @@ f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
 
 	// Write files containing cert and key (+ be sure to delete them at the end)
 	certFile, err := ioutil.TempFile("", "temp_cert.pem")
-    defer func() {
-        err := os.Remove(certFile.Name())
-        require.Nil(t, err)
-    }()
+	defer func() {
+		err := os.Remove(certFile.Name())
+		require.Nil(t, err)
+	}()
 	require.Nil(t, err)
 	certFile.WriteString(wsTLSCert)
 	certFile.Close()
 
 	keyFile, err := ioutil.TempFile("", "temp_key.pem")
-    defer func() {
-        err := os.Remove(keyFile.Name())
-        require.Nil(t, err)
-    }()
+	defer func() {
+		err := os.Remove(keyFile.Name())
+		require.Nil(t, err)
+	}()
 	require.Nil(t, err)
 	keyFile.WriteString(wsTLSCertKey)
 	keyFile.Close()
@@ -213,7 +213,7 @@ f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
 
 		srv.Close()
 
-        err = os.Remove(privateToml.Name())
-        require.Nil(t, err)
+		err = os.Remove(privateToml.Name())
+		require.Nil(t, err)
 	}
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"github.com/stretchr/testify/require"
 )
 
 var o bytes.Buffer
@@ -47,5 +50,158 @@ func TestReadGroupDescToml(t *testing.T) {
 	}
 	if group.Description[group.Roster.List[1]] != "Ismail's server" {
 		t.Fatal("This should be Ismail's server")
+	}
+}
+
+func TestParseCothority(t *testing.T) {
+	suite := "Ed25519"
+	public := "6a921638a4ade8970ebcd9e371570f08d71a24987f90f12391b9f6c525be5be4"
+	private := "6a921638a4ade8970ebcd9e371570f08d71a24987f90f12391b9f6c525be5be4"
+	address := "tcp://1.2.3.4:1234"
+	listenAddr := "127.0.0.1:0"
+	description := "This is a description."
+
+	privateInfo := fmt.Sprintf(`Suite = "%s"
+        Public = "%s"
+        Private = "%s"
+        Address = "%s"
+        ListenAddress = "%s"
+        Description = "%s"`,
+		suite, public, private, address, listenAddr,
+		description)
+
+	privateToml, err := ioutil.TempFile("", "temp_private.toml")
+	require.Nil(t, err)
+
+	privateToml.WriteString(privateInfo)
+	privateToml.Close()
+
+	cothConfig, srv, err := ParseCothority(privateToml.Name())
+	require.Nil(t, err)
+
+	// Check basic information
+	require.Equal(t, suite, cothConfig.Suite)
+	require.Equal(t, public, cothConfig.Public)
+	require.Equal(t, private, cothConfig.Private)
+	require.Equal(t, address, cothConfig.Address.String())
+	require.Equal(t, listenAddr, cothConfig.ListenAddress)
+	require.Equal(t, description, cothConfig.Description)
+
+	srv.Close()
+}
+
+func TestParseCothorityWithTLSWebSocket(t *testing.T) {
+	suite := "Ed25519"
+	public := "6a921638a4ade8970ebcd9e371570f08d71a24987f90f12391b9f6c525be5be4"
+	private := "6a921638a4ade8970ebcd9e371570f08d71a24987f90f12391b9f6c525be5be4"
+	address := "tcp://1.2.3.4:1234"
+	listenAddr := "127.0.0.1:0"
+	description := "This is a description."
+
+	// Certificate and key examples taken from
+	// 'https://gist.github.com/blinksmith/579b2650a09f128a03ca'
+	wsTLSCert := `-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`
+	wsTLSCertKey := `-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9
+SjY1bIw4iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZB
+l2+XsDulrKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQAB
+AoGAGRzwwir7XvBOAy5tM/uV6e+Zf6anZzus1s1Y1ClbjbE6HXbnWWF/wbZGOpet
+3Zm4vD6MXc7jpTLryzTQIvVdfQbRc6+MUVeLKwZatTXtdZrhu+Jk7hx0nTPy8Jcb
+uJqFk541aEw+mMogY/xEcfbWd6IOkp+4xqjlFLBEDytgbIECQQDvH/E6nk+hgN4H
+qzzVtxxr397vWrjrIgPbJpQvBsafG7b0dA4AFjwVbFLmQcj2PprIMmPcQrooz8vp
+jy4SHEg1AkEA/v13/5M47K9vCxmb8QeD/asydfsgS5TeuNi8DoUBEmiSJwma7FXY
+fFUtxuvL7XvjwjN5B30pNEbc6Iuyt7y4MQJBAIt21su4b3sjXNueLKH85Q+phy2U
+fQtuUE9txblTu14q3N7gHRZB4ZMhFYyDy8CKrN2cPg/Fvyt0Xlp/DoCzjA0CQQDU
+y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
+qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
+f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
+-----END RSA PRIVATE KEY-----`
+
+	// Write files containing cert and key
+	certFile, err := ioutil.TempFile("", "temp_cert.pem")
+	require.Nil(t, err)
+	certFile.WriteString(wsTLSCert)
+	certFile.Close()
+
+	keyFile, err := ioutil.TempFile("", "temp_key.pem")
+	require.Nil(t, err)
+	keyFile.WriteString(wsTLSCertKey)
+	keyFile.Close()
+
+	// Testing different ways of putting TLS info.
+	privateInfos := []string{
+		fmt.Sprintf(`Suite = "%s"
+            Public = "%s"
+            Private = "%s"
+            Address = "%s"
+            ListenAddress = "%s"
+            Description = "%s"
+            WebSocketTLSCertificate = """string://%s"""
+            WebSocketTLSCertificateKey = """string://%s"""`,
+			suite, public, private, address, listenAddr,
+			description, wsTLSCert, wsTLSCertKey),
+		fmt.Sprintf(`Suite = "%s"
+            Public = "%s"
+            Private = "%s"
+            Address = "%s"
+            ListenAddress = "%s"
+            Description = "%s"
+            WebSocketTLSCertificate = "file://%s"
+            WebSocketTLSCertificateKey = "file://%s"`,
+			suite, public, private, address, listenAddr,
+			description, certFile.Name(), keyFile.Name()),
+		fmt.Sprintf(`Suite = "%s"
+            Public = "%s"
+            Private = "%s"
+            Address = "%s"
+            ListenAddress = "%s"
+            Description = "%s"
+            WebSocketTLSCertificate = "%s"
+            WebSocketTLSCertificateKey = "%s"`,
+			suite, public, private, address, listenAddr,
+			description, certFile.Name(), keyFile.Name()),
+	}
+
+	for _, privateInfo := range privateInfos {
+		privateToml, err := ioutil.TempFile("", "temp_private.toml")
+		require.Nil(t, err)
+
+		privateToml.WriteString(privateInfo)
+		privateToml.Close()
+
+		cothConfig, srv, err := ParseCothority(privateToml.Name())
+		require.Nil(t, err)
+
+		// Check basic information
+		require.Equal(t, suite, cothConfig.Suite)
+		require.Equal(t, public, cothConfig.Public)
+		require.Equal(t, private, cothConfig.Private)
+		require.Equal(t, address, cothConfig.Address.String())
+		require.Equal(t, listenAddr, cothConfig.ListenAddress)
+		require.Equal(t, description, cothConfig.Description)
+
+		// Check content of certificate and key
+		certContent, err := cothConfig.WebSocketTLSCertificate.Content()
+		require.Nil(t, err)
+		require.Equal(t, wsTLSCert, string(certContent))
+
+		keyContent, err := cothConfig.WebSocketTLSCertificateKey.Content()
+		require.Nil(t, err)
+		require.Equal(t, wsTLSCertKey, string(keyContent))
+
+		srv.Close()
 	}
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+    "os"
 	"strings"
 	"testing"
 
@@ -130,13 +131,21 @@ qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
 f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
 -----END RSA PRIVATE KEY-----`
 
-	// Write files containing cert and key
+	// Write files containing cert and key (+ be sure to delete them at the end)
 	certFile, err := ioutil.TempFile("", "temp_cert.pem")
+    defer func() {
+        err := os.Remove(certFile.Name())
+        require.Nil(t, err)
+    }()
 	require.Nil(t, err)
 	certFile.WriteString(wsTLSCert)
 	certFile.Close()
 
 	keyFile, err := ioutil.TempFile("", "temp_key.pem")
+    defer func() {
+        err := os.Remove(keyFile.Name())
+        require.Nil(t, err)
+    }()
 	require.Nil(t, err)
 	keyFile.WriteString(wsTLSCertKey)
 	keyFile.Close()
@@ -203,5 +212,8 @@ f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
 		require.Equal(t, wsTLSCertKey, string(keyContent))
 
 		srv.Close()
+
+        err = os.Remove(privateToml.Name())
+        require.Nil(t, err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dedis/kyber"
+	"github.com/dedis/onet/app"
 	"github.com/dedis/onet/cfgpath"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -184,6 +185,10 @@ func (c *Server) GetService(name string) Service {
 // It returns the ID of the protocol.
 func (c *Server) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID, error) {
 	return c.protocols.Register(name, protocol)
+}
+
+func (c *Server) SetWebsocketSSL(SSLCertificate app.PEM, SSLKey app.PEM) error {
+	return server.websocket.SetSSL(SSLCertificate, SSLKey)
 }
 
 // protocolInstantiate instantiate a protocol from its ID

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/dedis/kyber"
-	"github.com/dedis/onet/app"
 	"github.com/dedis/onet/cfgpath"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -187,8 +186,9 @@ func (c *Server) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID
 	return c.protocols.Register(name, protocol)
 }
 
-func (c *Server) SetWebsocketSSL(SSLCertificate app.PEM, SSLKey app.PEM) error {
-	return server.websocket.SetSSL(SSLCertificate, SSLKey)
+// SetWebsocketTLS sets the TLS configuration for its websocket.
+func (c *Server) SetWebsocketTLS(tlsCertificate []byte, tlsCertificateKey []byte) error {
+	return c.websocket.SetTLS(tlsCertificate, tlsCertificateKey)
 }
 
 // protocolInstantiate instantiate a protocol from its ID

--- a/server.go
+++ b/server.go
@@ -35,7 +35,7 @@ type Server struct {
 	// instance of it
 	protocols *protocolStorage
 	// webservice
-	websocket *WebSocket
+	WebSocket *WebSocket
 	// when this node has been started
 	started time.Time
 
@@ -71,7 +71,7 @@ func newServer(s network.Suite, dbPath string, r *network.Router, pkey kyber.Sca
 		suite:                s,
 	}
 	c.overlay = NewOverlay(c)
-	c.websocket = NewWebSocket(r.ServerIdentity)
+	c.WebSocket = NewWebSocket(r.ServerIdentity)
 	c.serviceManager = newServiceManager(c, c.overlay, dbPath, delDb)
 	c.statusReporterStruct.RegisterStatusReporter("Generic", c)
 	for name, inst := range protocols.instantiators {
@@ -153,7 +153,7 @@ func (c *Server) GetStatus() *Status {
 // Close closes the overlay and the Router
 func (c *Server) Close() error {
 	c.overlay.stop()
-	c.websocket.stop()
+	c.WebSocket.stop()
 	c.overlay.Close()
 	err := c.serviceManager.closeDatabase()
 	if err != nil {
@@ -186,11 +186,6 @@ func (c *Server) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID
 	return c.protocols.Register(name, protocol)
 }
 
-// SetWebsocketTLS sets the TLS configuration for its websocket.
-func (c *Server) SetWebsocketTLS(tlsCertificate []byte, tlsCertificateKey []byte) error {
-	return c.websocket.SetTLS(tlsCertificate, tlsCertificateKey)
-}
-
 // protocolInstantiate instantiate a protocol from its ID
 func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) (ProtocolInstance, error) {
 	fn, ok := c.protocols.instantiators[c.protocols.ProtocolIDToName(protoID)]
@@ -200,7 +195,7 @@ func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) 
 	return fn(tni)
 }
 
-// Start makes the router and the websocket listen on their respective
+// Start makes the router and the WebSocket listen on their respective
 // ports. It blocks until the server is stopped.
 func (c *Server) Start() {
 	InformServerStarted()
@@ -209,5 +204,5 @@ func (c *Server) Start() {
 		c.started.Format("2006-01-02 15:04:05"),
 		c.ServerIdentity.Address, c.ServerIdentity.Public)
 	go c.Router.Start()
-	c.websocket.start()
+	c.WebSocket.start()
 }

--- a/service.go
+++ b/service.go
@@ -252,7 +252,7 @@ func newServiceManager(svr *Server, o *Overlay, dbPath string, delDb bool) *serv
 		}
 		log.Lvl3("Started Service", name)
 		services[id] = s
-		svr.websocket.registerService(name, s)
+		svr.WebSocket.registerService(name, s)
 	}
 	log.Lvl3(svr.Address(), "instantiated all services")
 	svr.statusReporterStruct.RegisterStatusReporter("Db", s)

--- a/status_test.go
+++ b/status_test.go
@@ -3,6 +3,7 @@ package onet
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"strconv"
 
@@ -24,6 +25,11 @@ func TestStatusHost(t *testing.T) {
 	defer l.CloseAll()
 
 	c := newTCPServer(tSuite, 0, l.path)
+	go c.Start()
+	for !c.Listening() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	defer c.Close()
 	stats := c.GetStatus()
 	a := ServiceFactory.RegisteredServiceNames()

--- a/websocket.go
+++ b/websocket.go
@@ -92,7 +92,7 @@ func (w *WebSocket) SetTLS(tlsCertificate []byte, tlsCertificateKey []byte) erro
 	w.Lock()
 	defer w.Unlock()
 	if w.started {
-		return fmt.Errorf("Cannot set SSL for websocket when it has already been started.")
+		return fmt.Errorf("Cannot set SSL for websocket when it has already been started")
 	}
 	cert, err := tls.X509KeyPair(tlsCertificate, tlsCertificateKey)
 	if err != nil {
@@ -293,11 +293,11 @@ func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]b
 		} else {
 			wsProtocol = "ws"
 		}
-		serverUrl := fmt.Sprintf("%s://%s/%s/%s", wsProtocol, url, c.service, path)
+		serverURL := fmt.Sprintf("%s://%s/%s/%s", wsProtocol, url, c.service, path)
 		headers := http.Header{"Origin": []string{"http://" + url}}
 		// Re-try to connect in case the websocket is just about to start
 		for a := 0; a < network.MaxRetryConnect; a++ {
-			conn, _, err = d.Dial(serverUrl, headers)
+			conn, _, err = d.Dial(serverURL, headers)
 			if err == nil {
 				break
 			}

--- a/websocket.go
+++ b/websocket.go
@@ -111,11 +111,9 @@ func (w *WebSocket) start() {
 	go func() {
 		// Check if server is configured for TLS
 		if w.server.Server.TLSConfig != nil && len(w.server.Server.TLSConfig.Certificates) >= 1 {
-			err := w.server.ListenAndServeTLS("", "")
-			log.ErrFatal(err)
+			w.server.ListenAndServeTLS("", "")
 		} else {
-			err := w.server.ListenAndServe()
-			log.ErrFatal(err)
+			w.server.ListenAndServe()
 		}
 	}()
 	w.startstop <- true

--- a/websocket.go
+++ b/websocket.go
@@ -114,7 +114,8 @@ func (w *WebSocket) start() {
 			err := w.server.ListenAndServeTLS("", "")
 			log.ErrFatal(err)
 		} else {
-			w.server.ListenAndServe()
+			err := w.server.ListenAndServe()
+			log.ErrFatal(err)
 		}
 	}()
 	w.startstop <- true

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -114,7 +115,16 @@ func getSelfSignedCertificateAndKey() ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	err = os.Remove(certFilePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	key, err := ioutil.ReadFile(keyFilePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = os.Remove(keyFilePath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,12 +1,22 @@
 package onet
 
 import (
-	"net/http"
-	"testing"
-
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
-
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
 	"sync"
+	"testing"
+	"time"
 
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -19,6 +29,123 @@ import (
 
 func init() {
 	RegisterNewService(serviceWebSocket, newServiceWebSocket)
+}
+
+func generateSelfSignedCert() (string, string, error) {
+	var (
+		// Comma-separated hostnames and IPs to generate a certificate for
+		host = "127.0.0.1"
+		// Creation date formatted as Jan 1 15:04:05 2006
+		validFrom = time.Now().Format("Jan 1 15:04:05 2006")
+		// Duration that certificate is valid for
+		validFor = 365 * 24 * time.Hour
+		// ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521
+		ecdsaCurve = "P256"
+	)
+
+	var priv *ecdsa.PrivateKey
+	var err error
+	switch ecdsaCurve {
+	case "P224":
+		priv, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case "P256":
+		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case "P384":
+		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case "P521":
+		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	default:
+		return "", "", fmt.Errorf("Unrecognized elliptic curve: %q", ecdsaCurve)
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	var notBefore time.Time
+	if len(validFrom) == 0 {
+		notBefore = time.Now()
+	} else {
+		notBefore, err = time.Parse("Jan 2 15:04:05 2006", validFrom)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	notAfter := notBefore.Add(validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return "", "", err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"DEDIS EPFL"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	certOut, err := ioutil.TempFile("", "cert.pem")
+	if err != nil {
+		return "", "", err
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+
+	keyOut, err := ioutil.TempFile("", "key.pem")
+	if err != nil {
+		return "", "", err
+	}
+
+	b, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return "", "", err
+	}
+	pemBlockForKey := &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+
+	pem.Encode(keyOut, pemBlockForKey)
+	keyOut.Close()
+
+	return certOut.Name(), keyOut.Name(), nil
+}
+
+func getSelfSignedCertificateAndKey() ([]byte, []byte, error) {
+	certFilePath, keyFilePath, err := generateSelfSignedCert()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := ioutil.ReadFile(certFilePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	key, err := ioutil.ReadFile(keyFilePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, key, nil
 }
 
 func TestNewWebSocket(t *testing.T) {
@@ -34,6 +161,46 @@ func TestNewWebSocket(t *testing.T) {
 	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/WebSocket/SimpleResponse", url),
 		"", "http://something_else")
 	log.ErrFatal(err)
+	req := &SimpleResponse{}
+	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
+	buf, err := protobuf.Encode(req)
+	log.ErrFatal(err)
+	log.ErrFatal(websocket.Message.Send(ws, buf))
+
+	log.Lvl1("Waiting for reply")
+	var rcv []byte
+	log.ErrFatal(websocket.Message.Receive(ws, &rcv))
+	log.Lvlf1("Received reply: %x", rcv)
+	rcvMsg := &SimpleResponse{}
+	log.ErrFatal(protobuf.Decode(rcv, rcvMsg))
+	assert.Equal(t, 1, rcvMsg.Val)
+}
+
+func TestNewWebSocketTLS(t *testing.T) {
+	cert, key, err := getSelfSignedCertificateAndKey()
+	log.ErrFatal(err)
+	CAPool := x509.NewCertPool()
+	CAPool.AppendCertsFromPEM(cert)
+
+	l := NewLocalTest(tSuite)
+	defer l.CloseAll()
+
+	c := newTCPServerWithWebSocketTLS(tSuite, 0, l.path, cert, key)
+	defer c.Close()
+
+	require.Equal(t, len(c.serviceManager.services), len(c.websocket.services))
+	require.NotEmpty(t, c.websocket.services[serviceWebSocket])
+	url, err := getWebAddress(c.ServerIdentity, false)
+	log.ErrFatal(err)
+
+	serverUrl := fmt.Sprintf("wss://%s/WebSocket/SimpleResponse", url)
+	origin := "http://localhost"
+	config, err := websocket.NewConfig(serverUrl, origin)
+	log.ErrFatal(err)
+	config.TlsConfig = &tls.Config{RootCAs: CAPool}
+	ws, err := websocket.DialConfig(config)
+	log.ErrFatal(err)
+
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
 	buf, err := protobuf.Encode(req)
@@ -92,6 +259,43 @@ func TestClient_Send(t *testing.T) {
 	assert.True(t, client.Tx() > client.Rx())
 }
 
+func TestClientTLS_Send(t *testing.T) {
+	cert, key, err := getSelfSignedCertificateAndKey()
+	log.ErrFatal(err)
+	CAPool := x509.NewCertPool()
+	CAPool.AppendCertsFromPEM(cert)
+
+	local := NewTCPTestWithTLS(tSuite, cert, key)
+	defer local.CloseAll()
+
+	// register service
+	RegisterNewService(backForthServiceName, func(c *Context) (Service, error) {
+		return &simpleService{
+			ctx: c,
+		}, nil
+	})
+	defer ServiceFactory.Unregister(backForthServiceName)
+
+	// create servers
+	servers, el, _ := local.GenTree(4, false)
+	client := local.NewClient(backForthServiceName)
+	client.tls = true
+	client.trustedCertificates = CAPool
+
+	r := &SimpleRequest{
+		ServerIdentities: el,
+		Val:              10,
+	}
+	sr := &SimpleResponse{}
+	assert.Equal(t, uint64(0), client.Rx())
+	assert.Equal(t, uint64(0), client.Tx())
+	log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+	assert.Equal(t, sr.Val, 10)
+	assert.NotEqual(t, uint64(0), client.Rx())
+	assert.NotEqual(t, uint64(0), client.Tx())
+	assert.True(t, client.Tx() > client.Rx())
+}
+
 func TestClient_Parallel(t *testing.T) {
 	nbrNodes := 4
 	nbrParallel := 20
@@ -119,6 +323,50 @@ func TestClient_Parallel(t *testing.T) {
 				Val:              10 * i,
 			}
 			client := local.NewClient(backForthServiceName)
+			sr := &SimpleResponse{}
+			log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+			assert.Equal(t, 10*i, sr.Val)
+			log.Lvl1("Done with message", i)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestClientTLS_Parallel(t *testing.T) {
+	cert, key, err := getSelfSignedCertificateAndKey()
+	log.ErrFatal(err)
+	CAPool := x509.NewCertPool()
+	CAPool.AppendCertsFromPEM(cert)
+
+	nbrNodes := 4
+	nbrParallel := 20
+	local := NewTCPTestWithTLS(tSuite, cert, key)
+	defer local.CloseAll()
+
+	// register service
+	RegisterNewService(backForthServiceName, func(c *Context) (Service, error) {
+		return &simpleService{
+			ctx: c,
+		}, nil
+	})
+	defer ServiceFactory.Unregister(backForthServiceName)
+
+	// create servers
+	servers, el, _ := local.GenTree(nbrNodes, true)
+
+	wg := sync.WaitGroup{}
+	wg.Add(nbrParallel)
+	for i := 0; i < nbrParallel; i++ {
+		go func(i int) {
+			log.Lvl1("Starting message", i)
+			r := &SimpleRequest{
+				ServerIdentities: el,
+				Val:              10 * i,
+			}
+			client := local.NewClient(backForthServiceName)
+			client.tls = true
+			client.trustedCertificates = CAPool
 			sr := &SimpleResponse{}
 			log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
 			assert.Equal(t, 10*i, sr.Val)
@@ -158,6 +406,37 @@ func TestMultiplePath(t *testing.T) {
 	require.Equal(t, path2, string(resp))
 }
 
+func TestMultiplePathTLS(t *testing.T) {
+	cert, key, err := getSelfSignedCertificateAndKey()
+	log.ErrFatal(err)
+	CAPool := x509.NewCertPool()
+	CAPool.AppendCertsFromPEM(cert)
+
+	_, err = RegisterNewService(dummyService3Name, func(c *Context) (Service, error) {
+		ds := &DummyService3{}
+		return ds, nil
+	})
+	log.ErrFatal(err)
+	defer UnregisterService(dummyService3Name)
+
+	local := NewTCPTestWithTLS(tSuite, cert, key)
+	hs := local.GenServers(2)
+	server := hs[0]
+	defer local.CloseAll()
+	client := NewClientKeep(tSuite, dummyService3Name)
+	client.tls = true
+	client.trustedCertificates = CAPool
+	msg, err := protobuf.Encode(&DummyMsg{})
+	require.Nil(t, err)
+	path1, path2 := "path1", "path2"
+	resp, err := client.Send(server.ServerIdentity, path1, msg)
+	require.Nil(t, err)
+	require.Equal(t, path1, string(resp))
+	resp, err = client.Send(server.ServerIdentity, path2, msg)
+	require.Nil(t, err)
+	require.Equal(t, path2, string(resp))
+}
+
 func TestWebSocket_Error(t *testing.T) {
 	client := NewClientKeep(tSuite, dummyService3Name)
 	local := NewTCPTest(tSuite)
@@ -167,6 +446,27 @@ func TestWebSocket_Error(t *testing.T) {
 
 	log.OutputToBuf()
 	_, err := client.Send(server.ServerIdentity, "test", nil)
+	log.OutputToOs()
+	require.NotEqual(t, "websocket: bad handshake", err.Error())
+	assert.NotEqual(t, "", log.GetStdOut())
+}
+
+func TestWebSocketTLS_Error(t *testing.T) {
+	cert, key, err := getSelfSignedCertificateAndKey()
+	log.ErrFatal(err)
+	CAPool := x509.NewCertPool()
+	CAPool.AppendCertsFromPEM(cert)
+
+	client := NewClientKeep(tSuite, dummyService3Name)
+	client.tls = true
+	client.trustedCertificates = CAPool
+	local := NewTCPTestWithTLS(tSuite, cert, key)
+	hs := local.GenServers(2)
+	server := hs[0]
+	defer local.CloseAll()
+
+	log.OutputToBuf()
+	_, err = client.Send(server.ServerIdentity, "test", nil)
 	log.OutputToOs()
 	require.NotEqual(t, "websocket: bad handshake", err.Error())
 	assert.NotEqual(t, "", log.GetStdOut())

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -157,28 +157,28 @@ func TestNewWebSocket(t *testing.T) {
 	require.Equal(t, len(c.serviceManager.services), len(c.websocket.services))
 	require.NotEmpty(t, c.websocket.services[serviceWebSocket])
 	url, err := getWebAddress(c.ServerIdentity, false)
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/WebSocket/SimpleResponse", url),
 		"", "http://something_else")
 	log.ErrFatal(err)
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
 	buf, err := protobuf.Encode(req)
-	log.ErrFatal(err)
-	log.ErrFatal(websocket.Message.Send(ws, buf))
+	require.Nil(t, err)
+	require.Nil(t, websocket.Message.Send(ws, buf))
 
 	log.Lvl1("Waiting for reply")
 	var rcv []byte
-	log.ErrFatal(websocket.Message.Receive(ws, &rcv))
+	require.Nil(t, websocket.Message.Receive(ws, &rcv))
 	log.Lvlf1("Received reply: %x", rcv)
 	rcvMsg := &SimpleResponse{}
-	log.ErrFatal(protobuf.Decode(rcv, rcvMsg))
+	require.Nil(t, protobuf.Decode(rcv, rcvMsg))
 	assert.Equal(t, 1, rcvMsg.Val)
 }
 
 func TestNewWebSocketTLS(t *testing.T) {
 	cert, key, err := getSelfSignedCertificateAndKey()
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	CAPool := x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(cert)
 
@@ -191,28 +191,28 @@ func TestNewWebSocketTLS(t *testing.T) {
 	require.Equal(t, len(c.serviceManager.services), len(c.websocket.services))
 	require.NotEmpty(t, c.websocket.services[serviceWebSocket])
 	url, err := getWebAddress(c.ServerIdentity, false)
-	log.ErrFatal(err)
+	require.Nil(t, err)
 
-	serverUrl := fmt.Sprintf("wss://%s/WebSocket/SimpleResponse", url)
+	serverURL := fmt.Sprintf("wss://%s/WebSocket/SimpleResponse", url)
 	origin := "http://localhost"
-	config, err := websocket.NewConfig(serverUrl, origin)
-	log.ErrFatal(err)
+	config, err := websocket.NewConfig(serverURL, origin)
+	require.Nil(t, err)
 	config.TlsConfig = &tls.Config{RootCAs: CAPool}
 	ws, err := websocket.DialConfig(config)
-	log.ErrFatal(err)
+	require.Nil(t, err)
 
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
 	buf, err := protobuf.Encode(req)
-	log.ErrFatal(err)
-	log.ErrFatal(websocket.Message.Send(ws, buf))
+	require.Nil(t, err)
+	require.Nil(t, websocket.Message.Send(ws, buf))
 
 	log.Lvl1("Waiting for reply")
 	var rcv []byte
-	log.ErrFatal(websocket.Message.Receive(ws, &rcv))
+	require.Nil(t, websocket.Message.Receive(ws, &rcv))
 	log.Lvlf1("Received reply: %x", rcv)
 	rcvMsg := &SimpleResponse{}
-	log.ErrFatal(protobuf.Decode(rcv, rcvMsg))
+	require.Nil(t, protobuf.Decode(rcv, rcvMsg))
 	assert.Equal(t, 1, rcvMsg.Val)
 }
 
@@ -222,10 +222,10 @@ func TestGetWebHost(t *testing.T) {
 	url, err = getWebAddress(&network.ServerIdentity{Address: "tcp://8.8.8.8"}, false)
 	require.NotNil(t, err)
 	url, err = getWebAddress(&network.ServerIdentity{Address: "tcp://8.8.8.8:7770"}, true)
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	require.Equal(t, "0.0.0.0:7771", url)
 	url, err = getWebAddress(&network.ServerIdentity{Address: "tcp://8.8.8.8:7770"}, false)
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	require.Equal(t, "8.8.8.8:7771", url)
 }
 
@@ -252,7 +252,7 @@ func TestClient_Send(t *testing.T) {
 	sr := &SimpleResponse{}
 	assert.Equal(t, uint64(0), client.Rx())
 	assert.Equal(t, uint64(0), client.Tx())
-	log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+	require.Nil(t, client.SendProtobuf(servers[0].ServerIdentity, r, sr))
 	assert.Equal(t, sr.Val, 10)
 	assert.NotEqual(t, uint64(0), client.Rx())
 	assert.NotEqual(t, uint64(0), client.Tx())
@@ -261,7 +261,7 @@ func TestClient_Send(t *testing.T) {
 
 func TestClientTLS_Send(t *testing.T) {
 	cert, key, err := getSelfSignedCertificateAndKey()
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	CAPool := x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(cert)
 
@@ -289,7 +289,7 @@ func TestClientTLS_Send(t *testing.T) {
 	sr := &SimpleResponse{}
 	assert.Equal(t, uint64(0), client.Rx())
 	assert.Equal(t, uint64(0), client.Tx())
-	log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+	require.Nil(t, client.SendProtobuf(servers[0].ServerIdentity, r, sr))
 	assert.Equal(t, sr.Val, 10)
 	assert.NotEqual(t, uint64(0), client.Rx())
 	assert.NotEqual(t, uint64(0), client.Tx())
@@ -324,7 +324,7 @@ func TestClient_Parallel(t *testing.T) {
 			}
 			client := local.NewClient(backForthServiceName)
 			sr := &SimpleResponse{}
-			log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+			require.Nil(t, client.SendProtobuf(servers[0].ServerIdentity, r, sr))
 			assert.Equal(t, 10*i, sr.Val)
 			log.Lvl1("Done with message", i)
 			wg.Done()
@@ -335,7 +335,7 @@ func TestClient_Parallel(t *testing.T) {
 
 func TestClientTLS_Parallel(t *testing.T) {
 	cert, key, err := getSelfSignedCertificateAndKey()
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	CAPool := x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(cert)
 
@@ -368,7 +368,7 @@ func TestClientTLS_Parallel(t *testing.T) {
 			client.tls = true
 			client.trustedCertificates = CAPool
 			sr := &SimpleResponse{}
-			log.ErrFatal(client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+			require.Nil(t, client.SendProtobuf(servers[0].ServerIdentity, r, sr))
 			assert.Equal(t, 10*i, sr.Val)
 			log.Lvl1("Done with message", i)
 			wg.Done()
@@ -387,7 +387,7 @@ func TestMultiplePath(t *testing.T) {
 		ds := &DummyService3{}
 		return ds, nil
 	})
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	defer UnregisterService(dummyService3Name)
 
 	local := NewTCPTest(tSuite)
@@ -408,7 +408,7 @@ func TestMultiplePath(t *testing.T) {
 
 func TestMultiplePathTLS(t *testing.T) {
 	cert, key, err := getSelfSignedCertificateAndKey()
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	CAPool := x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(cert)
 
@@ -416,7 +416,7 @@ func TestMultiplePathTLS(t *testing.T) {
 		ds := &DummyService3{}
 		return ds, nil
 	})
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	defer UnregisterService(dummyService3Name)
 
 	local := NewTCPTestWithTLS(tSuite, cert, key)
@@ -453,7 +453,7 @@ func TestWebSocket_Error(t *testing.T) {
 
 func TestWebSocketTLS_Error(t *testing.T) {
 	cert, key, err := getSelfSignedCertificateAndKey()
-	log.ErrFatal(err)
+	require.Nil(t, err)
 	CAPool := x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(cert)
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -31,6 +31,7 @@ func init() {
 	RegisterNewService(serviceWebSocket, newServiceWebSocket)
 }
 
+// Adapted from 'https://golang.org/src/crypto/tls/generate_cert.go'
 func generateSelfSignedCert() (string, string, error) {
 	var (
 		// Comma-separated hostnames and IPs to generate a certificate for


### PR DESCRIPTION
- Added 2 fields in `private.toml` for setting the WebSocket TLS certificate and key, if wanted.
- `WebSocket` is now using `ListenAndServeTLS` using the TLS configuration found in the `private.toml` if given.
- `Client` (in `websocket.go`) can now communicate in TLS, if asked.

In the `private.toml` file, we can set the 2 WebSocket TLS fields using 2 different ways:
- `string://{THE CONTENT OF THE CERTIFICATE}`
- `file://{THE PATH OF THE FILE CONTAINING THE CERTIFICATE}`

Fixes #383 
