### PR TITLE
Change the default port base when generating hosts

### DIFF
--- a/local.go
+++ b/local.go
@@ -69,9 +69,6 @@ type LocalTest struct {
 	// since now the temp directory is gone.
 	closed bool
 	T      *testing.T
-
-	// keep the latestPort used so that we can add nodes later
-	latestPort int
 }
 
 const (
@@ -90,17 +87,16 @@ func NewLocalTest(s network.Suite) *LocalTest {
 	}
 
 	return &LocalTest{
-		Servers:    make(map[network.ServerIdentityID]*Server),
-		Overlays:   make(map[network.ServerIdentityID]*Overlay),
-		Services:   make(map[network.ServerIdentityID]map[ServiceID]Service),
-		Trees:      make(map[TreeID]*Tree),
-		Nodes:      make([]*TreeNodeInstance, 0, 1),
-		Check:      CheckAll,
-		mode:       Local,
-		ctx:        network.NewLocalManager(),
-		Suite:      s,
-		path:       dir,
-		latestPort: 2000,
+		Servers:  make(map[network.ServerIdentityID]*Server),
+		Overlays: make(map[network.ServerIdentityID]*Overlay),
+		Services: make(map[network.ServerIdentityID]map[ServiceID]Service),
+		Trees:    make(map[TreeID]*Tree),
+		Nodes:    make([]*TreeNodeInstance, 0, 1),
+		Check:    CheckAll,
+		mode:     Local,
+		ctx:      network.NewLocalManager(),
+		Suite:    s,
+		path:     dir,
 	}
 }
 
@@ -552,9 +548,7 @@ func (l *LocalTest) genLocalHosts(n int) []*Server {
 	l.panicClosed()
 	servers := make([]*Server, n)
 	for i := 0; i < n; i++ {
-		port := l.latestPort
-		l.latestPort += 10
-		servers[i] = l.NewServer(l.Suite, port)
+		servers[i] = l.NewServer(l.Suite, network.GetFreePort())
 	}
 	return servers
 }

--- a/local_test.go
+++ b/local_test.go
@@ -1,6 +1,7 @@
 package onet
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -61,14 +62,25 @@ func Test_showFail(t *testing.T) {
 }
 
 func TestGenLocalHost(t *testing.T) {
-	l := NewLocalTest(tSuite)
-	hosts := l.genLocalHosts(2)
-	defer l.CloseAll()
+	n := 5
+	wg := sync.WaitGroup{}
+	wg.Add(n)
 
-	log.Lvl4("Hosts are:", hosts[0].Address(), hosts[1].Address())
-	if hosts[0].Address() == hosts[1].Address() {
-		t.Fatal("Both addresses are equal")
+	for i := 0; i < n; i++ {
+		go func() {
+			l := NewLocalTest(tSuite)
+			defer l.CloseAll()
+			defer wg.Done()
+
+			hosts := l.genLocalHosts(2)
+
+			if hosts[0].Address() == hosts[1].Address() {
+				t.Fatal("Both addresses are equal")
+			}
+		}()
 	}
+
+	wg.Wait()
 }
 
 func TestGenLocalHostAfter(t *testing.T) {

--- a/network/port.go
+++ b/network/port.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"flag"
+	"sync"
+)
+
+const rangePort = 3000
+
+var flagPort int
+var latestPort int
+var lockPort sync.Mutex
+
+func init() {
+	flag.IntVar(&flagPort, "baseport", 2000, "first value when generating network hosts")
+	flag.Parse()
+	latestPort = flagPort
+}
+
+// GetFreePort returns the next available port. When running multiple test at the same time,
+// you need to change the base used to generate hosts by using:
+// 	go test -args -baseport=[0-9]+
+//
+// Note that this is not thread-safe and the tests should run using the -p parameter
+func GetFreePort() int {
+	lockPort.Lock()
+	defer lockPort.Unlock()
+	defer incrementPort()
+
+	return latestPort
+}
+
+func incrementPort() {
+	latestPort += 10
+	latestPort %= flagPort + rangePort
+}


### PR DESCRIPTION
One recurrent problem on Jenkins is caused by multiple jobs running in parallel and causing conflicts with port binding. This PR tries to fix that issue by using a parameter that allows to change the base (currently 2000) when generating hosts.

I explored different options to even work on multithreading executions but this would require a lock in a file or similar and that would be dangerous when the cleaning routine fails.