### PR TITLE
Fixing protocol creation

### DIFF
--- a/server.go
+++ b/server.go
@@ -78,10 +78,6 @@ func newServer(s network.Suite, dbPath string, r *network.Router, pkey kyber.Sca
 	c.WebSocket = NewWebSocket(r.ServerIdentity)
 	c.serviceManager = newServiceManager(c, c.overlay, dbPath, delDb)
 	c.statusReporterStruct.RegisterStatusReporter("Generic", c)
-	for name, inst := range protocols.instantiators {
-		log.Lvl4("Registering global protocol", name)
-		c.ProtocolRegister(name, inst)
-	}
 	return c
 }
 


### PR DESCRIPTION
Instead of filling up the local protocol stack with the list of global protocols
_after_ service creation, do so before. This allows services to actually use the
protocols in their 'newService' method.