### PR TITLE
Improve test robustness some more

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -57,6 +57,7 @@ var bufStdOut bytes.Buffer
 var bufStdErr bytes.Buffer
 
 func init() {
+	setNonblock()
 	stdOut = os.Stdout
 	stdErr = os.Stderr
 }

--- a/log/nonblock_unix.go
+++ b/log/nonblock_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package log
+
+import (
+	"os"
+	"syscall"
+)
+
+func setNonblock() {
+	syscall.SetNonblock(int(os.Stderr.Fd()), true)
+	syscall.SetNonblock(int(os.Stdout.Fd()), true)
+	return
+}

--- a/log/nonblock_windows.go
+++ b/log/nonblock_windows.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package log
+
+import (
+	"os"
+	"syscall"
+)
+
+func setNonblock() {
+	syscall.SetNonblock(syscall.Handle(os.Stderr.Fd()), true)
+	syscall.SetNonblock(syscall.Handle(os.Stdout.Fd()), true)
+	return
+}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -2,6 +2,7 @@ package onet
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -80,6 +81,11 @@ func TestOverlayDispatchFailure(t *testing.T) {
 
 	// wait for the error message to get formatted by overlay.go
 	<-dispFailErr.ch
+
+	// This test was apparently always a bit fragile, and commit 5931349
+	// seems to have made it worse. Adding this tiny sleep makes
+	// 2000 iterations pass where before I could see errors about 1 in 20 times.
+	time.Sleep(5 * time.Millisecond)
 
 	// when using `go test -v`, the error string goes into the stderr buffer
 	// but with `go test`, it goes into the stdout buffer, so we check both


### PR DESCRIPTION
By adding in non-blocking logging and a fix for a recently destabilised test.