### PR TITLE
parsing RunWait in localhost, mininet and deterlab

### DIFF
--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -346,10 +346,8 @@ func (d *Deterlab) Start(args ...string) error {
 // Wait for the process to finish
 func (d *Deterlab) Wait() error {
 	wait, err := time.ParseDuration(d.RunWait)
-	if err != nil {
-		return err
-	}
-	if wait == 0 {
+	if err != nil || wait == 0 {
+		log.Error("Couldn't parse RunWait - using 600s as default value")
 		wait = 600 * time.Second
 	}
 	if d.started {

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -311,7 +311,7 @@ func (m *MiniNet) Start(args ...string) error {
 func (m *MiniNet) Wait() error {
 	wait, err := time.ParseDuration(m.RunWait)
 	if wait == 0 || err != nil {
-		log.Lvl2("Using standard 10 minutes for RunWait")
+		log.Error("Couldn't parse RunWait - using 600s as default value")
 		wait = 600 * time.Second
 	}
 	if m.started {


### PR DESCRIPTION
Different platforms had different implementations on what to do with `RunWait`. Unified it.