### PR TITLE
Do not let a panic is NewProtocol take down entire server

### DIFF
--- a/server.go
+++ b/server.go
@@ -204,8 +204,5 @@ func (c *Server) Start() {
 		c.started.Format("2006-01-02 15:04:05"),
 		c.ServerIdentity.Address, c.ServerIdentity.Public)
 	go c.Router.Start()
-	log.Lvlf1("Started server at %s on address %s with public key %s",
-		c.started.Format("2006-01-02 15:04:05"),
-		c.ServerIdentity.Address, c.ServerIdentity.Public)
 	c.websocket.start()
 }

--- a/websocket.go
+++ b/websocket.go
@@ -280,6 +280,7 @@ func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]b
 		return nil, err
 	}
 	c.tx += uint64(len(buf))
+
 	_, rcv, err := conn.ReadMessage()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Catch panics coming from services so that one service cannot
crash the whole server.

Fixes #409.