### PR TITLE
New format for TLS CommonNames

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dedis/kyber/util/encoding"
 	"github.com/dedis/onet/log"
 )
 
@@ -110,7 +109,7 @@ func (r *Router) Start() {
 		if err != nil {
 			if !strings.Contains(err.Error(), "EOF") {
 				// Avoid printing error message if it's just a stray connection.
-				log.Errorf("receiving server identity from %s failed: %s",
+				log.Errorf("receiving server identity from %#v failed: %v",
 					c.Remote().NetworkAddress(), err)
 			}
 			if err := c.Close(); err != nil {
@@ -454,7 +453,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 			if len(cs.PeerCertificates) == 0 {
 				return nil, errors.New("TLS connection with no peer certs?")
 			}
-			pub, err := encoding.StringHexToPoint(tcpConn.suite, cs.PeerCertificates[0].Subject.CommonName)
+			pub, err := pubFromCN(tcpConn.suite, cs.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
 				return nil, err
 			}
@@ -470,7 +469,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 			}
 		}
 	}
-	log.Lvlf3("%s: Identity received si=%x from %s", r.address, dst.Public, dst.Address)
+	log.Lvlf3("%s: Identity received si=%v from %s", r.address, dst.Public, dst.Address)
 	return dst, nil
 }
 

--- a/network/tls.go
+++ b/network/tls.go
@@ -9,11 +9,13 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"net"
 	"time"
 
+	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/encoding"
 	"github.com/dedis/kyber/util/random"
@@ -83,10 +85,14 @@ func newCertMaker(s Suite, si *ServerIdentity) (*certMaker, error) {
 	}
 	cm.k = k
 
-	cm.subj = pkix.Name{CommonName: cm.si.Public.String()}
+	// This used to be "CommonName: cm.si.Public.String()", which
+	// results in the "old style" CommonName encoding in pubFromCN.
+	// This worked ok for ed25519 and nist, but not for bn256.g1. See
+	// dedis/onet#485.
+	cm.subj = pkix.Name{CommonName: pubToCN(cm.si.Public)}
 	der, err := asn1.Marshal(cm.subj.CommonName)
 	if err != nil {
-		panic("unexpected asn.1 marshal failure")
+		return nil, err
 	}
 	cm.subjDer = der
 	return cm, nil
@@ -115,7 +121,7 @@ func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
 	// key named in the CN.
 	//
 	// Do this using the same standardized ASN.1 marshaling that x509 uses so
-	// that anyone trying to check these signatures themselves in antoher language
+	// that anyone trying to check these signatures themselves in another language
 	// will be able to easily do so with their own x509 + kyber implementation.
 	buf := bytes.NewBuffer(nonce)
 	buf.Write(cm.subjDer)
@@ -305,8 +311,9 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 		// When we know who we are connecting to (e.g. client mode):
 		// Check that the CN is the same as the public key.
 		if them != nil {
-			err = cert.VerifyHostname(them.Public.String())
+			err = cert.VerifyHostname(pubToCN(them.Public))
 			if err != nil {
+				println("here", err.Error())
 				return err
 			}
 		}
@@ -325,13 +332,13 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 
 		// Check that the DEDIS signature is valid w.r.t. si.Public.
 		cn = cert.Subject.CommonName
-		pub, err := encoding.StringHexToPoint(suite, cert.Subject.CommonName)
+		pub, err := pubFromCN(suite, cn)
 		if err != nil {
 			return err
 		}
 
 		buf := bytes.NewBuffer(nonce)
-		subAsn1, err := asn1.Marshal(cert.Subject.CommonName)
+		subAsn1, err := asn1.Marshal(cn)
 		if err != nil {
 			return err
 		}
@@ -340,6 +347,37 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 
 		return err
 	}, nonce
+}
+
+func pubFromCN(suite kyber.Group, cn string) (kyber.Point, error) {
+	if len(cn) < 1 {
+		return nil, errors.New("commonName is missing a type byte")
+	}
+	tp := cn[0]
+
+	switch tp {
+	case 'Z':
+		// New style encoding: unhex and then unmarshal.
+		buf, err := hex.DecodeString(cn[1:])
+		if err != nil {
+			return nil, err
+		}
+		r := bytes.NewBuffer(buf)
+
+		pub := suite.Point()
+		_, err = pub.UnmarshalFrom(r)
+		return pub, err
+
+	default:
+		// Old style encoding: simply StringHexToPoint
+		return encoding.StringHexToPoint(suite, cn)
+	}
+}
+
+func pubToCN(pub kyber.Point) string {
+	w := &bytes.Buffer{}
+	pub.MarshalTo(w)
+	return "Z" + hex.EncodeToString(w.Bytes())
 }
 
 // tlsConfig returns a generic config that has things set as both the server

--- a/network/tls_test.go
+++ b/network/tls_test.go
@@ -5,20 +5,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/kyber/suites"
 	"github.com/dedis/kyber/util/key"
 	"github.com/stretchr/testify/require"
 )
 
