### PR TITLE
Assert that packets' sender address is correct

### DIFF
--- a/treenode.go
+++ b/treenode.go
@@ -407,6 +407,12 @@ func (n *TreeNodeInstance) reflectCreate(t reflect.Type, msg *ProtocolMsg) refle
 			m.Field(0).Set(reflect.ValueOf(tn))
 			m.Field(1).Set(reflect.Indirect(reflect.ValueOf(msg.Msg)))
 		}
+		// Check whether the sender treenode actually is the same as the node who sent it.
+		// We can trust msg.ServerIdentity, because it is written in Router.handleConn and
+		// is not writable by the sending node.
+		if !tn.ServerIdentity.Equal(msg.ServerIdentity){
+			panic("Attack detected")
+		}
 	}
 	return m
 }


### PR DESCRIPTION
@jeffallen discovered an attack where a node maliciously changes the  field of the
message being sent to a node, thus impersonating another node in the system.
This patch verifies that the sender is correct.

TODO: better catch the error.