### PR TITLE
Roster concatenation

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -701,6 +701,24 @@ func (ro *Roster) Contains(pubs []kyber.Point) bool {
 	return true
 }
 
+// Concat makes a new roster using an existing one and a list
+// of server identities
+func (ro *Roster) Concat(sis []*network.ServerIdentity) *Roster {
+	roMap := make(map[string]*network.ServerIdentity)
+	for _, si := range append(ro.List, sis...) {
+		roMap[si.String()] = si
+	}
+
+	newList := make([]*network.ServerIdentity, len(roMap))
+	i := 0
+	for _, si := range roMap {
+		newList[i] = si
+		i++
+	}
+
+	return NewRoster(newList)
+}
+
 // addNary is a recursive function to create the binary tree.
 func (ro *Roster) addNary(parent *TreeNode, N, start, end int) *TreeNode {
 	if !(start <= end && end < len(ro.List)) {

--- a/tree.go
+++ b/tree.go
@@ -709,11 +709,9 @@ func (ro *Roster) Concat(sis []*network.ServerIdentity) *Roster {
 		roMap[si.String()] = si
 	}
 
-	newList := make([]*network.ServerIdentity, len(roMap))
-	i := 0
+	newList := make([]*network.ServerIdentity, 0)
 	for _, si := range roMap {
-		newList[i] = si
-		i++
+		newList = append(newList, si)
 	}
 
 	return NewRoster(newList)

--- a/tree_test.go
+++ b/tree_test.go
@@ -550,6 +550,22 @@ func TestRoster_Contains(t *testing.T) {
 	require.False(t, roster.Contains(pubs[1:]))
 }
 
+// Checks that you can concatenate two rosters together
+// without duplicates
+func TestRoster_Concat(t *testing.T) {
+	_, roster := genLocalTree(10, 2000)
+
+	r1 := NewRoster(roster.List[:7])
+	r2 := NewRoster(roster.List[2:])
+
+	r := r1.Concat(r2.List)
+	require.Equal(t, 10, len(r.List))
+	require.True(t, r.Contains(roster.Publics()))
+
+	r = r1.Concat([]*network.ServerIdentity{})
+	require.Equal(t, len(r1.List), len(r.List))
+}
+
 func TestTreeNode_AggregatePublic(t *testing.T) {
 	tree, el := genLocalTree(7, 2000)
 	agg := el.Aggregate


### PR DESCRIPTION
This adds a function that will create a new roster using an existing
one and a list of server identities.

The helper function will be use to concatenate two rosters from two different blocks when propagating forward-links so that every conode implied will know about it.