### PR TITLE
Correctly calculate ServiceAggregate

### DIFF
--- a/network/struct.go
+++ b/network/struct.go
@@ -236,6 +236,17 @@ func (si *ServerIdentity) HasServiceKeyPair(name string) bool {
 	return false
 }
 
+// HasServicePublic returns true if the public key is
+// generated for the given service. The default public key is ignored.
+func (si *ServerIdentity) HasServicePublic(name string) bool {
+	for _, srvid := range si.ServiceIdentities {
+		if srvid.Name == name && srvid.Public != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // Toml converts an ServerIdentity to a Toml-structure
 func (si *ServerIdentity) Toml(suite Suite) *ServerIdentityToml {
 	var buf bytes.Buffer

--- a/network/struct_test.go
+++ b/network/struct_test.go
@@ -78,6 +78,7 @@ func TestServiceIdentity(t *testing.T) {
 	kp2 := key.NewKeyPair(tSuite)
 	si.ServiceIdentities = append(si.ServiceIdentities, NewServiceIdentity("a", tSuite, pub, priv))
 	si.ServiceIdentities = append(si.ServiceIdentities, NewServiceIdentityFromPair("b", tSuite, kp2))
+	si.ServiceIdentities = append(si.ServiceIdentities, NewServiceIdentity("d", tSuite, pub, nil))
 
 	require.Equal(t, pub, si.ServicePublic("a"))
 	require.Equal(t, priv, si.ServicePrivate("a"))
@@ -88,4 +89,9 @@ func TestServiceIdentity(t *testing.T) {
 	require.True(t, si.HasServiceKeyPair("a"))
 	require.True(t, si.HasServiceKeyPair("b"))
 	require.False(t, si.HasServiceKeyPair("c"))
+
+	require.True(t, si.HasServicePublic("a"))
+	require.True(t, si.HasServicePublic("b"))
+	require.False(t, si.HasServicePublic("c"))
+	require.True(t, si.HasServicePublic("d"))
 }

--- a/tree.go
+++ b/tree.go
@@ -522,7 +522,7 @@ func (ro *Roster) ServicePublics(name string) []kyber.Point {
 // If one or more of the service public keys are not present, it will return an error.
 func (ro Roster) ServiceAggregate(name string) (kyber.Point, error) {
 	for _, si := range ro.List {
-		if !si.HasServiceKeyPair(name) {
+		if !si.HasServicePublic(name) {
 			return nil, errors.New("not all nodes have this service keypair")
 		}
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -648,6 +648,15 @@ func TestTreeNode_AggregatePublic(t *testing.T) {
 	}
 }
 
+func TestRoster_ServiceAggregate(t *testing.T) {
+	names := genLocalhostPeerNames(3, 2000)
+	ro := genRoster(tSuite, names)
+	_, err := ro.ServiceAggregate("unknown")
+	require.Error(t, err)
+	_, err = ro.ServiceAggregate("ServiceTest")
+	require.NoError(t, err)
+}
+
 // BenchmarkTreeMarshal will be the benchmark for the conversion between TreeMarshall and Tree
 func BenchmarkTreeMarshal(b *testing.B) {
 	tree, _ := genLocalTree(1000, 0)


### PR DESCRIPTION
Previously the ServiceAggregate failed because it checked for the presence
of a private key. But for the aggregate key, only the public key is needed.