### PR TITLE
Optionally list the WebSocket-side URL in ServerIdentity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test_data/
 test/
 deploy/
 .tags*
+profile.tmp

--- a/app/config.go
+++ b/app/config.go
@@ -132,6 +132,7 @@ type ServerToml struct {
 	Suite       string
 	Public      string
 	Description string
+	URL         string `toml:"URL,omitempty"`
 }
 
 // Group holds the Roster and the server-description.
@@ -214,7 +215,9 @@ func (s *ServerToml) toServerIdentity() (*network.ServerIdentity, error) {
 	if err != nil {
 		return nil, err
 	}
-	return network.NewServerIdentity(public, s.Address), nil
+	si := network.NewServerIdentity(public, s.Address)
+	si.URL = s.URL
+	return si, nil
 }
 
 // NewServerToml takes a public key and an address and returns

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -31,7 +31,9 @@ var serverGroup string = `Description = "Default Dedis Cothority"
   Address = "tcp://185.26.156.40:61117"
   Suite = "Ed25519"
   Public = "6a921638a4ade8970ebcd9e371570f08d71a24987f90f12391b9f6c525be5be4"
-  Description = "Ismail's server"`
+  Description = "Ismail's server"
+  URL = "https://ismail.example.com/conode"
+`
 
 func TestReadGroupDescToml(t *testing.T) {
 	group, err := ReadGroupDescToml(strings.NewReader(serverGroup))
@@ -51,6 +53,9 @@ func TestReadGroupDescToml(t *testing.T) {
 	}
 	if group.Description[group.Roster.List[1]] != "Ismail's server" {
 		t.Fatal("This should be Ismail's server")
+	}
+	if group.Roster.List[1].URL != "https://ismail.example.com/conode" {
+		t.Fatal("Did not find expected URL.")
 	}
 }
 

--- a/local.go
+++ b/local.go
@@ -161,6 +161,7 @@ func (l *LocalTest) GenServers(n int) []*Server {
 	l.panicClosed()
 	servers := l.genLocalHosts(n)
 	for _, server := range servers {
+		server.ServerIdentity.SetPrivate(server.private)
 		l.Servers[server.ServerIdentity.ID] = server
 		l.Overlays[server.ServerIdentity.ID] = server.overlay
 		l.Services[server.ServerIdentity.ID] = server.serviceManager.services

--- a/network/struct.go
+++ b/network/struct.go
@@ -70,13 +70,16 @@ type ServerIdentity struct {
 	Public kyber.Point
 	// The ServerIdentityID corresponding to that public key
 	ID ServerIdentityID
-	// A slice of addresses of where that Id might be found
+	// The address where that Id might be found
 	Address Address
 	// Description of the server
 	Description string
 	// This is the private key, may be nil. It is not exported so that it will never
 	// be marshalled.
 	private kyber.Scalar
+	// The URL where the WebSocket interface can be found. (If not set, then default is http, on port+1.)
+	// optional
+	URL string
 }
 
 // ServerIdentityID uniquely identifies an ServerIdentity struct

--- a/simul/monitor/tcpproxy.go
+++ b/simul/monitor/tcpproxy.go
@@ -203,7 +203,7 @@ func (tp *TCPProxy) runMonitor() {
 				}
 				go func(r *remote) {
 					if err := r.tryReactivate(); err != nil {
-						log.Warn("failed to activate endpoint [%s] due to %v (stay inactive for another %v)", r.addr, err, tp.MonitorInterval)
+						log.Warnf("failed to activate endpoint [%s] due to %v (stay inactive for another %v)", r.addr, err, tp.MonitorInterval)
 					} else {
 						log.Infof("activated %s", r.addr)
 					}

--- a/websocket.go
+++ b/websocket.go
@@ -319,18 +319,14 @@ func (c *Client) newConnIfNotExist(dst *network.ServerIdentity, path string) (*w
 			if err != nil {
 				return nil, err
 			}
-			header = http.Header{"Origin": []string{dst.URL}}
 			if u.Scheme == "https" {
 				u.Scheme = "wss"
 			} else {
 				u.Scheme = "ws"
 			}
-			u.Path += "/"
-			u.Path += c.service
-			u.Path += "/"
-			u.Path += path
+			u.Path += "/" + c.service + "/" + path
 			serverURL = u.String()
-			println("sending to url", serverURL)
+			header = http.Header{"Origin": []string{dst.URL}}
 		} else {
 			// Open connection to service.
 			hp, err := getWSHostPort(dst, false)


### PR DESCRIPTION
This change makes it possible to indicate to the websocket
client where it should contact a given server. In the past, the
websocket side of all servers had to be on port p+1. With
this change, it is possible to indicate in a roster.toml
file the correct URL to use to contact a given server.

Also: Fixed a problem go vet found.