### PR TITLE
Fix 32-bit architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,11 @@ install:
 script:
   - make test
 
+matrix:
+  include:
+    - name: "64-bit Unit Tests"
+    - name: "32-bit Unit Tests"
+      env: GOARCH=386
+
 notifications:
   email: false

--- a/context_test.go
+++ b/context_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 type ContextData struct {
-	I int
+	I int64
 	S string
 }
 
@@ -41,8 +41,9 @@ func TestContextSaveLoad(t *testing.T) {
 	wg.Add(nbr)
 	for i := range c {
 		go func(i int) {
+			// defer insures the call even on a panic
+			defer wg.Done()
 			testLoadSave(t, c[i])
-			wg.Done()
 		}(i)
 	}
 	wg.Wait()

--- a/messages.go
+++ b/messages.go
@@ -40,7 +40,7 @@ type ProtocolMsg struct {
 	// The actual data as binary blob
 	MsgSlice []byte
 	// The size of the data
-	Size int
+	Size network.Size
 }
 
 // ConfigMsg is sent by the overlay containing a generic slice of bytes to

--- a/network/big_test.go
+++ b/network/big_test.go
@@ -30,7 +30,7 @@ func TestTCPHugeConnections(t *testing.T) {
 	// the maximum number of connections using the above snippet.
 	nbrHosts := 10
 	// 1MB of message size
-	msgSize := 1024 * 1024 * 1
+	msgSize := int64(1024 * 1024 * 1)
 	big := bigMessage{
 		Msize: msgSize,
 		Msg:   make([]byte, msgSize),
@@ -147,7 +147,7 @@ func TestTCPHugeConnections(t *testing.T) {
 }
 
 type bigMessage struct {
-	Msize int
+	Msize int64
 	Msg   []byte
-	Pcrc  int
+	Pcrc  int64
 }

--- a/network/encoding_test.go
+++ b/network/encoding_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 type TestRegisterS1 struct {
-	I int
+	I int64
 }
 type TestRegisterS2 struct {
-	I int
+	I int64
 }
 
 func TestRegisterMessage(t *testing.T) {
@@ -50,7 +50,7 @@ func TestUnmarshalRegister(t *testing.T) {
 	ty, b, err := Unmarshal(buff, tSuite)
 	assert.Nil(t, err)
 	assert.Equal(t, trType, ty)
-	assert.Equal(t, 10, b.(*TestRegisterS1).I)
+	assert.Equal(t, int64(10), b.(*TestRegisterS1).I)
 
 	var randType [16]byte
 	rand.Read(randType[:])

--- a/network/local.go
+++ b/network/local.go
@@ -294,7 +294,7 @@ func (lc *LocalConn) Receive() (*Envelope, error) {
 	return &Envelope{
 		MsgType: id,
 		Msg:     body,
-		Size:    len(buff),
+		Size:    Size(len(buff)),
 	}, err
 }
 

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -148,7 +148,7 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 	// make the listener send and receive a struct that only they can know (this
 	// listener + conn
 	handshake := func(c Conn, sending, receiving Address) error {
-		sentLen, err := c.Send(&AddressTest{sending, secret})
+		sentLen, err := c.Send(&AddressTest{sending, int64(secret)})
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 		if at.Addr != receiving {
 			return fmt.Errorf("Receiveid wrong address")
 		}
-		if at.Val != secret {
+		if at.Val != int64(secret) {
 			return fmt.Errorf("Received wrong secret")
 		}
 		return nil
@@ -244,7 +244,7 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 			incomingConn <- true
 			nm, err := c.Receive()
 			assert.Nil(t, err)
-			assert.Equal(t, 3, nm.Msg.(*SimpleMessage).I)
+			assert.Equal(t, int64(3), nm.Msg.(*SimpleMessage).I)
 			// acknoledge the message
 			incomingConn <- true
 			sentLen, err := c.Send(&SimpleMessage{3})
@@ -278,7 +278,7 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 	// receive stg and send ack
 	nm, err := outgoing.Receive()
 	assert.Nil(t, err)
-	assert.Equal(t, 3, nm.Msg.(*SimpleMessage).I)
+	assert.Equal(t, int64(3), nm.Msg.(*SimpleMessage).I)
 	outgoingConn <- true
 
 	<-incomingConn
@@ -327,7 +327,7 @@ func TestLocalManyConn(t *testing.T) {
 			assert.NotZero(t, sentLen)
 			nm, err := c.Receive()
 			assert.Nil(t, err)
-			assert.Equal(t, 3, nm.Msg.(*SimpleMessage).I)
+			assert.Equal(t, int64(3), nm.Msg.(*SimpleMessage).I)
 			assert.Nil(t, c.Close())
 			wg.Done()
 		}(i)
@@ -361,7 +361,7 @@ func NewTestLocalHost(port int) (*LocalHost, error) {
 
 type AddressTest struct {
 	Addr Address
-	Val  int
+	Val  int64
 }
 
 var AddressTestType = RegisterMessage(&AddressTest{})

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -104,7 +104,7 @@ func TestRouterErrorHandling(t *testing.T) {
 	require.Nil(t, err)
 	require.NotZero(t, sentLen)
 	decoded := <-proc.relay
-	require.Equal(t, 3, decoded.I)
+	require.Equal(t, int64(3), decoded.I)
 	sentLen, err = h2.Send(h1.ServerIdentity, msgSimple)
 	require.Nil(t, err)
 	require.NotZero(t, sentLen)
@@ -142,7 +142,7 @@ func TestRouterSendToSelf(t *testing.T) {
 	require.Nil(t, err)
 	require.NotZero(t, sentLen)
 	decoded := <-proc.relay
-	require.Equal(t, 3, decoded.I)
+	require.Equal(t, int64(3), decoded.I)
 
 	// Ensure no connections were open (since sending to ourself)
 	r.Lock()
@@ -279,7 +279,7 @@ func TestRouterMessaging(t *testing.T) {
 	require.NotZero(t, sentLen)
 
 	decoded := <-proc.relay
-	require.Equal(t, 3, decoded.I)
+	require.Equal(t, int64(3), decoded.I)
 
 	// make sure the connection is registered in host1 (because it's launched in
 	// a go routine). Since we try to avoid random timeout, let's send a msg
@@ -289,7 +289,7 @@ func TestRouterMessaging(t *testing.T) {
 	require.NotZero(t, sentLen)
 
 	decoded = <-proc.relay
-	require.Equal(t, 3, decoded.I)
+	require.Equal(t, int64(3), decoded.I)
 
 	written := h1.Tx()
 	read := h2.Rx()

--- a/network/struct.go
+++ b/network/struct.go
@@ -60,7 +60,7 @@ type Envelope struct {
 	// A *pointer* to the underlying message
 	Msg Message
 	// The length of the message in bytes
-	Size int
+	Size Size
 	// which constructors are used
 	Constructors protobuf.Constructors
 }

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -110,7 +110,7 @@ func (c *TCPConn) Receive() (env *Envelope, e error) {
 	return &Envelope{
 		MsgType: id,
 		Msg:     body,
-		Size:    len(buff),
+		Size:    Size(len(buff)),
 	}, err
 }
 

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -634,7 +634,7 @@ func NewTestServerIdentity(address Address) *ServerIdentity {
 
 // SimpleMessage is just used to transfer one integer
 type SimpleMessage struct {
-	I int
+	I int64
 }
 
 var SimpleMessageType MessageTypeID
@@ -661,7 +661,7 @@ func (smp *simpleMessageProc) Process(e *Envelope) {
 
 type statusMessage struct {
 	Ok  bool
-	Val int
+	Val int64
 }
 
 var statusMsgID = RegisterMessage(statusMessage{})

--- a/node_test.go
+++ b/node_test.go
@@ -247,7 +247,7 @@ func TestTreeNodeFlags(t *testing.T) {
 
 // Protocol/service Channels test code:
 type NodeTestMsg struct {
-	I int
+	I int64
 }
 
 var Incoming chan struct {
@@ -256,7 +256,7 @@ var Incoming chan struct {
 }
 
 type NodeTestAggMsg struct {
-	I int
+	I int64
 }
 
 type ProtocolChannels struct {

--- a/processor_test.go
+++ b/processor_test.go
@@ -2,9 +2,8 @@ package onet
 
 import (
 	"errors"
-	"testing"
-
 	"reflect"
+	"testing"
 
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -154,7 +153,7 @@ func TestServiceProcessor_ProcessClientRequest_Streaming(t *testing.T) {
 	h := func(m *testMsg) (chan network.Message, chan bool, error) {
 		outChan := make(chan network.Message)
 		go func() {
-			for i := 0; i < m.I; i++ {
+			for i := 0; i < int(m.I); i++ {
 				outChan <- m
 			}
 			close(outChan)
@@ -164,7 +163,7 @@ func TestServiceProcessor_ProcessClientRequest_Streaming(t *testing.T) {
 	require.Nil(t, p.RegisterStreamingHandler(h))
 
 	n := 5
-	buf, err := protobuf.Encode(&testMsg{n})
+	buf, err := protobuf.Encode(&testMsg{int64(n)})
 	require.NoError(t, err)
 	rep, tun, err := p.ProcessClientRequest(nil, "testMsg", buf)
 	require.Nil(t, rep)
@@ -178,7 +177,7 @@ func TestServiceProcessor_ProcessClientRequest_Streaming(t *testing.T) {
 			buf := <-tun.out
 			val := &testMsg{}
 			require.Nil(t, protobuf.Decode(buf, val))
-			require.Equal(t, val.I, n)
+			require.Equal(t, val.I, int64(n))
 		}
 	}
 }
@@ -203,7 +202,7 @@ func TestProcessor_ProcessClientRequest(t *testing.T) {
 }
 
 type testMsg struct {
-	I int
+	I int64
 }
 
 type testMsg2 testMsg

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -91,7 +91,7 @@ func (p *SimpleProtocol) ReturnError(msg MsgSimpleMessage) error {
 }
 
 type SimpleMessage struct {
-	I int
+	I int64
 }
 
 type MsgSimpleMessage struct {

--- a/simul/manage/count.go
+++ b/simul/manage/count.go
@@ -2,9 +2,8 @@ package manage
 
 import (
 	"errors"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -58,7 +57,7 @@ type NodeIsUp struct{}
 
 // Count sends the number of children to the parent node.
 type Count struct {
-	Children int
+	Children int32
 }
 
 // CountMsg is wrapper around the Count-structure
@@ -163,11 +162,11 @@ func (p *ProtocolCount) FuncPC() {
 func (p *ProtocolCount) FuncC(cc []CountMsg) {
 	count := 1
 	for _, c := range cc {
-		count += c.Count.Children
+		count += int(c.Count.Children)
 	}
 	if !p.IsRoot() {
 		log.Lvl3(p.Info(), "Sends to", p.Parent().ID, p.Parent().ServerIdentity.Address)
-		if err := p.SendTo(p.Parent(), &Count{count}); err != nil {
+		if err := p.SendTo(p.Parent(), &Count{int32(count)}); err != nil {
 			log.Lvl2(p.Name(), "coouldn't send to parent",
 				p.Parent().Name())
 		}

--- a/treenode_test.go
+++ b/treenode_test.go
@@ -195,7 +195,7 @@ func (s *spawnProto) Start() error {
 }
 
 type spawn struct {
-	I int
+	I int64
 }
 
 type spawnMsg struct {


### PR DESCRIPTION
This PR first fixes test that were crashing in the middle of wait groups and then hanging the whole suite.

It also fixes the messages used in the tests so that the new job added in Travis that is running in 386 mode passes.

Finally it fixes the issue caused by the int field in ProtocolMsg.

Fixes #505