### PR TITLE
Non-Integer parameters of simulation not in resulting csv-file #446

### DIFF
--- a/simul/monitor/monitor.go
+++ b/simul/monitor/monitor.go
@@ -34,7 +34,6 @@ const Sink = "0.0.0.0"
 // DefaultSinkPort is the default port where a monitor will listen and a proxy
 // will contact the monitor.
 const DefaultSinkPort = 10000
-
 // Monitor struct is used to collect measures and make the statistics about
 // them. It takes a stats object so it update that in a concurrent-safe manner
 // for each new measure it receives.

--- a/simul/monitor/monitor.go
+++ b/simul/monitor/monitor.go
@@ -34,6 +34,7 @@ const Sink = "0.0.0.0"
 // DefaultSinkPort is the default port where a monitor will listen and a proxy
 // will contact the monitor.
 const DefaultSinkPort = 10000
+
 // Monitor struct is used to collect measures and make the statistics about
 // them. It takes a stats object so it update that in a concurrent-safe manner
 // for each new measure it receives.

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -89,38 +89,39 @@ func setupMonitor(t *testing.T) (*Monitor, *Stats) {
 	return mon, stat
 }
 
-type testStringInput map[string]string // for testing string input  in setupMonitor
-
-//type Pair struct { // this holds pairs of out put mon and stats below
-//	m *Monitor
-
-//	s *Stats
-//}
+type testStringInput map[string]string // holds the string map in setupMonitorStringTest below
 
 // setupMonitorStringTest launches a basic monitor with a created Stats object
 // When finished with the monitor, just call `End()`
-// It mimics the setMonitor above but with interface as ouput. This enables testing multiple
-// string as input
+// It mimics the setMonitor  above but uses int test count to select
+// the map to be used as input.
 func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 
-	var myMapSlice []testStringInput // for storing an array for maps. To be use for testing
+	var myMapSlice []testStringInput // for storing an array for maps.
 
+	// The map data type to be tested. At each call the testcount
+	// variable determines which one is selected
 	m1 := testStringInput{"server1": "crazyStrings"}
 	m2 := testStringInput{"server2": ""}
 	m3 := testStringInput{"server3": "123456789"}
 	m4 := testStringInput{"server4": "crazyString098765432"}
 	m5 := testStringInput{"server5": "456712309crazyString"}
 
+	// Store the maps in an array
 	myMapSlice = append(myMapSlice, m1, m2, m3, m4, m5)
 
+	// If the value of testCount is greater than size of array
+	// then just return the last element in the array of maps
 	if testCount > len(myMapSlice) {
 
 		testCount = len(myMapSlice) - 1
 
 	}
 
+	// select the input to be used. Note the use of testCount as indexs
 	m := myMapSlice[testCount]
 
+	// initialize the stats varaible using the NewStats function
 	stat := NewStats(m)
 
 	// First set up monitor listening
@@ -128,11 +129,10 @@ func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 	go mon.Listen()
 	time.Sleep(100 * time.Millisecond)
 
-	// Then measure
-
+	// k is a  variable to be used in connection
 	k := strconv.Itoa(int(mon.SinkPort))
 
-	err := ConnectSink("localhost:" + k)
+	err := ConnectSink("localhost:" + k) // k is used here, return error if connection error
 	if err != nil {
 		t.Fatal(fmt.Sprintf("Error starting monitor: %s", err))
 	}

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -88,3 +88,57 @@ func setupMonitor(t *testing.T) (*Monitor, *Stats) {
 	}
 	return mon, stat
 }
