### PR TITLE
Cd into modules directory to do go build

### DIFF
--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -5,12 +5,10 @@ package platform
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"go.dedis.ch/onet/v3/log"
 )
@@ -100,9 +98,14 @@ func Build(path, out, goarch, goos string, buildArgs ...string) (string, error) 
 	buildBuffer := bufio.NewWriter(&b)
 	wd, _ := os.Getwd()
 	log.Lvl4("In directory", wd)
-	// we have to cd into the directory to do the build when using go
-	// modules, not sure about the exact reason for this behaviour yet
-	cmd = exec.Command("/bin/bash", "-c", fmt.Sprintf("(cd %s && go build -v %s -o %s)", path, strings.Join(buildArgs, " "), out))
+	var args []string
+	args = append(args, "build", "-v")
+	args = append(args, buildArgs...)
+	args = append(args, "-o", out)
+	cmd = exec.Command("go", args...)
+	// we have to change the working directory to do the build when using
+	// go modules, not sure about the exact reason for this behaviour yet
+	cmd.Dir = path
 	log.Lvl4("Building", cmd.Args, "in", path)
 	cmd.Stdout = buildBuffer
 	cmd.Stderr = buildBuffer

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -5,10 +5,12 @@ package platform
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"go.dedis.ch/onet/v3/log"
 )
@@ -98,11 +100,9 @@ func Build(path, out, goarch, goos string, buildArgs ...string) (string, error) 
 	buildBuffer := bufio.NewWriter(&b)
 	wd, _ := os.Getwd()
 	log.Lvl4("In directory", wd)
-	var args []string
-	args = append(args, "build", "-v")
-	args = append(args, buildArgs...)
-	args = append(args, "-o", out, path)
-	cmd = exec.Command("go", args...)
+	// we have to cd into the directory to do the build when using go
+	// modules, not sure about the exact reason for this behaviour yet
+	cmd = exec.Command("/bin/bash", "-c", fmt.Sprintf("(cd %s && go build -v %s -o %s)", path, strings.Join(buildArgs, " "), out))
 	log.Lvl4("Building", cmd.Args, "in", path)
 	cmd.Stdout = buildBuffer
 	cmd.Stderr = buildBuffer

--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -184,7 +184,7 @@ func (d *Deterlab) Build(build string, arg ...string) error {
 			}
 			if err != nil {
 				KillGo()
-				log.Lvl1(out)
+				log.Error(out)
 				log.Fatal(err)
 			}
 		}(p)

--- a/utils.go
+++ b/utils.go
@@ -35,7 +35,7 @@ func ReadTomlConfig(conf interface{}, filename string, dirOpt ...string) error {
 
 	_, err = toml.Decode(string(buf), conf)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("failed to parse " + filename + ": " + err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Fixes the deterlab part of dedis/cothority#1763

Tested on deterlab with normal go.mod file and `redirect`.