### PR TITLE
Comparing ServerIdentityID when checking if sending package to ourself.

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -168,7 +168,7 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 	}
 
 	// If sending to ourself, directly dispatch it
-	if e.Address == r.address {
+	if e.ID == r.ServerIdentity.ID {
 		log.Lvlf4("Sending to ourself (%s) msg: %+v", e, msg)
 		packet := &Envelope{
 			ServerIdentity: e,

--- a/network/router.go
+++ b/network/router.go
@@ -168,7 +168,7 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 	}
 
 	// If sending to ourself, directly dispatch it
-	if e.ID == r.ServerIdentity.ID {
+	if e.ID.Equal(r.ServerIdentity.ID) {
 		log.Lvlf4("Sending to ourself (%s) msg: %+v", e, msg)
 		packet := &Envelope{
 			ServerIdentity: e,


### PR DESCRIPTION
Comparing addresses can lead to issues due to canonicalisation. Comparing `ServerIdentity`'s ID to know if we are sending a message to ourself is thus better.

Fixes #423 