### PR TITLE
Public keys comparison for a roster

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-
 	"math/rand"
 
 	"github.com/dedis/kyber"
@@ -677,6 +676,28 @@ func (ro Roster) IsRotation(target *Roster) bool {
 			return false
 		}
 	}
+	return true
+}
+
+// Contains checks if the roster contains the given array of public keys
+// and no more
+func (ro *Roster) Contains(pubs []kyber.Point) bool {
+	if len(ro.List) != len(pubs) {
+		return false
+	}
+
+	table := make(map[string]bool)
+	for _, p := range pubs {
+		table[p.String()] = true
+	}
+
+	for _, p := range ro.Publics() {
+		_, ok := table[p.String()]
+		if !ok {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -2,16 +2,17 @@ package onet
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strconv"
-	"testing"
-
 	"strings"
+	"testing"
 
 	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var prefix = "127.0.0.1:"
@@ -531,6 +532,22 @@ func TestRoster_IsRotation(t *testing.T) {
 	assert.False(t, roster.IsRotation(rosterSwapped))
 	assert.True(t, roster.IsRotation(rosterRotated0))
 	assert.True(t, roster.IsRotation(rosterRotated1))
+}
+
+func TestRoster_Contains(t *testing.T) {
+	_, roster := genLocalTree(10, 2000)
+
+	pubs := roster.Publics()
+	require.True(t, roster.Contains(pubs))
+
+	for i := 0; i < 10; i++ {
+		rand.Shuffle(len(pubs), func(i, j int) {
+			pubs[i], pubs[j] = pubs[j], pubs[i]
+			require.True(t, roster.Contains(pubs))
+		})
+	}
+
+	require.False(t, roster.Contains(pubs[1:]))
 }
 
 func TestTreeNode_AggregatePublic(t *testing.T) {


### PR DESCRIPTION
This PR adds a Contains function to the Roster struct that will check if the given list of public keys is the same list (but in a different order) as for the Roster.

Requirement for the issue cothority-1538