### PR TITLE
Run TestClose in parallel

### DIFF
--- a/local.go
+++ b/local.go
@@ -293,6 +293,12 @@ func (l *LocalTest) CloseAll() {
 		}
 	}
 
+	for _, node := range l.Nodes {
+		log.Lvl3("Closing node", node)
+		node.closeDispatch()
+	}
+	l.Nodes = make([]*TreeNodeInstance, 0)
+
 	for _, server := range l.Servers {
 		log.Lvl3("Closing server", server.ServerIdentity.Address)
 		err := server.Close()
@@ -308,13 +314,10 @@ func (l *LocalTest) CloseAll() {
 		delete(l.Servers, server.ServerIdentity.ID)
 	}
 	l.ctx.Stop()
-	for _, node := range l.Nodes {
-		log.Lvl3("Closing node", node)
-		node.closeDispatch()
-	}
-	l.Nodes = make([]*TreeNodeInstance, 0)
+
 	os.RemoveAll(l.path)
 	l.closed = true
+
 	if log.DebugVisible() == 0 {
 		log.OutputToOs()
 	}

--- a/server.go
+++ b/server.go
@@ -165,7 +165,7 @@ func (c *Server) Close() error {
 	var wg sync.WaitGroup
 	for _, serv := range c.serviceManager.services {
 		wg.Add(1)
-		func(s Service) {
+		go func(s Service) {
 			defer wg.Done()
 			c, ok := s.(TestClose)
 			if ok {


### PR DESCRIPTION
We run TestClose in parallel because if one of the TestClose takes a
long time then it may cause strange behaviour in other services.