### PR TITLE
Adding a TestClose interface

### DIFF
--- a/local.go
+++ b/local.go
@@ -32,6 +32,13 @@ const (
 	CheckAll
 )
 
+// TestClose interface allows a service to clean up for the tests. It will only
+// be called when a test calls `LocalTest.CloseAll()`.
+type TestClose interface {
+	// TestClose can clean up things needed in the service.
+	TestClose()
+}
+
 // LocalTest represents all that is needed for a local test-run
 type LocalTest struct {
 	// A map of ServerIdentity.Id to Servers
@@ -258,6 +265,7 @@ func (l *LocalTest) CloseAll() {
 	}
 
 	InformAllServersStopped()
+
 	// If the debug-level is 0, we copy all errors to a buffer that
 	// will be discarded at the end.
 	if log.DebugVisible() == 0 {

--- a/server.go
+++ b/server.go
@@ -162,6 +162,15 @@ func (c *Server) Close() error {
 		c.IsStarted = false
 	}
 	c.Unlock()
+
+	// For all services that have `TestClose` defined, call it to make
+	// sure they are able to clean up. This should only be used for tests!
+	for _, serv := range c.serviceManager.services {
+		s, ok := serv.(TestClose)
+		if ok {
+			s.TestClose()
+		}
+	}
 	c.overlay.stop()
 	c.WebSocket.stop()
 	c.overlay.Close()

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -151,6 +151,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 			log.Error("The tree doesn't use all ServerIdentities from the list!\n" +
 				"This means that the CloseAll will fail and the experiment never ends!")
 		}
+
 		// Recreate a tree out of the original roster, to be sure all nodes are included and
 		// that the tree is easy to close.
 		closeTree := rootSC.Roster.GenerateBinaryTree()


### PR DESCRIPTION
If a service implements a `TestClose` method, it will be called in `LocalTest.CloseAll()`.