### PR TITLE
Test Closing Fixes

### DIFF
--- a/local.go
+++ b/local.go
@@ -293,7 +293,6 @@ func (l *LocalTest) CloseAll() {
 		}
 	}
 
-	l.ctx.Stop()
 	for _, server := range l.Servers {
 		log.Lvl3("Closing server", server.ServerIdentity.Address)
 		err := server.Close()
@@ -308,6 +307,7 @@ func (l *LocalTest) CloseAll() {
 		}
 		delete(l.Servers, server.ServerIdentity.ID)
 	}
+	l.ctx.Stop()
 	for _, node := range l.Nodes {
 		log.Lvl3("Closing node", node)
 		node.closeDispatch()

--- a/overlay.go
+++ b/overlay.go
@@ -571,7 +571,8 @@ func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolI
 	go func() {
 		err := pi.Dispatch()
 		if err != nil {
-			log.Error(err)
+			log.Errorf("%s.Dispatch() created in service %s returned error %s",
+				name, ServiceFactory.Name(sid), err)
 		}
 	}()
 	return pi, err

--- a/server_test.go
+++ b/server_test.go
@@ -3,7 +3,7 @@ package onet
 import (
 	"testing"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/onet/log"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/satori/go.uuid.v1"


### PR DESCRIPTION
Makes a nicer closing of tests by asking the services _first_ to shut down,
and only then closing the network.