+
+type testStringInput map[string]string // for testing string input  in setupMonitor
+
+//type Pair struct { // this holds pairs of out put mon and stats below
+//	m *Monitor
+
+//	s *Stats
+//}
+
+// setupMonitorStringTest launches a basic monitor with a created Stats object
+// When finished with the monitor, just call `End()`
+// It mimics the setMonitor above but with interface as ouput. This enables testing multiple
+// string as input
+func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
+
+	var myMapSlice []testStringInput // for storing an array for maps. To be use for testing
+
+	m1 := testStringInput{"server1": "crazyString"}
+	m2 := testStringInput{"server2": ""}
+	m3 := testStringInput{"server3": "123456789"}
+
+	myMapSlice = append(myMapSlice, m1, m2, m3)
+
+	if testCount < len(myMapSlice) {
+
+		testCount = testCount
+
+	} else {
+
+		testCount = len(myMapSlice) - 1
+
+	}
+
+	m := myMapSlice[testCount]
+
+	stat := NewStats(m)
+
+	// First set up monitor listening
+	mon := NewMonitor(stat)
+	go mon.Listen()
+	time.Sleep(100 * time.Millisecond)
+
+	// Then measure
+
+	k := strconv.Itoa(int(mon.SinkPort))
+
+	err := ConnectSink("localhost:" + k)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Error starting monitor: %s", err))
+	}
+
+	return mon, stat
+
+}

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -111,11 +111,7 @@ func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 
 	myMapSlice = append(myMapSlice, m1, m2, m3)
 
