### PR TITLE
Do not panic on failure to start a service.

### DIFF
--- a/service.go
+++ b/service.go
@@ -257,7 +257,7 @@ func newServiceManager(srv *Server, o *Overlay, dbPath string, delDb bool) *serv
 
 		srvc, err := ServiceFactory.start(name, cont)
 		if err != nil {
-			log.Panic("Trying to instantiate service", name, ": error=", err)
+			log.Fatalf("Trying to instantiate service %v: %v", name, err)
 		}
 		log.Lvl3("Started Service", name)
 		s.servicesMutex.Lock()


### PR DESCRIPTION
The panic was too noisy, fatal lets the user more easily find and read the error message.

This is needed to make the ByzCoin database version message more visible.