### PR TITLE
Fix data race when getting new buckets

### DIFF
--- a/context.go
+++ b/context.go
@@ -253,7 +253,11 @@ func (c *Context) SaveVersion(version int) error {
 // Additionally, the user should not create buckets directly on the DB but always
 // call this function to create new buckets to avoid bucket name conflicts.
 func (c *Context) GetAdditionalBucket(name []byte) (*bbolt.DB, []byte) {
-	fullName := append(append(c.bucketName, byte('_')), name...)
+	// make a copy to insure c.bucketName is not written
+	bucketName := make([]byte, len(c.bucketName))
+	copy(bucketName, c.bucketName)
+
+	fullName := append(append(bucketName, byte('_')), name...)
 	err := c.manager.db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(fullName)
 		if err != nil {

--- a/context_test.go
+++ b/context_test.go
@@ -107,11 +107,11 @@ func TestContext_GetAdditionalBucket(t *testing.T) {
 	c := createContext(t, tmp)
 	db, name := c.GetAdditionalBucket([]byte("new"))
 	require.NotNil(t, db)
-	require.Equal(t, []byte("testService_new"), name)
+	require.Equal(t, "testService_new", string(name))
 	// Need to accept a second run with an existing bucket
 	db, name = c.GetAdditionalBucket([]byte("new"))
 	require.NotNil(t, db)
-	require.Equal(t, []byte("testService_new"), name)
+	require.Equal(t, "testService_new", string(name))
 }
 
 func TestContext_Path(t *testing.T) {


### PR DESCRIPTION
It might happen that the append builtin was modifying the inner array and then creating a data race. The modification should not happen anyway so this is fixed by copying the array so that there is only reads.