-	if testCount < len(myMapSlice) {
-
-		testCount = testCount
-
-	} else {
+	if testCount > len(myMapSlice) {
 
 		testCount = len(myMapSlice) - 1
 

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -105,7 +105,7 @@ func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 
 	var myMapSlice []testStringInput // for storing an array for maps. To be use for testing
 
-	m1 := testStringInput{"server1": "crazyString"}
+	m1 := testStringInput{"server1": "crazyStrings"}
 	m2 := testStringInput{"server2": ""}
 	m3 := testStringInput{"server3": "123456789"}
 

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -108,8 +108,8 @@ func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 	m1 := testStringInput{"server1": "crazyStrings"}
 	m2 := testStringInput{"server2": ""}
 	m3 := testStringInput{"server3": "123456789"}
-	m4 := testStringInput{"server3": "crazyString098765432"}
-	m5 := testStringInput{"server3": "456712309crazyString"}
+	m4 := testStringInput{"server4": "crazyString098765432"}
+	m5 := testStringInput{"server5": "456712309crazyString"}
 
 	myMapSlice = append(myMapSlice, m1, m2, m3, m4, m5)
 

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -108,8 +108,10 @@ func setupMonitorStringTest(t *testing.T, testCount int) (*Monitor, *Stats) {
 	m1 := testStringInput{"server1": "crazyStrings"}
 	m2 := testStringInput{"server2": ""}
 	m3 := testStringInput{"server3": "123456789"}
+	m4 := testStringInput{"server3": "crazyString098765432"}
+	m5 := testStringInput{"server3": "456712309crazyString"}
 
-	myMapSlice = append(myMapSlice, m1, m2, m3)
+	myMapSlice = append(myMapSlice, m1, m2, m3, m4, m5)
 
 	if testCount > len(myMapSlice) {
 

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os" // me
 	"regexp"
 	"sort"
 	"strconv"
@@ -108,6 +109,12 @@ func (s *Stats) WriteValues(w io.Writer) {
 		v := s.values[k]
 		values = append(values, v.Values()...)
 	}
+
+	file, _ := os.Create("file.csv") // this is experimental
+	//w := w.NewWriter(f)
+	file.Write([]byte(strings.Join(values, ","))) // experimental: write values to .csv file
+	defer file.Close()
+	fmt.Println(strings.Join(values, ","))
 	fmt.Fprintf(w, "%s", strings.Join(values, ","))
 	fmt.Fprintf(w, "\n")
 }

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -110,11 +110,6 @@ func (s *Stats) WriteValues(w io.Writer) {
 		values = append(values, v.Values()...)
 	}
 
-	//file, _ := os.Create("file.csv") // this is experimental
-	//w := w.NewWriter(f)
-	//file.Write([]byte(strings.Join(values, ","))) // experimental: write values to .csv file
-	//defer file.Close()
-	//fmt.Println(strings.Join(values, ","))
 	fmt.Fprintf(w, "%s", strings.Join(values, ","))
 	fmt.Fprintf(w, "\n")
 }

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -25,7 +25,7 @@ import (
 type Stats struct {
 	// The static fields are created when creating the stats out of a
 	// running config.
-	static     map[string]int
+	static     map[string]string
 	staticKeys []string
 
 	// The received measures we have and the keys ordered
@@ -49,7 +49,7 @@ func NewStats(rc map[string]string, defaults ...string) *Stats {
 func (s *Stats) init() *Stats {
 	s.values = make(map[string]*Value)
 	s.keys = make([]string, 0)
-	s.static = make(map[string]int)
+	s.static = make(map[string]string)
 	s.staticKeys = make([]string, 0)
 	return s
 }
@@ -101,7 +101,7 @@ func (s *Stats) WriteValues(w io.Writer) {
 	var values []string
 	for _, k := range s.staticKeys {
 		if v, ok := s.static[k]; ok {
-			values = append(values, fmt.Sprintf("%d", v))
+			values = append(values, fmt.Sprintf("%v", v))
 		}
 	}
 	// write the values
@@ -145,7 +145,7 @@ func (s *Stats) WriteIndividualStats(w io.Writer) error {
 	var static []string
 	for _, k := range s.staticKeys {
 		if v, ok := s.static[k]; ok {
-			static = append(static, fmt.Sprintf("%d", v))
+			static = append(static, fmt.Sprintf("%v", v))
 		}
 	}
 
@@ -304,7 +304,7 @@ func (s *Stats) String() string {
 	defer s.Unlock()
 	var str string
 	for _, k := range s.staticKeys {
-		str += fmt.Sprintf("%s = %d ", k, s.static[k])
+		str += fmt.Sprintf("%s = %s", k, s.static[k])
 	}
 	for _, v := range s.values {
 		str += fmt.Sprintf("%v ", v.Values())
@@ -320,13 +320,10 @@ func (s *Stats) readRunConfig(rc map[string]string, defaults ...string) {
 		if !ok {
 			log.Fatal("Could not find the default value", def, "in the RunConfig")
 		}
-		if i, err := strconv.Atoi(valStr); err != nil {
-			log.Fatal("Could not parse to integer value", def)
-		} else {
-			// registers the static value
-			s.static[def] = i
-			s.staticKeys = append(s.staticKeys, def)
-		}
+
+		s.static[def] = valStr
+		s.staticKeys = append(s.staticKeys, def)
+
 	}
 	// Then parse the others keys
 	var statics []string
@@ -342,14 +339,10 @@ func (s *Stats) readRunConfig(rc map[string]string, defaults ...string) {
 		if alreadyRegistered {
 			continue
 		}
-		// store it
-		if i, err := strconv.Atoi(v); err != nil {
-			log.Lvl3("Could not parse the value", k, "from runconfig (v=", v, ")")
-			continue
-		} else {
-			s.static[k] = i
-			statics = append(statics, k)
-		}
+
+		s.static[k] = v
+		statics = append(statics, k)
+
 	}
 	// sort them so it's always the same order
 	sort.Strings(statics)

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -114,7 +114,7 @@ func (s *Stats) WriteValues(w io.Writer) {
 	//w := w.NewWriter(f)
 	//file.Write([]byte(strings.Join(values, ","))) // experimental: write values to .csv file
 	//defer file.Close()
-	fmt.Println(strings.Join(values, ","))
+	//fmt.Println(strings.Join(values, ","))
 	fmt.Fprintf(w, "%s", strings.Join(values, ","))
 	fmt.Fprintf(w, "\n")
 }

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os" // me
+	//"os" // me
 	"regexp"
 	"sort"
 	"strconv"
@@ -110,10 +110,10 @@ func (s *Stats) WriteValues(w io.Writer) {
 		values = append(values, v.Values()...)
 	}
 
-	file, _ := os.Create("file.csv") // this is experimental
+	//file, _ := os.Create("file.csv") // this is experimental
 	//w := w.NewWriter(f)
-	file.Write([]byte(strings.Join(values, ","))) // experimental: write values to .csv file
-	defer file.Close()
+	//file.Write([]byte(strings.Join(values, ","))) // experimental: write values to .csv file
+	//defer file.Close()
 	fmt.Println(strings.Join(values, ","))
 	fmt.Fprintf(w, "%s", strings.Join(values, ","))
 	fmt.Fprintf(w, "\n")

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"bytes"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -212,37 +213,44 @@ func TestStatsString(t *testing.T) {
 	}
 }
 
+// this function generates random number for this simulation
+func random(min, max int) int {
+	rand.Seed(time.Now().UTC().UnixNano())
+	return rand.Intn((max-min)+1) + min
+}
+
 func TestStructParsedWithString(t *testing.T) {
-	testRange := [3]int{1, 2, 3}
-	for testCount, _ := range testRange {
-		mon, _ := setupMonitorStringTest(t, testCount)
-		//mon := monStatValues.m
-		dm := &DummyCounterIO{0, 0}
-		// create the counter measure
-		cm := NewCounterIOMeasure("dummy", dm)
-		if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
-			t.Logf("baseRx = %d vs rvalue = %d || baseTx = %d vs wvalue = %d", cm.baseRx, dm.rvalue, cm.baseTx, dm.wvalue)
-			t.Fatal("Tx() / Rx() not working ?")
+	testRange := [5]int{1, 2, 3, 4, 5}
 
-		}
+	rand.Seed(time.Now().UTC().UnixNano())
+	testCount := random(0, len(testRange)-1)
 
-		//bread, bwritten := cm.baseRx, cm.baseTx
-		cm.Record()
-		// check the values again
-		if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
-			t.Fatal("Record() not working for CounterIOMeasure")
-		}
-
-		// Important otherwise data don't get written down to the monitor yet.
-		time.Sleep(100 * time.Millisecond)
-		str := new(bytes.Buffer)
-		stat := mon.stats
-		stat.Collect()
-		stat.WriteHeader(str)
-		stat.WriteValues(str)
-		EndAndCleanup()
-		time.Sleep(120 * time.Millisecond)
+	mon, _ := setupMonitorStringTest(t, testCount)
+	//mon := monStatValues.m
+	dm := &DummyCounterIO{0, 0}
+	// create the counter measure
+	cm := NewCounterIOMeasure("dummy", dm)
+	if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
+		t.Logf("baseRx = %d vs rvalue = %d || baseTx = %d vs wvalue = %d", cm.baseRx, dm.rvalue, cm.baseTx, dm.wvalue)
+		t.Fatal("Tx() / Rx() not working ?")
 
 	}
+
+	//bread, bwritten := cm.baseRx, cm.baseTx
+	cm.Record()
+	// check the values again
+	if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
+		t.Fatal("Record() not working for CounterIOMeasure")
+	}
+
+	// Important otherwise data don't get written down to the monitor yet.
+	time.Sleep(100 * time.Millisecond)
+	str := new(bytes.Buffer)
+	stat := mon.stats
+	stat.Collect()
+	stat.WriteHeader(str)
+	stat.WriteValues(str)
+	EndAndCleanup()
+	time.Sleep(120 * time.Millisecond)
 
 }

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -240,10 +240,10 @@ func TestStructParsedWithString(t *testing.T) {
 		stat.Collect()
 		stat.WriteHeader(str)
 		stat.WriteValues(str)
-		time.Sleep(120 * time.Millisecond)
-		time.Sleep(120 * time.Millisecond)
-		EndAndCleanup()
 
 	}
+
+	EndAndCleanup()
+	time.Sleep(120 * time.Millisecond)
 
 }

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -245,11 +245,11 @@ func StructParsedWithString(t *testing.T, testCount int) *Stats {
 
 	// Important otherwise data don't get written down to the monitor yet.
 	time.Sleep(100 * time.Millisecond)
-	//str := new(bytes.Buffer)
+	str := new(bytes.Buffer)
 	stat := mon.stats
 	stat.Collect()
-	//stat.WriteHeader(str)
-	//stat.WriteValues(str)
+	stat.WriteHeader(str)
+	stat.WriteValues(str)
 	EndAndCleanup()
 	time.Sleep(120 * time.Millisecond)
 	return stat

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -211,3 +211,41 @@ func TestStatsString(t *testing.T) {
 		t.Fatal("The measurement should contain 0.1:", rs.String())
 	}
 }
+
+
+
+func TestStructParsedWithString(t *testing.T) {
+	testRange := [3]int{1, 2, 3}
+	for testCount, _ := range testRange {
+		mon, _ := setupMonitorStringTest(t, testCount)
+		//mon := monStatValues.m
+		dm := &DummyCounterIO{0, 0}
+		// create the counter measure
+		cm := NewCounterIOMeasure("dummy", dm)
+		if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
+			t.Logf("baseRx = %d vs rvalue = %d || baseTx = %d vs wvalue = %d", cm.baseRx, dm.rvalue, cm.baseTx, dm.wvalue)
+			t.Fatal("Tx() / Rx() not working ?")
+
+		}
+
+		//bread, bwritten := cm.baseRx, cm.baseTx
+		cm.Record()
+		// check the values again
+		if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
+			t.Fatal("Record() not working for CounterIOMeasure")
+		}
+
+		// Important otherwise data don't get written down to the monitor yet.
+		time.Sleep(100 * time.Millisecond)
+		str := new(bytes.Buffer)
+		stat := mon.stats
+		stat.Collect()
+		stat.WriteHeader(str)
+		stat.WriteValues(str)
+		time.Sleep(120 * time.Millisecond)
+		time.Sleep(120 * time.Millisecond)
+		EndAndCleanup()
+
+	}
+
+}

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -240,10 +240,9 @@ func TestStructParsedWithString(t *testing.T) {
 		stat.Collect()
 		stat.WriteHeader(str)
 		stat.WriteValues(str)
+		EndAndCleanup()
+		time.Sleep(120 * time.Millisecond)
 
 	}
-
-	EndAndCleanup()
-	time.Sleep(120 * time.Millisecond)
 
 }

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -2,7 +2,6 @@ package monitor
 
 import (
 	"bytes"
-	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -213,17 +212,9 @@ func TestStatsString(t *testing.T) {
 	}
 }
 
-// this function generates random number for this simulation
-func random(min, max int) int {
-	rand.Seed(time.Now().UTC().UnixNano())
-	return rand.Intn((max-min)+1) + min
-}
-
+// setupMonitor launches a basic monitor with a created Stats object
+// When finished with the monitor, just call `End()`.
 func StructParsedWithString(t *testing.T, testCount int) *Stats {
-	//testRange := [5]int{1, 2, 3, 4, 5}
-
-	//rand.Seed(time.Now().UTC().UnixNano())
-	//testCount := random(0, len(testRange)-1)
 
 	mon, _ := setupMonitorStringTest(t, testCount)
 	//mon := monStatValues.m
@@ -235,14 +226,12 @@ func StructParsedWithString(t *testing.T, testCount int) *Stats {
 		t.Fatal("Tx() / Rx() not working ?")
 
 	}
-
 	//bread, bwritten := cm.baseRx, cm.baseTx
 	cm.Record()
 	// check the values again
 	if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
 		t.Fatal("Record() not working for CounterIOMeasure")
 	}
-
 	// Important otherwise data don't get written down to the monitor yet.
 	time.Sleep(100 * time.Millisecond)
 	str := new(bytes.Buffer)
@@ -256,32 +245,42 @@ func StructParsedWithString(t *testing.T, testCount int) *Stats {
 
 }
 
+// TestStructParsedWithString uses StructParsedWithString to test for different
+// cases of string input .
 func TestStructParsedWithString(t *testing.T) {
 
+	// test to be conducted onmultiple strings returned
+	// from stats
 	m1 := StructParsedWithString(t, 0)
 	m2 := StructParsedWithString(t, 1)
 	m3 := StructParsedWithString(t, 2)
 	m4 := StructParsedWithString(t, 3)
 	m5 := StructParsedWithString(t, 4)
 
+	// stats has variable called static which is a map
+	// The key and value of the map is a string
+	// We test the string values here making sure they correspond to the
+	// used in the set up ( in the the monitor_test.go file)
+	// If the string is same and the one returned the test passes
+	// otherwise return an error
 	if m1.static["server1"] != "crazyStrings" {
-		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m1.static["server1"])
+		t.Errorf("The correct string value,  %s , was not  returned", m1.static["server1"])
 	}
 
 	if m2.static["server2"] != "" {
-		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m2.static["server2"])
+		t.Errorf("The correct string value,  %s , was not  returned", m2.static["server2"])
 	}
 
 	if m3.static["server3"] != "123456789" {
-		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m3.static["server3"])
+		t.Errorf("The correct string value,  %s , was not  returned", m3.static["server3"])
 	}
 
 	if m4.static["server4"] != "crazyString098765432" {
-		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m4.static["server4"])
+		t.Errorf("The correct string value,  %s , was not  returned", m4.static["server4"])
 	}
 
 	if m5.static["server5"] != "456712309crazyString" {
-		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m5.static["server5"])
+		t.Errorf("The correct string value,  %s , was not  returned", m5.static["server5"])
 	}
 
 }

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -219,11 +219,11 @@ func random(min, max int) int {
 	return rand.Intn((max-min)+1) + min
 }
 
