### PR TITLE
correctly panicking when CloseAll is called from defer

### DIFF
--- a/local.go
+++ b/local.go
@@ -240,6 +240,13 @@ func (l *LocalTest) WaitDone(t time.Duration) error {
 // CloseAll closes all the servers.
 func (l *LocalTest) CloseAll() {
 	log.Lvl3("Stopping all")
+	if r := recover(); r != nil {
+		// Make sure that a panic is correctly caught, as CloseAll is most often
+		// called in a `defer` statement, and we don't want to show leaking
+		// go-routines or hanging protocolInstances if a panic occurs.
+		panic(r)
+	}
+
 	InformAllServersStopped()
 	// If the debug-level is 0, we copy all errors to a buffer that
 	// will be discarded at the end.

--- a/local_test.go
+++ b/local_test.go
@@ -28,6 +28,20 @@ func Test_panicClose(t *testing.T) {
 	require.Panics(t, func() { l.genLocalHosts(2) })
 }
 
+func Test_showPanic(t *testing.T) {
+	l := NewLocalTest(tSuite)
+	c := make(chan bool)
+	go func() {
+		<-c
+	}()
+	defer func() {
+		require.NotNil(t, recover())
+		c <- true
+	}()
+	defer l.CloseAll()
+	panic("this should be caught")
+}
+
 func TestGenLocalHost(t *testing.T) {
 	l := NewLocalTest(tSuite)
 	hosts := l.genLocalHosts(2)


### PR DESCRIPTION
I had several instances where the code was panicking, but `defer CloseAll()` overwrote the panic with a `Fatal` about still existing go-routines.

This puts panic at a higher priority than leaking go-routines.