### PR TITLE
Catching errors and improving shutdown

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -158,6 +158,9 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 		// request the PI from the Service and binds the two
 		pi, err = o.server.serviceManager.newProtocol(tni, config)
 		if err != nil {
+			o.instancesLock.Lock()
+			o.nodeDelete(onetMsg.To)
+			o.instancesLock.Unlock()
 			return err
 		}
 		if pi == nil {

--- a/service.go
+++ b/service.go
@@ -426,6 +426,10 @@ func (s *serviceManager) serviceByID(id ServiceID) (Service, bool) {
 // the creation of the PI. Otherwise the service is responsible for setting up
 // the PI.
 func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfig) (pi ProtocolInstance, err error) {
+	if s.server.Closed() {
+		err = errors.New("will not pass protocol once the server is closed")
+		return
+	}
 	si, ok := s.serviceByID(tni.Token().ServiceID)
 	defaultHandle := func() (ProtocolInstance, error) { return s.server.protocolInstantiate(tni.Token().ProtoID, tni) }
 	if !ok {

--- a/treenode.go
+++ b/treenode.go
@@ -338,6 +338,11 @@ func (n *TreeNodeInstance) Shutdown() error {
 
 // closeDispatch shuts down the go-routine and calls the protocolInstance-shutdown
 func (n *TreeNodeInstance) closeDispatch() error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Recovered panic:", r)
+		}
+	}()
 	log.Lvl3("Closing node", n.Info())
 	n.msgDispatchQueueMutex.Lock()
 	n.closing = true
@@ -617,6 +622,7 @@ func (n *TreeNodeInstance) Public() kyber.Point {
 // NOTE: It is to be used VERY carefully and is likely to disappear in the next
 // releases.
 func (n *TreeNodeInstance) CloseHost() error {
+	n.Host().callTestClose()
 	return n.Host().Close()
 }
 


### PR DESCRIPTION
Some errors were not caught when shutting down the service and Treenodes.
Also the shutdown-logic has been changed to start calling  before shutting down the server.