### PR TITLE
Fix leaking goroutine in treestorage

### DIFF
--- a/treestorage_test.go
+++ b/treestorage_test.go
@@ -104,6 +104,9 @@ func TestTreeStorage_Close(t *testing.T) {
 	// make sure several calls are ok
 	store.Close()
 
+	// this should not create a new goroutine
+	store.Remove(trees[0].ID)
+
 	checkLeakingGoroutines(t)
 }
 


### PR DESCRIPTION
After the server is closed, it can still process messages and this triggers the storage to clean some trees which creates again new goroutines that won't be closed. This addresses the scenario.

Note: this fixes a flaky test in dedis/cothority