### PR TITLE
Adding servers later

### DIFF
--- a/local.go
+++ b/local.go
@@ -69,6 +69,9 @@ type LocalTest struct {
 	// since now the temp directory is gone.
 	closed bool
 	T      *testing.T
+
+	// keep the latestPort used so that we can add nodes later
+	latestPort int
 }
 
 const (
@@ -87,16 +90,17 @@ func NewLocalTest(s network.Suite) *LocalTest {
 	}
 
 	return &LocalTest{
-		Servers:  make(map[network.ServerIdentityID]*Server),
-		Overlays: make(map[network.ServerIdentityID]*Overlay),
-		Services: make(map[network.ServerIdentityID]map[ServiceID]Service),
-		Trees:    make(map[TreeID]*Tree),
-		Nodes:    make([]*TreeNodeInstance, 0, 1),
-		Check:    CheckAll,
-		mode:     Local,
-		ctx:      network.NewLocalManager(),
-		Suite:    s,
-		path:     dir,
+		Servers:    make(map[network.ServerIdentityID]*Server),
+		Overlays:   make(map[network.ServerIdentityID]*Overlay),
+		Services:   make(map[network.ServerIdentityID]map[ServiceID]Service),
+		Trees:      make(map[TreeID]*Tree),
+		Nodes:      make([]*TreeNodeInstance, 0, 1),
+		Check:      CheckAll,
+		mode:       Local,
+		ctx:        network.NewLocalManager(),
+		Suite:      s,
+		path:       dir,
+		latestPort: 2000,
 	}
 }
 
@@ -532,7 +536,8 @@ func (l *LocalTest) genLocalHosts(n int) []*Server {
 	l.panicClosed()
 	servers := make([]*Server, n)
 	for i := 0; i < n; i++ {
-		port := 2000 + i*10
+		port := l.latestPort
+		l.latestPort += 10
 		servers[i] = l.NewServer(l.Suite, port)
 	}
 	return servers

--- a/local_test.go
+++ b/local_test.go
@@ -71,6 +71,14 @@ func TestGenLocalHost(t *testing.T) {
 	}
 }
 
+func TestGenLocalHostAfter(t *testing.T) {
+	l := NewLocalTest(tSuite)
+	defer l.CloseAll()
+	hosts := l.genLocalHosts(2)
+	hosts2 := l.genLocalHosts(2)
+	require.NotEqual(t, hosts2[0].Address(), hosts[0].Address())
+}
+
 // This tests the client-connection in the case of a non-garbage-collected
 // client that stays in the service.
 func TestNewTCPTest(t *testing.T) {


### PR DESCRIPTION
For a new test with new nodes it is easier to create a first set of nodes, then
add the second set of nodes later.