### PR TITLE
LRU cache with maximum size onet-273

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dedis/onet/log"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -12,103 +13,144 @@ import (
 // The implementation is robust against concurrent call
 type cacheTTL struct {
 	entries         map[uuid.UUID]*cacheTTLEntry
-	stopCh          chan (struct{})
-	stopOnce        sync.Once
-	cleanInterval   time.Duration
+	head            *cacheTTLEntry
+	tail            *cacheTTLEntry
 	entryExpiration time.Duration
+	size            int
 	sync.Mutex
 }
 
 type cacheTTLEntry struct {
+	key        uuid.UUID
 	item       interface{}
 	expiration time.Time
+	prev       *cacheTTLEntry
+	next       *cacheTTLEntry
 }
 
 // create a generic cache and start the cleaning routine
-func newCacheTTL(interval, expiration time.Duration) *cacheTTL {
-	c := &cacheTTL{
+func newCacheTTL(expiration time.Duration, size int) *cacheTTL {
+	if size == 0 {
+		log.Error("Cannot instantiate a cache with a size of 0")
+		return nil
+	}
+
+	return &cacheTTL{
 		entries:         make(map[uuid.UUID]*cacheTTLEntry),
-		stopCh:          make(chan (struct{})),
-		cleanInterval:   interval,
 		entryExpiration: expiration,
+		size:            size,
 	}
-	go c.cleaner()
-	return c
-}
-
-// Stop the cleaning routine
-func (c *cacheTTL) stop() {
-	c.stopOnce.Do(func() {
-		close(c.stopCh)
-	})
-}
-
-// Wait for either a clean or a stop order
-func (c *cacheTTL) cleaner() {
-	for {
-		select {
-		case <-time.After(c.cleanInterval):
-			c.clean()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// Check and delete expired items
-func (c *cacheTTL) clean() {
-	c.Lock()
-	now := time.Now()
-	for k, e := range c.entries {
-		if now.After(e.expiration) {
-			delete(c.entries, k)
-		}
-	}
-	c.Unlock()
 }
 
 // add the item to the cache with the given key
 func (c *cacheTTL) set(key uuid.UUID, item interface{}) {
-	c.Lock()
-	c.entries[key] = &cacheTTLEntry{
-		item:       item,
-		expiration: time.Now().Add(c.entryExpiration),
+	entry := c.entries[key]
+	if entry != nil {
+		entry.expiration = time.Now().Add(c.entryExpiration)
+		entry.item = item
+	} else {
+		entry = &cacheTTLEntry{
+			key:        key,
+			item:       item,
+			expiration: time.Now().Add(c.entryExpiration),
+		}
+
+		c.clean() // clean before checking the size
+		if len(c.entries) >= c.size && c.tail != nil {
+			// deletes the oldest entry and ignore edge cases with size = 0
+			delete(c.entries, c.tail.key)
+			c.tail = c.tail.next
+			c.tail.prev = nil
+		}
 	}
-	c.Unlock()
+
+	c.moveToHead(entry)
+	c.entries[key] = entry
 }
 
 // returns the cached item or nil
 func (c *cacheTTL) get(key uuid.UUID) interface{} {
-	c.Lock()
-	defer c.Unlock()
-
 	entry, ok := c.entries[key]
 	if ok && time.Now().Before(entry.expiration) {
 		entry.expiration = time.Now().Add(c.entryExpiration)
+		c.moveToHead(entry)
 		return entry.item
 	}
 
+	c.clean() // defensive cleaning
 	return nil
+}
+
+func (c *cacheTTL) moveToHead(e *cacheTTLEntry) {
+	if c.head == e {
+		// already at the top of the list
+		return
+	}
+
+	if c.tail == e && e.next != nil {
+		// item was the tail so we need to assign the new tail
+		c.tail = e.next
+	}
+	// remove the list entry from its previous position
+	if e.next != nil {
+		e.next.prev = e.prev
+	}
+	if e.prev != nil {
+		e.prev.next = e.next
+	}
+
+	// assign the entry at the top of the list
+	if c.head == nil {
+		c.head = e
+		if c.tail == nil {
+			c.tail = c.head
+		}
+	} else {
+		c.head.next = e
+		e.prev = c.head
+		e.next = nil
+		c.head = e
+	}
+}
+
+func (c *cacheTTL) clean() {
+	now := time.Now()
+
+	for c.tail != nil && now.After(c.tail.expiration) {
+		delete(c.entries, c.tail.key)
+
+		if c.head == c.tail {
+			c.head = nil
+			c.tail = nil
+		} else {
+			c.tail = c.tail.next
+		}
+	}
 }
 
 type treeCacheTTL struct {
 	*cacheTTL
 }
 
-func newTreeCache(interval, expiration time.Duration) *treeCacheTTL {
+func newTreeCache(expiration time.Duration, size int) *treeCacheTTL {
 	return &treeCacheTTL{
-		cacheTTL: newCacheTTL(interval, expiration),
+		cacheTTL: newCacheTTL(expiration, size),
 	}
 }
 
 // Set stores the given tree in the cache
 func (c *treeCacheTTL) Set(tree *Tree) {
+	c.Lock()
 	c.set(uuid.UUID(tree.ID), tree)
+	c.Unlock()
 }
 
 // Get retrieves the tree with the given ID if it exists
 // or returns nil
 func (c *treeCacheTTL) Get(id TreeID) *Tree {
+	c.Lock()
+	defer c.Unlock()
+
 	tree := c.get(uuid.UUID(id))
 	if tree != nil {
 		return tree.(*Tree)
@@ -126,20 +168,25 @@ type rosterCacheTTL struct {
 	*cacheTTL
 }
 
-func newRosterCache(interval, expiration time.Duration) *rosterCacheTTL {
+func newRosterCache(expiration time.Duration, size int) *rosterCacheTTL {
 	return &rosterCacheTTL{
-		cacheTTL: newCacheTTL(interval, expiration),
+		cacheTTL: newCacheTTL(expiration, size),
 	}
 }
 
 // Set stores the roster in the cache
 func (c *rosterCacheTTL) Set(roster *Roster) {
+	c.Lock()
 	c.set(uuid.UUID(roster.ID), roster)
+	c.Unlock()
 }
 
 // Get retrieves the Roster with the given ID if it exists
 // or it returns nil
 func (c *rosterCacheTTL) Get(id RosterID) *Roster {
+	c.Lock()
+	defer c.Unlock()
+
 	roster := c.get(uuid.UUID(id))
 	if roster != nil {
 		return roster.(*Roster)
@@ -161,22 +208,23 @@ type treeNodeCacheTTL struct {
 	*cacheTTL
 }
 
-func newTreeNodeCache(interval, expiration time.Duration) *treeNodeCacheTTL {
+func newTreeNodeCache(expiration time.Duration, size int) *treeNodeCacheTTL {
 	return &treeNodeCacheTTL{
-		cacheTTL: newCacheTTL(interval, expiration),
+		cacheTTL: newCacheTTL(expiration, size),
 	}
 }
 
 func (c *treeNodeCacheTTL) Set(tree *Tree, treeNode *TreeNode) {
 	c.Lock()
-	ce, ok := c.entries[uuid.UUID(tree.ID)]
-	if !ok {
-		ce = &cacheTTLEntry{
-			item:       make(map[TreeNodeID]*TreeNode),
-			expiration: time.Now().Add(c.entryExpiration),
-		}
+
+	var treeNodeMap map[TreeNodeID]*TreeNode
+	e := c.get(uuid.UUID(tree.ID))
+	if e == nil {
+		treeNodeMap = make(map[TreeNodeID]*TreeNode)
+	} else {
+		treeNodeMap = e.(map[TreeNodeID]*TreeNode)
 	}
-	treeNodeMap := ce.item.(map[TreeNodeID]*TreeNode)
+
 	// add treenode
 	treeNodeMap[treeNode.ID] = treeNode
 	// add parent if not root
@@ -188,24 +236,24 @@ func (c *treeNodeCacheTTL) Set(tree *Tree, treeNode *TreeNode) {
 		treeNodeMap[c.ID] = c
 	}
 	// add cache
-	c.entries[uuid.UUID(tree.ID)] = ce
+	c.set(uuid.UUID(tree.ID), treeNodeMap)
 	c.Unlock()
 }
 
 func (c *treeNodeCacheTTL) GetFromToken(tok *Token) *TreeNode {
 	c.Lock()
 	defer c.Unlock()
+
 	if tok == nil {
 		return nil
 	}
-	ce, ok := c.entries[uuid.UUID(tok.TreeID)]
-	if !ok || time.Now().After(ce.expiration) {
-		// no tree cached for this token
+
+	e := c.get(uuid.UUID(tok.TreeID))
+	if e == nil {
 		return nil
 	}
-	ce.expiration = time.Now().Add(c.entryExpiration)
 
-	treeNodeMap := ce.item.(map[TreeNodeID]*TreeNode)
+	treeNodeMap := e.(map[TreeNodeID]*TreeNode)
 	tn, ok := treeNodeMap[tok.TreeNodeID]
 	if !ok {
 		// no treeNode cached for this token

--- a/overlay.go
+++ b/overlay.go
@@ -12,7 +12,7 @@ import (
 )
 
 const expirationTime = 1 * time.Minute
-const cleanInterval = 5 * time.Minute
+const cacheSize = 1000
 
 // Overlay keeps all trees and entity-lists for a given Server. It creates
 // Nodes and ProtocolInstances upon request and dispatches the messages.
@@ -56,9 +56,9 @@ type Overlay struct {
 func NewOverlay(c *Server) *Overlay {
 	o := &Overlay{
 		server:             c,
-		treeCache:          newTreeCache(cleanInterval, expirationTime),
-		rosterCache:        newRosterCache(cleanInterval, expirationTime),
-		treeNodeCache:      newTreeNodeCache(cleanInterval, expirationTime),
+		treeCache:          newTreeCache(expirationTime, cacheSize),
+		rosterCache:        newRosterCache(expirationTime, cacheSize),
+		treeNodeCache:      newTreeNodeCache(expirationTime, cacheSize),
 		instances:          make(map[TokenID]*TreeNodeInstance),
 		instancesInfo:      make(map[TokenID]bool),
 		protocolInstances:  make(map[TokenID]ProtocolInstance),
@@ -75,13 +75,6 @@ func NewOverlay(c *Server) *Overlay {
 		SendRosterMsgID,    // send a roster back to request
 		ConfigMsgID)        // fetch config information
 	return o
-}
-
-// stop stops goroutines associated with this overlay.
-func (o *Overlay) stop() {
-	o.treeNodeCache.stop()
-	o.treeCache.stop()
-	o.rosterCache.stop()
 }
 
 // Process implements the Processor interface so it process the messages that it

--- a/server.go
+++ b/server.go
@@ -175,7 +175,6 @@ func (c *Server) Close() error {
 	}
 	c.serviceManager.servicesMutex.Unlock()
 	wg.Wait()
-	c.overlay.stop()
 	c.WebSocket.stop()
 	c.overlay.Close()
 	err := c.serviceManager.closeDatabase()


### PR DESCRIPTION
This PR changes the cache to use a LRU policy with a maximum number of entries. This maximum is for the moment static when instantiating the cache.

It also removes the goroutine that cleans the expired items by a simple check when getting elements as we can simply check the tail expiration.

Fixes #273 