### PR TITLE
Improving shutdown of tests

### DIFF
--- a/server.go
+++ b/server.go
@@ -173,8 +173,8 @@ func (c *Server) Close() error {
 			}
 		}(serv)
 	}
-	wg.Wait()
 	c.serviceManager.servicesMutex.Unlock()
+	wg.Wait()
 	c.overlay.stop()
 	c.WebSocket.stop()
 	c.overlay.Close()

--- a/service.go
+++ b/service.go
@@ -395,7 +395,12 @@ func (s *serviceManager) service(name string) Service {
 	}
 	s.servicesMutex.Lock()
 	defer s.servicesMutex.Unlock()
-	return s.services[id]
+	ser, ok := s.services[id]
+	if !ok {
+		log.Error("this service is not instantiated")
+		return nil
+	}
+	return ser
 }
 
 func (s *serviceManager) serviceByID(id ServiceID) (Service, bool) {


### PR DESCRIPTION
Parallelizes the closing of the servers so that the nodes don't wait for each other.
Unlocks the servicesMutex before waiting for all servers to finish.