### PR TITLE
Fix TreeNodeInstance rx status

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -39,6 +39,8 @@ type ProtocolMsg struct {
 	Msg network.Message
 	// The actual data as binary blob
 	MsgSlice []byte
+	// The size of the data
+	Size int
 }
 
 // ConfigMsg is sent by the overlay containing a generic slice of bytes to

--- a/network/local.go
+++ b/network/local.go
@@ -294,6 +294,7 @@ func (lc *LocalConn) Receive() (*Envelope, error) {
 	return &Envelope{
 		MsgType: id,
 		Msg:     body,
+		Size:    len(buff),
 	}, err
 }
 

--- a/network/struct.go
+++ b/network/struct.go
@@ -59,6 +59,8 @@ type Envelope struct {
 	MsgType MessageTypeID
 	// A *pointer* to the underlying message
 	Msg Message
+	// The length of the message in bytes
+	Size int
 	// which constructors are used
 	Constructors protobuf.Constructors
 }

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -110,6 +110,7 @@ func (c *TCPConn) Receive() (env *Envelope, e error) {
 	return &Envelope{
 		MsgType: id,
 		Msg:     body,
+		Size:    len(buff),
 	}, err
 }
 

--- a/overlay.go
+++ b/overlay.go
@@ -103,6 +103,11 @@ func (o *Overlay) Process(env *network.Envelope) {
 	case info.Roster != nil:
 		o.handleSendRoster(env.ServerIdentity, info.Roster)
 	default:
+		buf, err := network.Marshal(env.Msg)
+		if err != nil {
+			log.Errorf("Error when marshaling a message: %s", err)
+		}
+
 		typ := network.MessageType(inner)
 		protoMsg := &ProtocolMsg{
 			From:           info.TreeNodeInfo.From,
@@ -110,8 +115,9 @@ func (o *Overlay) Process(env *network.Envelope) {
 			ServerIdentity: env.ServerIdentity,
 			Msg:            inner,
 			MsgType:        typ,
+			MsgSlice:       buf,
 		}
-		err := o.TransmitMsg(protoMsg, io)
+		err = o.TransmitMsg(protoMsg, io)
 		if err != nil {
 			log.Errorf("Msg %s from %s produced error: %s", protoMsg.MsgType,
 				protoMsg.ServerIdentity, err.Error())

--- a/overlay.go
+++ b/overlay.go
@@ -93,7 +93,7 @@ func (o *Overlay) Process(env *network.Envelope) {
 		log.Error("unwrapping: ", err)
 		return
 	}
-	switch true {
+	switch {
 	case info.RequestTree != nil:
 		o.handleRequestTree(env.ServerIdentity, info.RequestTree, io)
 	case info.TreeMarshal != nil:
@@ -103,11 +103,6 @@ func (o *Overlay) Process(env *network.Envelope) {
 	case info.Roster != nil:
 		o.handleSendRoster(env.ServerIdentity, info.Roster)
 	default:
-		buf, err := network.Marshal(env.Msg)
-		if err != nil {
-			log.Errorf("Error when marshaling a message: %s", err)
-		}
-
 		typ := network.MessageType(inner)
 		protoMsg := &ProtocolMsg{
 			From:           info.TreeNodeInfo.From,
@@ -115,7 +110,7 @@ func (o *Overlay) Process(env *network.Envelope) {
 			ServerIdentity: env.ServerIdentity,
 			Msg:            inner,
 			MsgType:        typ,
-			MsgSlice:       buf,
+			Size:           env.Size,
 		}
 		err = o.TransmitMsg(protoMsg, io)
 		if err != nil {

--- a/treenode.go
+++ b/treenode.go
@@ -493,7 +493,7 @@ func (n *TreeNodeInstance) dispatchMsgReader() {
 // dispatchMsgToProtocol will dispatch this onet.Data to the right instance
 func (n *TreeNodeInstance) dispatchMsgToProtocol(onetMsg *ProtocolMsg) error {
 
-	n.rx.add(uint64(len(onetMsg.MsgSlice)))
+	n.rx.add(uint64(onetMsg.Size))
 
 	// if message comes from parent, dispatch directly
 	// if messages come from children we must aggregate them


### PR DESCRIPTION
This fixes the rx status that was always 0 even
after processing a message.

Fixes #481