### PR TITLE
pass tests with DEBUG_TIME=true

### DIFF
--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func TestTime(t *testing.T) {
+	SetShowTime(false)
 	SetDebugVisible(1)
 	GetStdOut()
 	Lvl1("No time")

--- a/processor_test.go
+++ b/processor_test.go
@@ -87,9 +87,12 @@ func TestServiceProcessor_ProcessClientRequest(t *testing.T) {
 	// Test non-existing endpoint
 	buf, err = protobuf.Encode(&testMsg2{42})
 	log.ErrFatal(err)
+	lvl := log.DebugVisible()
+	log.SetDebugVisible(0)
 	log.OutputToBuf()
 	_, err = p.ProcessClientRequest(nil, "testMsgNotAvailable", buf)
 	log.OutputToOs()
+	log.SetDebugVisible(lvl)
 	assert.NotNil(t, err)
 	assert.NotEqual(t, "", log.GetStdOut())
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -448,9 +448,12 @@ func TestWebSocket_Error(t *testing.T) {
 	server := hs[0]
 	defer local.CloseAll()
 
+	lvl := log.DebugVisible()
+	log.SetDebugVisible(0)
 	log.OutputToBuf()
 	_, err := client.Send(server.ServerIdentity, "test", nil)
 	log.OutputToOs()
+	log.SetDebugVisible(lvl)
 	require.NotEqual(t, "websocket: bad handshake", err.Error())
 	require.NotEqual(t, "", log.GetStdOut())
 }
@@ -470,9 +473,12 @@ func TestWebSocketTLS_Error(t *testing.T) {
 	server := hs[0]
 	defer local.CloseAll()
 
+	lvl := log.DebugVisible()
+	log.SetDebugVisible(0)
 	log.OutputToBuf()
 	_, err = client.Send(server.ServerIdentity, "test", nil)
 	log.OutputToOs()
+	log.SetDebugVisible(lvl)
 	require.NotEqual(t, "websocket: bad handshake", err.Error())
 	require.NotEqual(t, "", log.GetStdOut())
 }


### PR DESCRIPTION
Make log-tests pass also with new coveralls.sh that uses `DEBUG_TIME=true`