### PR TITLE
Waiting on processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ include $(shell go env GOPATH)/src/github.com/dedis/Coding/bin/Makefile.base
 # for more than once in Travis. Change `make test` in .travis.yml
 # to `make test_playground`.
 test_playground:
-	cd network; \
 	for a in $$( seq 100 ); do \
-	  go test -v -race -run ParallelStore || exit 1 ; \
+	  if DEBUG_TIME=true go test -v -race -short > log.txt 2>&1; then \
+		  echo Successfully ran at $$(date); \
+		else \
+		  echo Failed at $$(date); \
+			cat log.txt; \
+			exit 1; \
+		fi; \
 	done;

--- a/local_test.go
+++ b/local_test.go
@@ -2,6 +2,7 @@ package onet
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dedis/kyber/suites"
 	"github.com/dedis/onet/log"
@@ -13,8 +14,12 @@ var tSuite = suites.MustFind("Ed25519")
 
 const clientServiceName = "ClientService"
 
+var clientServiceID ServiceID
+
 func init() {
-	RegisterNewService(clientServiceName, newClientService)
+	var err error
+	clientServiceID, err = RegisterNewService(clientServiceName, newClientService)
+	log.ErrFatal(err)
 }
 
 func Test_panicClose(t *testing.T) {
@@ -46,12 +51,37 @@ func TestNewTCPTest(t *testing.T) {
 	log.ErrFatal(err)
 }
 
+func TestWaitDone(t *testing.T) {
+	l := NewTCPTest(tSuite)
+	servers, ro, _ := l.GenTree(1, true)
+	defer l.CloseAll()
+
+	services := l.GetServices(servers, clientServiceID)
+	service := services[0].(*clientService)
+	require.Nil(t, service.SendRaw(ro.List[0], &RawMessage{}))
+	<-service.click
+	select {
+	case <-service.click:
+		log.Fatal("service is already done")
+	default:
+	}
+	require.Nil(t, l.WaitDone(5*time.Second))
+	select {
+	case <-service.click:
+	default:
+		log.Fatal("service should be done by now")
+	}
+}
+
 type clientService struct {
 	*ServiceProcessor
-	cl *Client
+	cl    *Client
+	click chan bool
 }
 
 type SimpleMessage2 struct{}
+
+type RawMessage struct{}
 
 func (c *clientService) SimpleMessage(msg *SimpleMessage) (network.Message, error) {
 	log.Lvl3("Got request", msg)
@@ -68,7 +98,14 @@ func newClientService(c *Context) (Service, error) {
 	s := &clientService{
 		ServiceProcessor: NewServiceProcessor(c),
 		cl:               NewClient(c.server.Suite(), clientServiceName),
+		click:            make(chan bool, 1),
 	}
 	log.ErrFatal(s.RegisterHandlers(s.SimpleMessage, s.SimpleMessage2))
+	s.RegisterProcessorFunc(network.RegisterMessage(RawMessage{}), func(arg1 *network.Envelope) {
+		s.click <- true
+		time.Sleep(100 * time.Millisecond)
+		s.click <- true
+	})
+
 	return s, nil
 }

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -367,8 +367,9 @@ func testRouterLotsOfConn(t *testing.T, fac routerFactory, nbrRouter int) {
 			}
 			go r.Start()
 			for !r.Listening() {
-				time.Sleep(20 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond)
 			}
+
 			routers[j] = r
 			// expect nbrRouter - 1 messages
 			proc := newNSquareProc(t, r, nbrRouter-1, &wg2)

--- a/overlay.go
+++ b/overlay.go
@@ -721,7 +721,9 @@ func newTreeNodeCache() *treeNodeCache {
 }
 
 func (tnc *treeNodeCache) stop() {
-	tnc.stopOnce.Do(func() { close(tnc.stopCh) })
+	tnc.stopOnce.Do(func() {
+		close(tnc.stopCh)
+	})
 }
 
 func (tnc *treeNodeCache) cleaner() {

--- a/simul/monitor/tcpproxy.go
+++ b/simul/monitor/tcpproxy.go
@@ -85,7 +85,6 @@ func (tp *TCPProxy) Run() error {
 	for _, ep := range tp.Endpoints {
 		eps = append(eps, fmt.Sprintf("%s:%d", ep.Target, ep.Port))
 	}
-	log.Printf("ready to proxy client requests to %+v", eps)
 
 	go tp.runMonitor()
 	for {
@@ -206,7 +205,7 @@ func (tp *TCPProxy) runMonitor() {
 					if err := r.tryReactivate(); err != nil {
 						log.Warn("failed to activate endpoint [%s] due to %v (stay inactive for another %v)", r.addr, err, tp.MonitorInterval)
 					} else {
-						log.Printf("activated %s", r.addr)
+						log.Infof("activated %s", r.addr)
 					}
 				}(rem)
 			}

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dedis/onet/log"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimulationBF(t *testing.T) {
@@ -54,9 +55,7 @@ func TestSimulationBigTree(t *testing.T) {
 	}
 	for i := uint(4); i < 8; i++ {
 		_, _, err := createBFTree(1<<i-1, 2, false, []string{"test1", "test2"})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 	}
 }
 

--- a/status_test.go
+++ b/status_test.go
@@ -3,7 +3,6 @@ package onet
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"strconv"
 
@@ -25,10 +24,7 @@ func TestStatusHost(t *testing.T) {
 	defer l.CloseAll()
 
 	c := newTCPServer(tSuite, 0, l.path)
-	go c.Start()
-	for !c.Listening() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	c.Start()
 
 	defer c.Close()
 	stats := c.GetStatus()

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -22,7 +21,6 @@ import (
 	"github.com/dedis/onet/network"
 	"github.com/dedis/protobuf"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/websocket"
 	"gopkg.in/satori/go.uuid.v1"
 )
 
@@ -137,28 +135,19 @@ func TestNewWebSocket(t *testing.T) {
 	defer l.CloseAll()
 
 	c := newTCPServer(tSuite, 0, l.path)
-	go c.Start()
-	for !c.Listening() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	c.Start()
 
 	defer c.Close()
 	require.Equal(t, len(c.serviceManager.services), len(c.WebSocket.services))
 	require.NotEmpty(t, c.WebSocket.services[serviceWebSocket])
-	url, err := getWebAddress(c.ServerIdentity, false)
-	require.Nil(t, err)
-	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/WebSocket/SimpleResponse", url),
-		"", "http://something_else")
-	log.ErrFatal(err)
+	cl := NewClientKeep(tSuite, "WebSocket")
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
 	buf, err := protobuf.Encode(req)
 	require.Nil(t, err)
-	require.Nil(t, websocket.Message.Send(ws, buf))
+	rcv, err := cl.Send(c.ServerIdentity, "SimpleResponse", buf)
+	require.Nil(t, err)
 
-	log.Lvl1("Waiting for reply")
-	var rcv []byte
-	require.Nil(t, websocket.Message.Receive(ws, &rcv))
 	log.Lvlf1("Received reply: %x", rcv)
 	rcvMsg := &SimpleResponse{}
 	require.Nil(t, protobuf.Decode(rcv, rcvMsg))
@@ -183,34 +172,19 @@ func TestNewWebSocketTLS(t *testing.T) {
 	c.WebSocket.Lock()
 	c.WebSocket.TLSConfig = &tls.Config{Certificates: []tls.Certificate{certToAdd}}
 	c.WebSocket.Unlock()
-	go c.Start()
-	for !c.Listening() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	c.Start()
 	defer c.Close()
 
 	require.Equal(t, len(c.serviceManager.services), len(c.WebSocket.services))
 	require.NotEmpty(t, c.WebSocket.services[serviceWebSocket])
-	url, err := getWebAddress(c.ServerIdentity, false)
-	require.Nil(t, err)
 
-	serverURL := fmt.Sprintf("wss://%s/WebSocket/SimpleResponse", url)
-	origin := "https://127.0.0.1"
-	config, err := websocket.NewConfig(serverURL, origin)
-	require.Nil(t, err)
-	config.TlsConfig = &tls.Config{RootCAs: CAPool}
-	ws, err := websocket.DialConfig(config)
-	require.Nil(t, err)
-
+	cl := NewClientKeep(tSuite, "WebSocket")
+	cl.TLSClientConfig = &tls.Config{RootCAs: CAPool}
 	req := &SimpleResponse{}
 	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
 	buf, err := protobuf.Encode(req)
 	require.Nil(t, err)
-	require.Nil(t, websocket.Message.Send(ws, buf))
-
-	log.Lvl1("Waiting for reply")
-	var rcv []byte
-	require.Nil(t, websocket.Message.Receive(ws, &rcv))
+	rcv, err := cl.Send(c.ServerIdentity, "SimpleResponse", buf)
 	log.Lvlf1("Received reply: %x", rcv)
 	rcvMsg := &SimpleResponse{}
 	require.Nil(t, protobuf.Decode(rcv, rcvMsg))
@@ -326,7 +300,8 @@ func TestClient_Parallel(t *testing.T) {
 			}
 			client := local.NewClient(backForthServiceName)
 			sr := &SimpleResponse{}
-			require.Nil(t, client.SendProtobuf(servers[0].ServerIdentity, r, sr))
+			err := client.SendProtobuf(servers[0].ServerIdentity, r, sr)
+			require.Nil(t, err)
 			require.Equal(t, 10*i, sr.Val)
 			log.Lvl1("Done with message", i)
 			wg.Done()


### PR DESCRIPTION
During tests, a service might still have 'Process'es running,
when working on messages sent with 'SendRaw'.
This PR allows the 'Local' test to wait for these running
processes and put an error if they take too long.

Also adjusted all tests in onet to work correctly with the
new local-test cleanup verification.

It will break cothority, because some of Cothority's tests
are not correct...

**Please review but don't merge before cothority-patch-PR is not merged**