### PR TITLE
Adding ip2ip tunnel and cleaning up

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -57,6 +57,8 @@ type Router struct {
 	// This field should only be set during testing. It disables an important
 	// log message meant to discourage TCP connections.
 	UnauthOk bool
+	// Quiets the startup of the server if set to true.
+	Quiet bool
 }
 
 // NewRouter returns a new Router attached to a ServerIdentity and the host we want to
@@ -70,7 +72,6 @@ func NewRouter(own *ServerIdentity, h Host) *Router {
 		connectionErrorHandlers: make([]func(*ServerIdentity), 0),
 	}
 	r.address = h.Address()
-	log.Lvlf1("New router with address %s and public key %s", r.address, r.ServerIdentity.Public)
 	return r
 }
 
@@ -98,6 +99,10 @@ func (r *Router) Unpause() {
 // Start the listening routine of the underlying Host. This is a
 // blocking call until r.Stop() is called.
 func (r *Router) Start() {
+	if !r.Quiet {
+		log.Lvlf1("New router with address %s and public key %s", r.address, r.ServerIdentity.Public)
+	}
+
 	// Any incoming connection waits for the remote server identity
 	// and will create a new handling routine.
 	err := r.host.Listen(func(c Conn) {

--- a/server.go
+++ b/server.go
@@ -219,9 +219,11 @@ func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) 
 func (c *Server) Start() {
 	InformServerStarted()
 	c.started = time.Now()
-	log.Lvlf1("Starting server at %s on address %s with public key %s",
-		c.started.Format("2006-01-02 15:04:05"),
-		c.ServerIdentity.Address, c.ServerIdentity.Public)
+	if !c.Quiet {
+		log.Lvlf1("Starting server at %s on address %s with public key %s",
+			c.started.Format("2006-01-02 15:04:05"),
+			c.ServerIdentity.Address, c.ServerIdentity.Public)
+	}
 	go c.Router.Start()
 	go c.WebSocket.start()
 	for !c.Router.Listening() || !c.WebSocket.Listening() {

--- a/simul/manage/count.go
+++ b/simul/manage/count.go
@@ -74,13 +74,8 @@ func NewCount(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 		timeout:          1 * time.Second,
 	}
 	p.Count = make(chan int, 1)
-	if err := p.RegisterChannel(&p.CountChan); err != nil {
-		log.Error("Couldn't reister channel:", err)
-	}
-	if err := p.RegisterChannel(&p.PrepareCountChan); err != nil {
-		log.Error("Couldn't reister channel:", err)
-	}
-	if err := p.RegisterChannel(&p.NodeIsUpChan); err != nil {
+	if err := p.RegisterChannelsLength(len(n.Tree().List()),
+		&p.CountChan, &p.PrepareCountChan, &p.NodeIsUpChan); err != nil {
 		log.Error("Couldn't reister channel:", err)
 	}
 	return p, nil

--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -347,7 +347,6 @@ func (d *Deterlab) Start(args ...string) error {
 func (d *Deterlab) Wait() error {
 	wait, err := time.ParseDuration(d.RunWait)
 	if err != nil || wait == 0 {
-		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
 		err = nil
 	}

--- a/simul/platform/fd_unix.go
+++ b/simul/platform/fd_unix.go
@@ -1,0 +1,52 @@
+// +build !windows
+
+package platform
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/dedis/onet/log"
+)
+
+// By default in simulation we update the per-process file descriptor limit
+// to the maximal limit.
+func init() {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Fatal("Error Getting Rlimit ", err)
+	}
+
+	if rLimit.Cur < rLimit.Max {
+		rLimit.Cur = rLimit.Max
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			log.Warn("Error Setting Rlimit:", err)
+		}
+	}
+
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Error("Couldn't raise Rlimit: " + err.Error())
+	}
+}
+
+// CheckOutOfFileDescriptors tries to duplicate the stdout file descriptor
+// and throws an error if it cannot do it. This is a horrible hack mainly for
+// MacOSX where the file descriptor limit is quite low and we need to tell
+// people running simulations what they can do about it.
+func CheckOutOfFileDescriptors() error {
+	// Check if we're out of file descriptors
+	newFS, err := syscall.Dup(syscall.Stdout)
+	if err != nil {
+		return errors.New(`Out of file descriptors. You might want to do something like this for Mac OSX:
+    sudo sysctl -w kern.maxfiles=122880
+    sudo sysctl -w kern.maxfilesperproc=102400
+    sudo sysctl -w kern.ipc.somaxconn=20480`)
+	}
+	if err = syscall.Close(newFS); err != nil {
+		return errors.New("Couldn't close new file descriptor: " + err.Error())
+	}
+	return nil
+}

--- a/simul/platform/fd_windows.go
+++ b/simul/platform/fd_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package platform
+
+// CheckOutOfFileDescriptors on Windows is not used.
+func CheckOutOfFileDescriptors() error {
+	return nil
+}

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -220,7 +220,6 @@ func (d *Localhost) Wait() error {
 
 	wait, err := time.ParseDuration(d.RunWait)
 	if err != nil || wait == 0 {
-		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
 		err = nil
 	}

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -5,6 +5,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -296,7 +297,6 @@ func (m *MiniNet) Start(args ...string) error {
 	go func() {
 		config := strings.Split(m.config, "\n")
 		sort.Strings(config)
-		log.Lvlf1("Starting simulation %s over mininet", strings.Join(config, " :: "))
 		err := SSHRunStdout(m.Login, m.External, "cd mininet_run; ./start.py list go")
 		if err != nil {
 			log.Lvl3(err)
@@ -311,7 +311,6 @@ func (m *MiniNet) Start(args ...string) error {
 func (m *MiniNet) Wait() error {
 	wait, err := time.ParseDuration(m.RunWait)
 	if wait == 0 || err != nil {
-		log.Warn("Couldn't parse RunWait or it is set to 0 - using 600s as default value")
 		wait = 600 * time.Second
 		err = nil
 	}
@@ -347,7 +346,10 @@ func (m *MiniNet) parseServers() error {
 		if len(h) > 0 {
 			ips, err := net.LookupIP(h)
 			if err != nil {
-				return err
+				if err2 := CheckOutOfFileDescriptors(); err2 != nil {
+					return errors.New("couldn't look up hostname: " + err2.Error())
+				}
+				return errors.New("error while looking up hostname: " + err.Error())
 			}
 			log.Lvl3("Found IP for", h, ":", ips[0])
 			m.HostIPs = append(m.HostIPs, ips[0].String())

--- a/simul/test_simul/count_big.toml
+++ b/simul/test_simul/count_big.toml
@@ -1,0 +1,14 @@
+Servers = 16
+Simulation = "CountTest"
+BF = 2
+Rounds = 4
+Suite = "Ed25519"
+
+Hosts
+3
+7
+15
+31
+255
+511
+1023

--- a/simulation.go
+++ b/simulation.go
@@ -122,6 +122,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 				e.SetPrivate(scf.PrivateKeys[e.Address])
 				server := NewServerTCP(e, suite)
 				server.UnauthOk = true
+				server.Quiet = true
 				scNew := *sc
 				scNew.Server = server
 				scNew.Overlay = server.overlay


### PR DESCRIPTION
Changes the start.py script to set up ip2ip tunnels between all hosts,
so that it also works when the iccluster-servers are on different
subnets.

In addition, there are some small cleanups and specifically the setting
of the maximum numbers of file descriptors that makes bigger simulations
passing on MacOSX.