### PR TITLE
Fix the roster ID generation

### DIFF
--- a/network/struct.go
+++ b/network/struct.go
@@ -120,6 +120,21 @@ func NewServiceIdentityFromPair(name string, suite suites.Suite, kp *key.Pair) S
 	return NewServiceIdentity(name, suite, kp.Public, kp.Private)
 }
 
+// ServiceIdentities provides definitions to sort the array by service name
+type ServiceIdentities []ServiceIdentity
+
+func (srvids ServiceIdentities) Len() int {
+	return len(srvids)
+}
+
+func (srvids ServiceIdentities) Swap(i, j int) {
+	srvids[i], srvids[j] = srvids[j], srvids[i]
+}
+
+func (srvids ServiceIdentities) Less(i, j int) bool {
+	return strings.Compare(srvids[i].Name, srvids[j].Name) == -1
+}
+
 // String returns a canonical representation of the ServerIdentityID.
 func (eId ServerIdentityID) String() string {
 	return uuid.UUID(eId).String()

--- a/tree.go
+++ b/tree.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -420,6 +421,7 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 			log.Error(err)
 		}
 
+		sort.Sort(network.ServiceIdentities(id.ServiceIdentities))
 		for _, srvid := range id.ServiceIdentities {
 			_, err = srvid.Public.MarshalTo(h)
 			if err != nil {

--- a/tree.go
+++ b/tree.go
@@ -378,6 +378,7 @@ func (tm *TreeMarshal) MakeTreeFromList(parent *TreeNode, ro *Roster) (*TreeNode
 // A Roster is a list of ServerIdentity we choose to run some tree on it ( and
 // therefor some protocols). Access is not safe from multiple goroutines.
 type Roster struct {
+	// Deprecated: ID can be generated using the list of server identities. Use GetID instead.
 	ID RosterID
 	// List is the list of actual entities.
 	List      []*network.ServerIdentity
@@ -421,7 +422,6 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 			log.Error(err)
 		}
 
-		sort.Sort(network.ServiceIdentities(id.ServiceIdentities))
 		for _, srvid := range id.ServiceIdentities {
 			_, err = srvid.Public.MarshalTo(h)
 			if err != nil {
@@ -451,6 +451,28 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 		r.Aggregate = agg
 	}
 	return r
+}
+
+// GetID generates the ID for the list of server identities of the roster
+func (ro *Roster) GetID() (RosterID, error) {
+	h := sha256.New()
+	for _, id := range ro.List {
+		_, err := id.Public.MarshalTo(h)
+		if err != nil {
+			return RosterID{}, err
+		}
+
+		// order is important for the hash
+		sort.Sort(network.ServiceIdentities(id.ServiceIdentities))
+		for _, srvid := range id.ServiceIdentities {
+			_, err = srvid.Public.MarshalTo(h)
+			if err != nil {
+				return RosterID{}, err
+			}
+		}
+	}
+
+	return RosterID(uuid.NewV5(uuid.NamespaceURL, hex.EncodeToString(h.Sum(nil)))), nil
 }
 
 // Search searches the Roster for the given ServerIdentityID and returns the
@@ -756,6 +778,21 @@ func (ro *Roster) Contains(pubs []kyber.Point) bool {
 	}
 
 	return true
+}
+
+// Equal checks if two roster are the same by checking the generated ID
+func (ro *Roster) Equal(other *Roster) (bool, error) {
+	roID, err := ro.GetID()
+	if err != nil {
+		return false, err
+	}
+
+	otherID, err := other.GetID()
+	if err != nil {
+		return false, err
+	}
+
+	return roID.Equal(otherID), nil
 }
 
 // Concat makes a new roster using an existing one and a list

--- a/tree_test.go
+++ b/tree_test.go
@@ -432,6 +432,7 @@ func TestTreeNode_SubtreeCount(t *testing.T) {
 	}
 }
 
+// Deprecated: the ID should be gotten using GetID
 func TestRoster_ID(t *testing.T) {
 	names := genLocalhostPeerNames(10, 2000)
 	ro := genRoster(tSuite, names)
@@ -439,10 +440,37 @@ func TestRoster_ID(t *testing.T) {
 
 	assert.True(t, ro.ID.Equal(ro2.ID))
 
+	// check missing service identities
+	tt := []*network.ServerIdentity{}
+	for _, id := range ro.List {
+		tt = append(tt, network.NewServerIdentity(id.Public, id.Address))
+	}
+
+	ro3 := NewRoster(tt)
+	assert.False(t, ro3.ID.Equal(ro.ID))
+}
+
+func TestRoster_GetID(t *testing.T) {
+	names := genLocalhostPeerNames(10, 2000)
+	ro := genRoster(tSuite, names)
+	ro2 := NewRoster(ro.List)
+
+	roID, err := ro.GetID()
+	require.NoError(t, err)
+	ro2ID, err := ro2.GetID()
+	require.NoError(t, err)
+	require.True(t, roID.Equal(ro2ID))
+	ok, _ := ro.Equal(ro2)
+	require.True(t, ok)
+
 	// check unordered service identities
 	ro.List[0].ServiceIdentities[0], ro.List[0].ServiceIdentities[1] = ro.List[0].ServiceIdentities[1], ro.List[0].ServiceIdentities[0]
 	ro3 := NewRoster(ro.List)
-	assert.True(t, ro.ID.Equal(ro3.ID))
+	ro3ID, err := ro3.GetID()
+	require.NoError(t, err)
+	require.True(t, roID.Equal(ro3ID))
+	ok, _ = ro.Equal(ro3)
+	require.True(t, ok)
 
 	// check missing service identities
 	tt := []*network.ServerIdentity{}
@@ -451,7 +479,11 @@ func TestRoster_ID(t *testing.T) {
 	}
 
 	ro4 := NewRoster(tt)
-	assert.False(t, ro4.ID.Equal(ro.ID))
+	ro4ID, err := ro4.GetID()
+	require.NoError(t, err)
+	require.False(t, ro4ID.Equal(roID))
+	ok, _ = ro.Equal(ro4)
+	require.False(t, ok)
 }
 
 func TestRoster_GenerateNaryTree(t *testing.T) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -439,13 +439,19 @@ func TestRoster_ID(t *testing.T) {
 
 	assert.True(t, ro.ID.Equal(ro2.ID))
 
+	// check unordered service identities
+	ro.List[0].ServiceIdentities[0], ro.List[0].ServiceIdentities[1] = ro.List[0].ServiceIdentities[1], ro.List[0].ServiceIdentities[0]
+	ro3 := NewRoster(ro.List)
+	assert.True(t, ro.ID.Equal(ro3.ID))
+
+	// check missing service identities
 	tt := []*network.ServerIdentity{}
 	for _, id := range ro.List {
 		tt = append(tt, network.NewServerIdentity(id.Public, id.Address))
 	}
 
-	ro3 := NewRoster(tt)
-	assert.False(t, ro3.ID.Equal(ro.ID))
+	ro4 := NewRoster(tt)
+	assert.False(t, ro4.ID.Equal(ro.ID))
 }
 
 func TestRoster_GenerateNaryTree(t *testing.T) {
@@ -688,17 +694,20 @@ func genRoster(suite suites.Suite, names []network.Address) *Roster {
 	for _, n := range names {
 		kp := key.NewKeyPair(suite)
 		srvid := network.NewServerIdentity(kp.Public, n)
-		srvid.ServiceIdentities = []network.ServiceIdentity{genServiceIdentity(suite)}
+		srvid.ServiceIdentities = []network.ServiceIdentity{
+			genServiceIdentity("ServiceTest", suite),
+			genServiceIdentity("AnotherServiceTest", suite),
+		}
 
 		ids = append(ids, srvid)
 	}
 	return NewRoster(ids)
 }
 
-func genServiceIdentity(suite suites.Suite) network.ServiceIdentity {
+func genServiceIdentity(name string, suite suites.Suite) network.ServiceIdentity {
 	kp := key.NewKeyPair(suite)
 
-	return network.NewServiceIdentityFromPair("ServiceTest", suite, kp)
+	return network.NewServiceIdentityFromPair(name, suite, kp)
 }
 
 func genLocalTree(count, port int) (*Tree, *Roster) {


### PR DESCRIPTION
This sorts the service identities because it can happen the order
array change when writing/reading toml files. This makes sure it
doesn't impact the final ID.

This issue occurs when checking the roster sent back when creating a genesis block in dedis/cothority#1764