-func NewTestTLSHost(port int) (*TCPHost, error) {
+func NewTestTLSHost(suite suites.Suite, port int) (*TCPHost, error) {
 	addr := NewTLSAddress("127.0.0.1:" + strconv.Itoa(port))
-	kp := key.NewKeyPair(tSuite)
+	kp := key.NewKeyPair(suite)
 	e := NewServerIdentity(kp.Public, addr)
 	e.SetPrivate(kp.Private)
-	return NewTCPHost(e, tSuite)
+	return NewTCPHost(e, suite)
 }
 
-func NewTestRouterTLS(port int) (*Router, error) {
-	h, err := NewTestTLSHost(port)
+func NewTestRouterTLS(suite suites.Suite, port int) (*Router, error) {
+	h, err := NewTestTLSHost(suite, port)
 	if err != nil {
 		return nil, err
 	}
@@ -32,16 +33,14 @@ type hello struct {
 	From  ServerIdentity
 }
 
-var aKey = key.NewKeyPair(tSuite)
-var aHello = &hello{
-	Hello: "Howdy, partner.",
-	From:  *NewServerIdentity(aKey.Public, "127.0.0.1:9999"),
+func TestTLS(t *testing.T) {
+	testTLS(t, tSuite)
 }
 
-func TestTLS(t *testing.T) {
-	r1, err := NewTestRouterTLS(0)
+func testTLS(t *testing.T, s suites.Suite) {
+	r1, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router")
-	r2, err := NewTestRouterTLS(0)
+	r2, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router 2")
 
 	ready := make(chan bool)
@@ -83,7 +82,10 @@ func TestTLS(t *testing.T) {
 	}()
 
 	// now send a message from r2 to r1
-	sentLen, err := r2.Send(r1.ServerIdentity, aHello)
+	sentLen, err := r2.Send(r1.ServerIdentity, &hello{
+		Hello: "Howdy.",
+		From:  *r2.ServerIdentity,
+	})
 	require.Nil(t, err, "Could not router.Send")
 	require.NotZero(t, sentLen)
 
@@ -99,9 +101,9 @@ func BenchmarkMsgTCP(b *testing.B) {
 }
 
 func BenchmarkMsgTLS(b *testing.B) {
-	r1, err := NewTestRouterTLS(0)
+	r1, err := NewTestRouterTLS(tSuite, 0)
 	require.Nil(b, err, "new tls router")
-	r2, err := NewTestRouterTLS(0)
+	r2, err := NewTestRouterTLS(tSuite, 0)
 	require.Nil(b, err, "new tls router 2")
 	benchmarkMsg(b, r1, r2)
 }
@@ -136,7 +138,10 @@ func benchmarkMsg(b *testing.B, r1, r2 *Router) {
 
 	// Send one message from r2 to r1.
 	for i := 0; i < b.N; i++ {
-		_, err := r2.Send(r1.ServerIdentity, aHello)
+		_, err := r2.Send(r1.ServerIdentity, &hello{
+			Hello: "Howdy.",
+			From:  *r2.ServerIdentity,
+		})
 		if err != nil {
 			b.Log("Could not router.Send")
 		}
@@ -152,4 +157,22 @@ func benchmarkMsg(b *testing.B, r1, r2 *Router) {
 			b.Fatal("Could not stop router", i)
 		}
 	}
+}
+
+func Test_pubFromCN(t *testing.T) {
+	p1 := tSuite.Point().Pick(tSuite.RandomStream())
+
+	// old-style
+	cn := p1.String()
+
+	p2, err := pubFromCN(tSuite, cn)
+	require.NoError(t, err)
+	require.True(t, p2.Equal(p1))
+
+	// new-style
+	cn = pubToCN(p1)
+
+	p2, err = pubFromCN(tSuite, cn)
+	require.NoError(t, err)
+	require.True(t, p2.Equal(p1))
 }

--- a/network/tls_vartime_test.go
+++ b/network/tls_vartime_test.go
@@ -1,0 +1,13 @@
+// +build vartime
+
+package network
+
+import (
+	"testing"
+
+	"github.com/dedis/kyber/suites"
+)
+
+func TestTLS_bn256g1(t *testing.T) {
+	testTLS(t, suites.MustFind("bn256.g1"))
+}


### PR DESCRIPTION
The previous format for the CommonName was the string encoding of the public key.
However, the string encodings are not intended to be able to do round-trips
from point->string->point. Instead, we use hex(marshal(point)), with a 'Z'
on the front to indicate in a backwards-compatible way that this is a new style
CommonName.

(Why 'Z'? Because the resulting CommonName must be a valid domain name. 'Z'
is an invalid hex digit, so if a new-style common name is sent to an old
onet implementation, an error will be thrown, which will more or less clearly
indicate the problem.)

Fixes #485.