### PR TITLE
Add versions to db

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -51,6 +51,15 @@ func TestContextSaveLoad(t *testing.T) {
 	require.False(t, files[0].IsDir())
 	require.True(t, files[0].Mode().IsRegular())
 	require.True(t, strings.HasSuffix(files[0].Name(), ".db"))
+
+	v, err := c[0].LoadVersion()
+	require.Nil(t, err)
+	require.Equal(t, 0, v)
+	err = c[0].SaveVersion(1)
+	require.Nil(t, err)
+	v, err = c[0].LoadVersion()
+	require.Nil(t, err)
+	require.Equal(t, 1, v)
 }
 
 func testLoadSave(t *testing.T, c *Context) {

--- a/service.go
+++ b/service.go
@@ -240,12 +240,8 @@ func newServiceManager(svr *Server, o *Overlay, dbPath string, delDb bool) *serv
 		name := ServiceFactory.Name(id)
 		log.Lvl3("Starting service", name)
 
-		err = createBucketForService(s.db, name)
-		if err != nil {
-			log.Panic("Failed to create bucket: " + err.Error())
-		}
-
 		cont := newContext(svr, o, id, s)
+
 		s, err := ServiceFactory.start(name, cont)
 		if err != nil {
 			log.Panic("Trying to instantiate service", name, ": error=", err)
@@ -267,14 +263,6 @@ func openDb(path string) (*bolt.DB, error) {
 		return nil, err
 	}
 	return db, nil
-}
-
-// createBucketForService creates a bucket in the database `db` named `bucketName`.
-func createBucketForService(db *bolt.DB, bucketName string) error {
-	return db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte(bucketName))
-		return err
-	})
 }
 
 func (s *serviceManager) dbFileNameOld() string {


### PR DESCRIPTION
This PR adds LoadVersion and SaveVersion to store a db-version int for every service.
It also adds LoadRaw to fetch old versions of the db.