-func TestStructParsedWithString(t *testing.T) {
-	testRange := [5]int{1, 2, 3, 4, 5}
+func StructParsedWithString(t *testing.T, testCount int) *Stats {
+	//testRange := [5]int{1, 2, 3, 4, 5}
 
-	rand.Seed(time.Now().UTC().UnixNano())
-	testCount := random(0, len(testRange)-1)
+	//rand.Seed(time.Now().UTC().UnixNano())
+	//testCount := random(0, len(testRange)-1)
 
 	mon, _ := setupMonitorStringTest(t, testCount)
 	//mon := monStatValues.m
@@ -245,12 +245,43 @@ func TestStructParsedWithString(t *testing.T) {
 
 	// Important otherwise data don't get written down to the monitor yet.
 	time.Sleep(100 * time.Millisecond)
-	str := new(bytes.Buffer)
+	//str := new(bytes.Buffer)
 	stat := mon.stats
 	stat.Collect()
-	stat.WriteHeader(str)
-	stat.WriteValues(str)
+	//stat.WriteHeader(str)
+	//stat.WriteValues(str)
 	EndAndCleanup()
 	time.Sleep(120 * time.Millisecond)
+	return stat
+
+}
+
+func TestStructParsedWithString(t *testing.T) {
+
+	m1 := StructParsedWithString(t, 0)
+	m2 := StructParsedWithString(t, 1)
+	m3 := StructParsedWithString(t, 2)
+	m4 := StructParsedWithString(t, 3)
+	m5 := StructParsedWithString(t, 4)
+
+	if m1.static["server1"] != "crazyStrings" {
+		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m1.static["server1"])
+	}
+
+	if m2.static["server2"] != "" {
+		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m2.static["server2"])
+	}
+
+	if m3.static["server3"] != "123456789" {
+		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m3.static["server3"])
+	}
+
+	if m4.static["server4"] != "crazyString098765432" {
+		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m4.static["server4"])
+	}
+
+	if m5.static["server5"] != "456712309crazyString" {
+		t.Errorf("correct static string ,  %s , was not  returned or handled  ", m5.static["server5"])
+	}
 
 }

--- a/simul/monitor/stats_test.go
+++ b/simul/monitor/stats_test.go
@@ -212,8 +212,6 @@ func TestStatsString(t *testing.T) {
 	}
 }
 
-
-
 func TestStructParsedWithString(t *testing.T) {
 	testRange := [3]int{1, 2, 3}
 	for testCount, _ := range testRange {


### PR DESCRIPTION
 parameters of the simulation are only added to the resulting csv
 file when they can be parsed into an Integer.

Since other types might be used as well to parameterize a simulation,
 they should also be parsed.

We would like to change the parameters of simulation such that
they are  just  remembered -- instead of being parsed into ints, and
 then are written into the CSV file  as strings.

This is still work in progress
A series of test simulation have been added here. From there solutions can be easily written.
intended to fix #446