### PR TITLE
Adding streaming abilities to onet websockets

### DIFF
--- a/local.go
+++ b/local.go
@@ -514,6 +514,18 @@ func (l *LocalTest) NewClient(serviceName string) *Client {
 	}
 }
 
+// NewClientKeep returns *Client for which the types depend on the mode of the
+// LocalContext, the connection is not closed after sending requests.
+func (l *LocalTest) NewClientKeep(serviceName string) *Client {
+	switch l.mode {
+	case TCP:
+		return NewClientKeep(l.Suite, serviceName)
+	default:
+		log.Fatal("Can't make local client")
+		return nil
+	}
+}
+
 // genLocalHosts returns n servers created with a localRouter
 func (l *LocalTest) genLocalHosts(n int) []*Server {
 	l.panicClosed()

--- a/processor.go
+++ b/processor.go
@@ -45,15 +45,21 @@ var errType = reflect.TypeOf((*error)(nil)).Elem()
 //
 //  * msg is a pointer to a structure to the message sent.
 //  * ret is a pointer to a struct of the return-message.
-//  * err is can be nil, or any type that implements error.
+//  * err is an error, it can be nil, or any type that implements error.
 //
 // struct_name is stripped of its package-name, so a structure like
 // network.Body will be converted to Body.
 func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
-	if err := p.handlerSanityCheck(f); err != nil {
+	if err := p.handlerInputCheck(f); err != nil {
 		return err
 	}
+
+	// check output
 	ft := reflect.TypeOf(f)
+	if ft.NumOut() != 2 {
+		return errors.New("Need 2 return values: network.Body and error")
+	}
+	// first output
 	ret := ft.Out(0)
 	if ret.Kind() != reflect.Interface {
 		if ret.Kind() != reflect.Ptr {
@@ -62,6 +68,11 @@ func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 		if ret.Elem().Kind() != reflect.Struct {
 			return errors.New("1st return value must be a pointer to a *struct* or an interface")
 		}
+	}
+	// second output
+	if !ft.Out(1).Implements(errType) {
+		return errors.New("2nd return value has to implement error, but is: " +
+			ft.Out(1).String())
 	}
 
 	cr := ft.In(0)
@@ -72,18 +83,58 @@ func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 	return nil
 }
 
-// RegisterStreamingHandler TODO document
-// 2. func(msg interface{})(ret chan interface{}, err, error)
+// RegisterStreamingHandler stores a handler that is responsible for streaming
+// messages to the client via a channel. Websocket will accept requests for
+// this handler at "ws://service_name/struct_name", where struct_name is
+// argument of f, which must be in the form:
+// func(msg interface{})(retChan chan interface{}, closeChan chan bool, err error)
+//
+//  * msg is a pointer to a structure to the message sent.
+//  * retChan is a channel of a pointer to a struct, everything sent into this
+//    channel will be forwarded to the client, if there are no more messages,
+//    the service should close retChan.
+//  * closeChan is a boolean channel, upon receiving a message on this channel,
+//    the handler should stop sending messages and close retChan.
+//  * err is an error, it can be nil, or any type that implements error.
+//
+// struct_name is stripped of its package-name, so a structure like
+// network.Body will be converted to Body.
 func (p *ServiceProcessor) RegisterStreamingHandler(f interface{}) error {
-	if err := p.handlerSanityCheck(f); err != nil {
+	if err := p.handlerInputCheck(f); err != nil {
 		return err
 	}
+
+	// check output
 	ft := reflect.TypeOf(f)
-	ret := ft.Out(0)
-	if ret.Kind() != reflect.Chan {
+	if ft.NumOut() != 3 {
+		return errors.New("Need 3 return values: chan interface{}, chan bool and error")
+	}
+	// first output
+	ret0 := ft.Out(0)
+	if ret0.Kind() != reflect.Chan {
 		return errors.New("1st return value must be a channel")
 	}
-	// TODO is there a way to check the kind inside the channel?
+	if ret0.Elem().Kind() != reflect.Interface {
+		if ret0.Elem().Kind() != reflect.Ptr {
+			return errors.New("1st return value must be a channel of a *pointer* to a struct")
+		}
+		if ret0.Elem().Elem().Kind() != reflect.Struct {
+			return errors.New("1st return value must be a channel of a pointer to a *struct*")
+		}
+	}
+	// second output
+	ret1 := ft.Out(1)
+	if ret1.Kind() != reflect.Chan {
+		return errors.New("2nd return value must be a channel")
+	}
+	if ret1.Elem().Kind() != reflect.Bool {
+		return errors.New("2nd return value must be a boolean channel")
+	}
+	// third output
+	if !ft.Out(2).Implements(errType) {
+		return errors.New("3rd return value has to implement error, but is: " +
+			ft.Out(2).String())
+	}
 
 	cr := ft.In(0)
 	log.Lvl4("Registering streaming handler", cr.String())
@@ -93,9 +144,8 @@ func (p *ServiceProcessor) RegisterStreamingHandler(f interface{}) error {
 	return nil
 }
 
-func (p *ServiceProcessor) handlerSanityCheck(f interface{}) error {
+func (p *ServiceProcessor) handlerInputCheck(f interface{}) error {
 	ft := reflect.TypeOf(f)
-	// Check that we have the correct channel-type.
 	if ft.Kind() != reflect.Func {
 		return errors.New("Input is not a function")
 	}
@@ -108,14 +158,6 @@ func (p *ServiceProcessor) handlerSanityCheck(f interface{}) error {
 	}
 	if cr.Elem().Kind() != reflect.Struct {
 		return errors.New("Argument must be a pointer to *struct*")
-	}
-	if ft.NumOut() != 2 {
-		return errors.New("Need 2 return values: network.Body and error")
-	}
-
-	if !ft.Out(1).Implements(errType) {
-		return errors.New("2nd return value has to implement error, but is: " +
-			ft.Out(1).String())
 	}
 	return nil
 }
@@ -154,27 +196,31 @@ func (p *ServiceProcessor) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig
 	return nil, nil
 }
 
-// ProcessClientRequest takes a request from a websocket client, calculates the reply
-// and sends it back. It uses the path to find the appropriate handler-
-// function. It implements the Server interface.
-// ProcessClientRequest is called when a message from an
-// external client is received by the websocket for this
-// service. It returns a message that will be sent back to the
-// client. The returned error will be formatted as a websocket
-// error code 4000, using the string form of the error as the message.
-func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, chan []byte, error) {
+// StreamingTunnel is used as a tunnel between service processor and its
+// caller, usually the websocket read-loop. When the tunnel is returned to the
+// websocket loop, it should read from the out channel and forward the content
+// to the client. If the client is disconnected, then the close channel should
+// be closed. The signal exists to notify the service to stop streaming.
+type StreamingTunnel struct {
+	out   chan []byte
+	close chan bool
+}
+
+// ProcessClientRequest implementes the Service interface, see the interface
+// documentation.
+func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, *StreamingTunnel, error) {
 	mh, ok := p.handlers[path]
-	reply, err := func() (interface{}, error) {
+	reply, stopServiceChan, err := func() (interface{}, chan bool, error) {
 		if !ok {
 			err := errors.New("The requested message hasn't been registered: " + path)
 			log.Error(err)
-			return nil, err
+			return nil, nil, err
 		}
 		msg := reflect.New(mh.msgType).Interface()
 		err := protobuf.DecodeWithConstructors(buf, msg,
 			network.DefaultConstructors(p.Context.server.Suite()))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		to := reflect.TypeOf(mh.handler).In(0)
@@ -184,46 +230,60 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		arg.Elem().Set(reflect.ValueOf(msg).Elem())
 		ret := f.Call([]reflect.Value{arg})
 
-		// there will be an extra element in ret
+		if mh.streaming {
+			ierr := ret[2].Interface()
+			if ierr != nil {
+				return nil, nil, ierr.(error)
+			}
+			return ret[0].Interface(), ret[1].Interface().(chan bool), nil
+		}
 		ierr := ret[1].Interface()
 		if ierr != nil {
-			return nil, ierr.(error)
+			return nil, nil, ierr.(error)
 		}
-		return ret[0].Interface(), nil
+		return ret[0].Interface(), nil, nil
 	}()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if mh.streaming {
+		// We need some buffer space for the intermediate channel that
+		// is responsible for forwarding messages from the service to
+		// the client because we need to keep the select-loop running
+		// to handle channel closures.
 		outChan := make(chan []byte, 100)
 		go func() {
-			c := reflect.ValueOf(reply)
-			case0 := reflect.SelectCase{Dir: reflect.SelectRecv, Chan: c}
+			inChan := reflect.ValueOf(reply)
+			case0 := reflect.SelectCase{Dir: reflect.SelectRecv, Chan: inChan}
 			for {
 				chosen, v, ok := reflect.Select([]reflect.SelectCase{case0})
 				if !ok {
-					log.LLvlf4("publisher is closed for %s, closing outgoing channel", path)
+					log.Lvlf4("publisher is closed for %s, closing outgoing channel", path)
 					close(outChan)
 					return
 				}
 				if chosen == 0 {
+					// Send information down to the client.
 					buf, err = protobuf.Encode(v.Interface())
 					if err != nil {
 						log.Error(err)
-						// TODO close these?
 						close(outChan)
-						case0.Chan.Close()
 						return
 					}
 					outChan <- buf
+				} else {
+					panic("no such channel index")
 				}
-				// We don't add a way to close here, otherwise
-				// the service will block. The service should
-				// close the channel.
+				// We don't add a way to explicitly stop the
+				// go-routine, otherwise the service will
+				// block. The service should close the channel
+				// when it has nothing else to say because it
+				// is the producer. Then this go-routine will
+				// be stopped as well.
 			}
 		}()
-		return nil, outChan, nil
+		return nil, &StreamingTunnel{outChan, stopServiceChan}, nil
 	}
 
 	buf, err = protobuf.Encode(reply)

--- a/processor.go
+++ b/processor.go
@@ -23,8 +23,9 @@ type ServiceProcessor struct {
 
 // serviceHandler stores the handler and the message-type.
 type serviceHandler struct {
-	handler interface{}
-	msgType reflect.Type
+	handler   interface{}
+	msgType   reflect.Type
+	streaming bool
 }
 
 // NewServiceProcessor initializes your ServiceProcessor.
@@ -39,7 +40,7 @@ var errType = reflect.TypeOf((*error)(nil)).Elem()
 
 // RegisterHandler will store the given handler that will be used by the service.
 // WebSocket will then forward requests to "ws://service_name/struct_name"
-// to the given function f, which must be of the following form:
+// to the given function f, which must be in the following form:
 // func(msg interface{})(ret interface{}, err error)
 //
 //  * msg is a pointer to a structure to the message sent.
@@ -49,6 +50,50 @@ var errType = reflect.TypeOf((*error)(nil)).Elem()
 // struct_name is stripped of its package-name, so a structure like
 // network.Body will be converted to Body.
 func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
+	if err := p.handlerSanityCheck(f); err != nil {
+		return err
+	}
+	ft := reflect.TypeOf(f)
+	ret := ft.Out(0)
+	if ret.Kind() != reflect.Interface {
+		if ret.Kind() != reflect.Ptr {
+			return errors.New("1st return value must be a *pointer* to a struct or an interface")
+		}
+		if ret.Elem().Kind() != reflect.Struct {
+			return errors.New("1st return value must be a pointer to a *struct* or an interface")
+		}
+	}
+
+	cr := ft.In(0)
+	log.Lvl4("Registering handler", cr.String())
+	pm := strings.Split(cr.Elem().String(), ".")[1]
+	p.handlers[pm] = serviceHandler{f, cr.Elem(), false}
+
+	return nil
+}
+
+// RegisterStreamingHandler TODO document
+// 2. func(msg interface{})(ret chan interface{}, err, error)
+func (p *ServiceProcessor) RegisterStreamingHandler(f interface{}) error {
+	if err := p.handlerSanityCheck(f); err != nil {
+		return err
+	}
+	ft := reflect.TypeOf(f)
+	ret := ft.Out(0)
+	if ret.Kind() != reflect.Chan {
+		return errors.New("1st return value must be a channel")
+	}
+	// TODO is there a way to check the kind inside the channel?
+
+	cr := ft.In(0)
+	log.Lvl4("Registering streaming handler", cr.String())
+	pm := strings.Split(cr.Elem().String(), ".")[1]
+	p.handlers[pm] = serviceHandler{f, cr.Elem(), true}
+
+	return nil
+}
+
+func (p *ServiceProcessor) handlerSanityCheck(f interface{}) error {
 	ft := reflect.TypeOf(f)
 	// Check that we have the correct channel-type.
 	if ft.Kind() != reflect.Func {
@@ -68,24 +113,10 @@ func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 		return errors.New("Need 2 return values: network.Body and error")
 	}
 
-	ret := ft.Out(0)
-	if ret.Kind() != reflect.Interface {
-		if ret.Kind() != reflect.Ptr {
-			return errors.New("1st return value must be a *pointer* to a struct or an interface")
-		}
-		if ret.Elem().Kind() != reflect.Struct {
-			return errors.New("1st return value must be a pointer to a *struct* or an interface")
-		}
-	}
-
 	if !ft.Out(1).Implements(errType) {
 		return errors.New("2nd return value has to implement error, but is: " +
 			ft.Out(1).String())
 	}
-
-	log.Lvl4("Registering handler", cr.String())
-	pm := strings.Split(cr.Elem().String(), ".")[1]
-	p.handlers[pm] = serviceHandler{f, cr.Elem()}
 	return nil
 }
 
@@ -100,7 +131,19 @@ func (p *ServiceProcessor) RegisterHandlers(procs ...interface{}) error {
 	return nil
 }
 
-// Process implements the Processor interface and dispatches ClientRequest messages.
+// RegisterStreamingHandlers takes a vararg of messages to register and returns
+// the first error encountered or nil if everything was OK.
+func (p *ServiceProcessor) RegisterStreamingHandlers(procs ...interface{}) error {
+	for _, pr := range procs {
+		if err := p.RegisterStreamingHandler(pr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Process implements the Processor interface and dispatches ClientRequest
+// messages.
 func (p *ServiceProcessor) Process(env *network.Envelope) {
 	log.Panic("Cannot handle message.")
 }
@@ -114,7 +157,12 @@ func (p *ServiceProcessor) NewProtocol(tn *TreeNodeInstance, conf *GenericConfig
 // ProcessClientRequest takes a request from a websocket client, calculates the reply
 // and sends it back. It uses the path to find the appropriate handler-
 // function. It implements the Server interface.
-func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, error) {
+// ProcessClientRequest is called when a message from an
+// external client is received by the websocket for this
+// service. It returns a message that will be sent back to the
+// client. The returned error will be formatted as a websocket
+// error code 4000, using the string form of the error as the message.
+func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, chan []byte, error) {
 	mh, ok := p.handlers[path]
 	reply, err := func() (interface{}, error) {
 		if !ok {
@@ -136,6 +184,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		arg.Elem().Set(reflect.ValueOf(msg).Elem())
 		ret := f.Call([]reflect.Value{arg})
 
+		// there will be an extra element in ret
 		ierr := ret[1].Interface()
 		if ierr != nil {
 			return nil, ierr.(error)
@@ -143,12 +192,44 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		return ret[0].Interface(), nil
 	}()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	if mh.streaming {
+		outChan := make(chan []byte, 100)
+		go func() {
+			c := reflect.ValueOf(reply)
+			case0 := reflect.SelectCase{Dir: reflect.SelectRecv, Chan: c}
+			for {
+				chosen, v, ok := reflect.Select([]reflect.SelectCase{case0})
+				if !ok {
+					log.LLvlf4("publisher is closed for %s, closing outgoing channel", path)
+					close(outChan)
+					return
+				}
+				if chosen == 0 {
+					buf, err = protobuf.Encode(v.Interface())
+					if err != nil {
+						log.Error(err)
+						// TODO close these?
+						close(outChan)
+						case0.Chan.Close()
+						return
+					}
+					outChan <- buf
+				}
+				// We don't add a way to close here, otherwise
+				// the service will block. The service should
+				// close the channel.
+			}
+		}()
+		return nil, outChan, nil
+	}
+
 	buf, err = protobuf.Encode(reply)
 	if err != nil {
 		log.Error(err)
-		return nil, errors.New("")
+		return nil, nil, errors.New("")
 	}
-	return buf, nil
+	return buf, nil, nil
 }

--- a/processor.go
+++ b/processor.go
@@ -94,7 +94,7 @@ func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 //    channel will be forwarded to the client, if there are no more messages,
 //    the service should close retChan.
 //  * closeChan is a boolean channel, upon receiving a message on this channel,
-//    the handler should stop sending messages and close retChan.
+//    the handler must stop sending messages and close retChan.
 //  * err is an error, it can be nil, or any type that implements error.
 //
 // struct_name is stripped of its package-name, so a structure like
@@ -255,9 +255,11 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		outChan := make(chan []byte, 100)
 		go func() {
 			inChan := reflect.ValueOf(reply)
-			case0 := reflect.SelectCase{Dir: reflect.SelectRecv, Chan: inChan}
+			cases := []reflect.SelectCase{
+				reflect.SelectCase{Dir: reflect.SelectRecv, Chan: inChan},
+			}
 			for {
-				chosen, v, ok := reflect.Select([]reflect.SelectCase{case0})
+				chosen, v, ok := reflect.Select(cases)
 				if !ok {
 					log.Lvlf4("publisher is closed for %s, closing outgoing channel", path)
 					close(outChan)

--- a/service.go
+++ b/service.go
@@ -38,7 +38,9 @@ type Service interface {
 	// service. It returns a message that will be sent back to the
 	// client. The returned error will be formatted as a websocket
 	// error code 4000, using the string form of the error as the message.
-	ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, err error)
+	// TODO update docs
+	ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, replies chan []byte, err error)
+	// ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, stream bool, err error)
 	// Processor makes a Service being able to handle any kind of packets
 	// directly from the network. It is used for inter service communications,
 	// which are mostly single packets with no or little interactions needed. If

--- a/service.go
+++ b/service.go
@@ -33,14 +33,18 @@ type Service interface {
 	// the ProtocolInstance it is using. If a Service returns (nil,nil), that
 	// means this Service lets Onet handle the protocol instance.
 	NewProtocol(*TreeNodeInstance, *GenericConfig) (ProtocolInstance, error)
-	// ProcessClientRequest is called when a message from an
-	// external client is received by the websocket for this
-	// service. It returns a message that will be sent back to the
-	// client. The returned error will be formatted as a websocket
+	// ProcessClientRequest is called when a message from an external
+	// client is received by the websocket for this service. The message is
+	// forwarded to the corresponding handler keyed by the path. If the
+	// handler is a normal one, i.e., a request-response handler, it
+	// returns a message in the first return value and the second
+	// (StreamingTunnel) will be set to nil. If the handler is a streaming
+	// handler, the first return value is set to nil but the second
+	// (StreamingTunnel) will exist. It should be used to stream messages
+	// to the client. See the StreamingTunnel documentation on how it
+	// should be used. The returned error will be formatted as a websocket
 	// error code 4000, using the string form of the error as the message.
-	// TODO update docs
-	ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, replies chan []byte, err error)
-	// ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, stream bool, err error)
+	ProcessClientRequest(req *http.Request, handler string, msg []byte) (reply []byte, tunnel *StreamingTunnel, err error)
 	// Processor makes a Service being able to handle any kind of packets
 	// directly from the network. It is used for inter service communications,
 	// which are mostly single packets with no or little interactions needed. If

--- a/service_test.go
+++ b/service_test.go
@@ -507,7 +507,7 @@ func (s *simpleService) ProcessClientRequest(req *http.Request, path string, buf
 	msg := &SimpleRequest{}
 	err := protobuf.DecodeWithConstructors(buf, msg, network.DefaultConstructors(tSuite))
 	if err != nil {
-		return nil, nil, errors.New("")
+		return nil, nil, err
 	}
 	tree := msg.ServerIdentities.GenerateBinaryTree()
 	tni := s.ctx.NewTreeNodeInstance(tree, tree.Root, backForthServiceName)
@@ -516,10 +516,10 @@ func (s *simpleService) ProcessClientRequest(req *http.Request, path string, buf
 		ret <- n
 	})
 	if err != nil {
-		return nil, nil, errors.New("")
+		return nil, nil, err
 	}
 	if err = s.ctx.RegisterProtocolInstance(proto); err != nil {
-		return nil, nil, errors.New("")
+		return nil, nil, err
 	}
 	proto.Start()
 	if s.panic {
@@ -615,7 +615,7 @@ func (ds *DummyService) ProcessClientRequest(req *http.Request, path string, buf
 
 	if err := ds.c.RegisterProtocolInstance(dp); err != nil {
 		ds.link <- false
-		return nil, nil, errors.New("")
+		return nil, nil, err
 	}
 	log.Lvl2("Starting protocol")
 	go func() {

--- a/service_test.go
+++ b/service_test.go
@@ -503,7 +503,7 @@ type simpleService struct {
 	newProto chan bool
 }
 
-func (s *simpleService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, chan []byte, error) {
+func (s *simpleService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, *StreamingTunnel, error) {
 	msg := &SimpleRequest{}
 	err := protobuf.DecodeWithConstructors(buf, msg, network.DefaultConstructors(tSuite))
 	if err != nil {
@@ -599,7 +599,7 @@ type DummyService struct {
 	Config   DummyConfig
 }
 
-func (ds *DummyService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, chan []byte, error) {
+func (ds *DummyService) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, *StreamingTunnel, error) {
 	log.Lvl2("Got called with path", path, buf)
 	msg := &DummyMsg{}
 	err := protobuf.Decode(buf, msg)
@@ -669,7 +669,7 @@ func newDummyService2(c *Context) (Service, error) {
 	return &dummyService2{Context: c}, nil
 }
 
-func (ds *dummyService2) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, chan []byte, error) {
+func (ds *dummyService2) ProcessClientRequest(req *http.Request, path string, buf []byte) ([]byte, *StreamingTunnel, error) {
 	panic("should not be called")
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -157,10 +157,9 @@ func (t wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rx := 0
 	tx := 0
 	n := 0
-	ok := false
 
 	defer func() {
-		log.Lvl2("ws close", r.RemoteAddr, "n", n, "rx", rx, "tx", tx, "ok", ok)
+		log.Lvl2("ws close", r.RemoteAddr, "n", n, "rx", rx, "tx", tx)
 	}()
 
 	u := websocket.Upgrader{
@@ -182,6 +181,7 @@ func (t wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// Loop for each message
+outerReadLoop:
 	for err == nil {
 		mt, buf, rerr := ws.ReadMessage()
 		if rerr != nil {
@@ -193,25 +193,52 @@ func (t wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		s := t.service
 		var reply []byte
+		var replyChan chan []byte
 		path := strings.TrimPrefix(r.URL.Path, "/"+t.serviceName+"/")
 		log.Lvlf2("ws request from %s: %s/%s", r.RemoteAddr, t.serviceName, path)
-		reply, err = s.ProcessClientRequest(r, path, buf)
+		reply, replyChan, err = s.ProcessClientRequest(r, path, buf)
 		if err == nil {
-			tx += len(reply)
-			err := ws.WriteMessage(mt, reply)
-			if err != nil {
-				log.Error(err)
-				return
+			if replyChan == nil {
+				tx += len(reply)
+				err := ws.WriteMessage(mt, reply)
+				if err != nil {
+					log.Error(err)
+					break
+				}
+			} else {
+				// innerReadLoop:
+				// TODO some design discussion is needed here. ServeHTTP is per client.
+				// The client may decide to keep connection open for different requests.
+				// If the server stops streaming, should it close the connection?
+				// We don't have a suitable control-message for this type of notification.
+				for {
+					select {
+					case reply, ok := <-replyChan:
+						if !ok {
+							/*
+								log.LLvl4("service (publisher) closed, finished streaming, going back to read loop")
+								break innerReadLoop
+							*/
+							err = errors.New("service (publisher) closed, finished streaming")
+							break outerReadLoop
+						}
+						tx += len(reply)
+						err := ws.WriteMessage(mt, reply)
+						if err != nil {
+							log.Error(err)
+							break outerReadLoop
+						}
+					}
+				}
 			}
 		} else {
-			log.Lvlf3("Got an error while executing %s/%s: %s", t.serviceName, path, err.Error())
+			log.Errorf("Got an error while executing %s/%s: %s", t.serviceName, path, err.Error())
 		}
 	}
 
 	ws.WriteControl(websocket.CloseMessage,
 		websocket.FormatCloseMessage(4000, err.Error()),
 		time.Now().Add(time.Millisecond*500))
-	ok = true
 	return
 }
 
@@ -261,19 +288,26 @@ func (c *Client) Suite() network.Suite {
 	return c.suite
 }
 
-// Send will marshal the message into a ClientRequest message and send it.
-func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]byte, error) {
-	c.Lock()
-	defer c.Unlock()
+func (c *Client) closeSingleUseConn(dst *network.ServerIdentity, path string) {
+	dest := destination{dst, path}
+	if !c.keep {
+		if err := c.closeConn(dest); err != nil {
+			log.Errorf("error while closing the connection to %v : %v\n", dest, err)
+		}
+	}
+}
+
+func (c *Client) newConnIfNotExist(dst *network.ServerIdentity, path string) (*websocket.Conn, error) {
 	dest := destination{dst, path}
 	conn, ok := c.connections[dest]
 	if !ok {
+		// TODO we are opening a new connection for every new path?
+		// not possible to use an existing connection for the same service?
 		// Open connection to service.
 		url, err := getWebAddress(dst, false)
 		if err != nil {
 			return nil, err
 		}
-		log.Lvlf4("Sending %x to %s/%s/%s", buf, url, c.service, path)
 		d := &websocket.Dialer{}
 		d.TLSClientConfig = c.TLSClientConfig
 
@@ -294,6 +328,7 @@ func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]b
 			if err == nil {
 				break
 			}
+			panic(err.Error())
 			time.Sleep(network.WaitRetry)
 		}
 		if err != nil {
@@ -301,13 +336,21 @@ func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]b
 		}
 		c.connections[dest] = conn
 	}
-	defer func() {
-		if !c.keep {
-			if err := c.closeConn(dest); err != nil {
-				log.Errorf("error while closing the connection to %v : %v\n", dest, err)
-			}
-		}
-	}()
+	return conn, nil
+}
+
+// Send will marshal the message into a ClientRequest message and send it.
+func (c *Client) Send(dst *network.ServerIdentity, path string, buf []byte) ([]byte, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	conn, err := c.newConnIfNotExist(dst, path)
+	if err != nil {
+		return nil, err
+	}
+	defer c.closeSingleUseConn(dst, path)
+
+	log.Lvlf4("Sending %x to %s/%s", buf, c.service, path)
 	if err := conn.WriteMessage(websocket.BinaryMessage, buf); err != nil {
 		return nil, err
 	}
@@ -343,6 +386,48 @@ func (c *Client) SendProtobuf(dst *network.ServerIdentity, msg interface{}, ret 
 			network.DefaultConstructors(c.suite))
 	}
 	return nil
+}
+
+// StreamingConn allows clients to read from it without sending additional
+// requests.
+type StreamingConn struct {
+	conn  *websocket.Conn
+	suite network.Suite
+}
+
+// ReadMessage read more data from the connection, it will block if there are
+// no messages.
+func (c *StreamingConn) ReadMessage(ret interface{}) error {
+	_, buf, err := c.conn.ReadMessage()
+	// TODO no counter here
+	if err != nil {
+		return err
+	}
+	return protobuf.DecodeWithConstructors(buf, ret,
+		network.DefaultConstructors(c.suite))
+}
+
+// Stream will send a request to start streaming, it returns a connection where
+// the client can continue to read values from it.
+func (c *Client) Stream(dst *network.ServerIdentity, msg interface{}) (StreamingConn, error) {
+	buf, err := protobuf.Encode(msg)
+	if err != nil {
+		return StreamingConn{}, err
+	}
+	path := strings.Split(reflect.TypeOf(msg).String(), ".")[1]
+
+	c.Lock()
+	defer c.Unlock()
+	conn, err := c.newConnIfNotExist(dst, path)
+	if err != nil {
+		return StreamingConn{}, err
+	}
+	err = conn.WriteMessage(websocket.BinaryMessage, buf)
+	if err != nil {
+		return StreamingConn{}, err
+	}
+	c.tx += uint64(len(buf))
+	return StreamingConn{conn, c.Suite()}, nil
 }
 
 // SendToAll sends a message to all ServerIdentities of the Roster and returns

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -535,6 +535,8 @@ func TestWebSocket_Streaming(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
+// TestWebSocket_Streaming_Parallel is essentially the same as
+// TestWebSocket_Streaming, except we do it in parallel.
 func TestWebSocket_Streaming_Parallel(t *testing.T) {
 	local := NewTCPTest(tSuite)
 	defer local.CloseAll()


### PR DESCRIPTION
Adding streaming abilities to onet websockets.

We introduce a way to register handlers - `RegisterStreamingHandler`. This handler will return a channel to stream data to the client upon receiving a message. Internally, the processor listens on the channel and forwards all the messages to the websocket loop which then forwards them to the client.

If the client closes its connection. The websocket loop sends a stop signal back up the path to tell the service to stop streaming.

There shouldn't be any backward incompatible changes, `make test` works on cothority master.