### PR TITLE
Recover panic 1725

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -419,6 +419,13 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 		if err != nil {
 			log.Error(err)
 		}
+
+		for _, srvid := range id.ServiceIdentities {
+			_, err = srvid.Public.MarshalTo(h)
+			if err != nil {
+				log.Error(err)
+			}
+		}
 	}
 
 	r := &Roster{


### PR DESCRIPTION
The server can crash if a panic occurs during a protocol execution so this PR adds the missing recover to prevent the crash and log the event.

It also updates how the roster ID is generated to include the service keys. This PR changes the Go part but the Java and Javascript generation needs to be fixed also (even if that doesn't break the tests right away).

Fixes dedis/cothority#1725