### PR TITLE
Do not return error when we use default RunWait

### DIFF
--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -347,10 +347,9 @@ func (d *Deterlab) Start(args ...string) error {
 func (d *Deterlab) Wait() error {
 	wait, err := time.ParseDuration(d.RunWait)
 	if err != nil || wait == 0 {
-		if d.RunWait != "" {
-			log.Error("Couldn't parse RunWait - using 600s as default value")
-		}
+		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
+		err = nil
 	}
 	if d.started {
 		log.Lvl3("Simulation is started")

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -220,10 +220,9 @@ func (d *Localhost) Wait() error {
 
 	wait, err := time.ParseDuration(d.RunWait)
 	if err != nil || wait == 0 {
-		if d.RunWait != "" {
-			log.Error("Couldn't parse RunWait - using 600s as default value")
-		}
+		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
+		err = nil
 	}
 
 	go func() {

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -311,10 +311,9 @@ func (m *MiniNet) Start(args ...string) error {
 func (m *MiniNet) Wait() error {
 	wait, err := time.ParseDuration(m.RunWait)
 	if wait == 0 || err != nil {
-		if m.RunWait != "" {
-			log.Error("Couldn't parse RunWait - using 600s as default value")
-		}
+		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
+		err = nil
 	}
 	if m.started {
 		log.Lvl3("Simulation is started")


### PR DESCRIPTION
If we can't parse RunWait, the code will automatically pick a default
value. Hence, there is no reason to return and propagate the error up
the stack.