### PR TITLE
unbreaking server.Start behaviour

### DIFF
--- a/local.go
+++ b/local.go
@@ -201,7 +201,7 @@ func (l *LocalTest) WaitDone(t time.Duration) error {
 		for _, o := range l.Overlays {
 			o.instancesLock.Lock()
 			for si, pi := range o.protocolInstances {
-				log.LLvlf3("Lingering protocol instance: %s: %T", si, pi)
+				log.Lvlf3("Lingering protocol instance: %s: %T", si, pi)
 				ct++
 			}
 			o.instancesLock.Unlock()
@@ -437,7 +437,7 @@ func NewLocalServer(s network.Suite, port int) *Server {
 		panic(err)
 	}
 	h := newServer(s, dir, localRouter, priv)
-	h.Start()
+	h.StartInBackground()
 	return h
 }
 
@@ -483,7 +483,7 @@ func (l *LocalTest) NewServer(s network.Suite, port int) *Server {
 			server.WebSocket.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}}
 			server.WebSocket.Unlock()
 		}
-		server.Start()
+		server.StartInBackground()
 	default:
 		server = l.NewLocalServer(s, port)
 	}
@@ -512,7 +512,7 @@ func (l *LocalTest) NewLocalServer(s network.Suite, port int) *Server {
 		panic(err)
 	}
 	server := newServer(s, l.path, localRouter, priv)
-	server.Start()
+	server.StartInBackground()
 	l.Servers[server.ServerIdentity.ID] = server
 	l.Overlays[server.ServerIdentity.ID] = server.overlay
 	l.Services[server.ServerIdentity.ID] = server.serviceManager.services

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -103,7 +103,7 @@ func TestSimulationMultipleInstances(t *testing.T) {
 func closeAll(scs []*SimulationConfig) {
 	for _, s := range scs {
 		if err := s.Server.Close(); err != nil {
-			log.Error("Error closing host ", s.Server.ServerIdentity)
+			log.Error("Error closing host", s.Server.ServerIdentity, err)
 		}
 
 		for s.Server.Router.Listening() {

--- a/status_test.go
+++ b/status_test.go
@@ -24,7 +24,7 @@ func TestStatusHost(t *testing.T) {
 	defer l.CloseAll()
 
 	c := newTCPServer(tSuite, 0, l.path)
-	c.Start()
+	c.StartInBackground()
 
 	defer c.Close()
 	stats := c.GetStatus()

--- a/websocket.go
+++ b/websocket.go
@@ -39,7 +39,7 @@ type WebSocket struct {
 func NewWebSocket(si *network.ServerIdentity) *WebSocket {
 	w := &WebSocket{
 		services:  make(map[string]Service),
-		startstop: make(chan bool, 1),
+		startstop: make(chan bool),
 	}
 	webHost, err := getWebAddress(si, true)
 	log.ErrFatal(err)
@@ -87,6 +87,14 @@ func NewWebSocket(si *network.ServerIdentity) *WebSocket {
 	return w
 }
 
+// Listening returns true if the server has been started and is
+// listening on the ports for incoming connections.
+func (w *WebSocket) Listening() bool {
+	w.Lock()
+	defer w.Unlock()
+	return w.started
+}
+
 // start listening on the port.
 func (w *WebSocket) start() {
 	w.Lock()
@@ -104,8 +112,8 @@ func (w *WebSocket) start() {
 		}
 	}()
 	<-started
-	w.startstop <- true
 	w.Unlock()
+	w.startstop <- true
 }
 
 // registerService stores a service to the given path. All requests to that

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -135,7 +135,7 @@ func TestNewWebSocket(t *testing.T) {
 	defer l.CloseAll()
 
 	c := newTCPServer(tSuite, 0, l.path)
-	c.Start()
+	c.StartInBackground()
 
 	defer c.Close()
 	require.Equal(t, len(c.serviceManager.services), len(c.WebSocket.services))
@@ -172,7 +172,7 @@ func TestNewWebSocketTLS(t *testing.T) {
 	c.WebSocket.Lock()
 	c.WebSocket.TLSConfig = &tls.Config{Certificates: []tls.Certificate{certToAdd}}
 	c.WebSocket.Unlock()
-	c.Start()
+	c.StartInBackground()
 	defer c.Close()
 
 	require.Equal(t, len(c.serviceManager.services), len(c.WebSocket.services))


### PR DESCRIPTION
server.Start is again blocking, so as not to break existing software.
There are two new methods:
- server.StartReturn calls server.Start in a goroutine and waits for all ports to be listening
- server.WaitStartup loops until the server is completely started up