### PR TITLE
Move syslog into Unix-only source code

### DIFF
--- a/log/loggers.go
+++ b/log/loggers.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"fmt"
-	"log/syslog"
 	"os"
 
 	"github.com/daviddengcn/go-colortext"
@@ -108,41 +107,6 @@ func NewFileLogger(lInfo *LoggerInfo, path string) (Logger, error) {
 	return &fileLogger{
 		lInfo: lInfo,
 		file:  file,
-	}, nil
-}
-
-type syslogLogger struct {
-	lInfo  *LoggerInfo
-	writer *syslog.Writer
-}
-
-func (sl *syslogLogger) Log(level int, msg string) {
-	_, err := sl.writer.Write([]byte(msg))
-	if err != nil {
-		panic(err)
-	}
-}
-
-func (sl *syslogLogger) Close() {
-	sl.writer.Close()
-}
-
-func (sl *syslogLogger) GetLoggerInfo() *LoggerInfo {
-	return sl.lInfo
-}
-
-// NewSyslogLogger creates a logger that writes into syslog with
-// the given priority and tag, and is using the given LoggerInfo (without the
-// Logger).
-// It returns the logger.
-func NewSyslogLogger(lInfo *LoggerInfo, priority syslog.Priority, tag string) (Logger, error) {
-	writer, err := syslog.New(priority, tag)
-	if err != nil {
-		return nil, err
-	}
-	return &syslogLogger{
-		lInfo:  lInfo,
-		writer: writer,
 	}, nil
 }
 

--- a/log/syslog.go
+++ b/log/syslog.go
@@ -1,0 +1,40 @@
+// +build freebsd linux darwin
+
+package log
+
+import "log/syslog"
+
+type syslogLogger struct {
+	lInfo  *LoggerInfo
+	writer *syslog.Writer
+}
+
+func (sl *syslogLogger) Log(level int, msg string) {
+	_, err := sl.writer.Write([]byte(msg))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (sl *syslogLogger) Close() {
+	sl.writer.Close()
+}
+
+func (sl *syslogLogger) GetLoggerInfo() *LoggerInfo {
+	return sl.lInfo
+}
+
+// NewSyslogLogger creates a logger that writes into syslog with
+// the given priority and tag, and is using the given LoggerInfo (without the
+// Logger).
+// It returns the logger.
+func NewSyslogLogger(lInfo *LoggerInfo, priority syslog.Priority, tag string) (Logger, error) {
+	writer, err := syslog.New(priority, tag)
+	if err != nil {
+		return nil, err
+	}
+	return &syslogLogger{
+		lInfo:  lInfo,
+		writer: writer,
+	}, nil
+}


### PR DESCRIPTION
Windows does not have syslog, so we need to use build tags to fix the
build.

Fixes dedis/cothority#1326.