### PR TITLE
Allow different levels of CloseAll checks

### DIFF
--- a/log/testutil.go
+++ b/log/testutil.go
@@ -23,6 +23,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "(*LocalTest).CloseAll") ||
 			strings.Contains(stack, "created by testing.RunTests") ||
 			strings.Contains(stack, "testing.RunTests(") ||
+			strings.Contains(stack, "testing.(*T).Run(") ||
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "interestingGoroutines") ||

--- a/stable/script
+++ b/stable/script
@@ -4,3 +4,6 @@ DST="$2"
 # Adjust paths in libtest.sh - this will not be done by goimports.
 perl -pi -e "s:github.com/dedis/onet:gopkg.in/dedis/onet.v2:" $DST/app/libtest.sh
 perl -pi -e "s:github.com/dedis/kyber:gopkg.in/dedis/kyber.v2:" $DST/app/libtest.sh
+
+# Make CloseAll behave as before, so we don't break tests depending on onet.v2
+perl -pi -e "s/		Check:.*CheckAll,/		Check:    CheckGoroutines,/" $DST/local.go


### PR DESCRIPTION
This PR allows for three levels of checks:
- 0: no leaky test at all
- 1: only log.AfterTest
- 2: like 1 and test for leaky processors or protocolInstances (default)
