### PR TITLE
Make log.Panic correctly format it's arguments

### DIFF
--- a/log/ui.go
+++ b/log/ui.go
@@ -37,7 +37,14 @@ func Error(args ...interface{}) {
 // Panic prints out the panic message and panics
 func Panic(args ...interface{}) {
 	lvlUI(lvlPanic, args...)
-	panic(args)
+	switch len(args) {
+	case 0:
+		panic("")
+	case 1:
+		panic(args[0])
+	default:
+		panic(fmt.Sprintf(args[0].(string), args[1:]...))
+	}
 }
 
 // Fatal prints out the fatal message and quits

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -32,3 +32,15 @@ func TestLvl(t *testing.T) {
 	Warn("TestLvl")
 	assert.True(t, containsStdErr("W : (                             log.TestLvl:   0) - TestLvl\n"))
 }
+
+func TestPanic(t *testing.T) {
+	assert.PanicsWithValue(t, "", func() {
+		Panic()
+	})
+	assert.PanicsWithValue(t, "the number is 22", func() {
+		Panic("the number is 22")
+	})
+	assert.PanicsWithValue(t, "the number is 1", func() {
+		Panic("the number is %d", 1)
+	})
+}


### PR DESCRIPTION
Before log.Panic was giving unformatted arguments to panic(),
which was useless for debugging. Now it correctly formats the
output and passes one string to panic().

Fixes #430.