### PR TITLE
Statistics split into buckets

### DIFF
--- a/simul/README.md
+++ b/simul/README.md
@@ -39,6 +39,21 @@ If you use the `onet.SimulationBFTree`, the following variables are also availab
 - `Depth` - the depth of the tree in levels below the root-node
 - `Rounds` - for how many rounds the simulation should run
 
+### Statistics for subset of hosts
+
+Buckets of statistics can be defined using the following variable:
+
+- `Buckets` - indices range of the buckets
+
+The parameter is a string where the buckets are separated with spaces and the ranges
+by a dash (e.g. `Buckets = "0:5 5:10-15:20"` that will create a bucket with hosts 0
+to 4 and another one with hosts 5 to 9 and 15 to 19). Range indices can be compared
+to Go slices so that the lower index is inclusive and the higher is exclusive.
+
+A file will be written per bucket and the global one containing the statistics of all
+the conodes will always be present independantly from the parameter. Each file will have
+the bucket number as suffix.
+
 ### Simulations with long setup-times and multiple measurements
 
 Per default, all rounds of an individual simulation-run will be averaged and

--- a/simul/README.md
+++ b/simul/README.md
@@ -51,7 +51,7 @@ to 4 and another one with hosts 5 to 9 and 15 to 19). Range indices can be compa
 to Go slices so that the lower index is inclusive and the higher is exclusive.
 
 A file will be written per bucket and the global one containing the statistics of all
-the conodes will always be present independantly from the parameter. Each file will have
+the conodes will always be present independently from the parameter. Each file will have
 the bucket number as suffix.
 
 ### Simulations with long setup-times and multiple measurements

--- a/simul/build.go
+++ b/simul/build.go
@@ -151,7 +151,7 @@ func RunTests(deployP platform.Platform, name string, runconfigs []*platform.Run
 
 		for j, bucketStat := range stats {
 			if j >= len(files) {
-				f, err := os.OpenFile(testFile(name, j), args, 0660)
+				f, err := os.OpenFile(generateResultFileName(name, j), args, 0660)
 				if err != nil {
 					log.Fatal("error opening test file:", err)
 				}
@@ -260,7 +260,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 		}
 		return stats, nil
 	case <-time.After(timeout):
-		return nil, errors.New("Simulation timeout")
+		return nil, errors.New("simulation timeout")
 	}
 }
 
@@ -330,7 +330,7 @@ func mkTestDir() {
 	}
 }
 
-func testFile(name string, index int) string {
+func generateResultFileName(name string, index int) string {
 	if index == 0 {
 		// don't add the bucket index if it is the global one
 		return fmt.Sprintf("test_data/%s.csv", name)

--- a/simul/build.go
+++ b/simul/build.go
@@ -209,13 +209,17 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 	// according to the configuration file
 	buckets, err := rc.GetBuckets()
 	if err != nil {
-		return nil, err
-	}
+		if err != platform.ErrorFieldNotPresent {
+			return nil, err
+		}
 
-	for i, rules := range buckets {
-		bs := monitor.NewStats(rc.Map(), "hosts", "bf")
-		stats = append(stats, bs)
-		m.InsertBucket(i, rules, bs)
+		// Do nothing, there won't be any bucket.
+	} else {
+		for i, rules := range buckets {
+			bs := monitor.NewStats(rc.Map(), "hosts", "bf")
+			stats = append(stats, bs)
+			m.InsertBucket(i, rules, bs)
+		}
 	}
 
 	done := make(chan error)
@@ -327,7 +331,12 @@ func mkTestDir() {
 }
 
 func testFile(name string, index int) string {
-	return fmt.Sprintf("../test_data/%s_%d.csv", name, index)
+	if index == 0 {
+		// don't add the bucket index if it is the global one
+		return fmt.Sprintf("test_data/%s.csv", name)
+	}
+
+	return fmt.Sprintf("test_data/%s_%d.csv", name, index)
 }
 
 // returns a tuple of start and stop configurations to run

--- a/simul/monitor/bucket_stats.go
+++ b/simul/monitor/bucket_stats.go
@@ -1,0 +1,113 @@
+package monitor
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// bucketRule represents a filter that will tell if a measure must
+// be added to a bucket. It follows the logic of a slice indexing
+// so that the lower index is inclusive and the upper one is exclusive.
+type bucketRule struct {
+	low  int
+	high int
+}
+
+// newBucketRule takes a string and parse it to instantiate
+// a bucket rule.
+func newBucketRule(r string) (rule bucketRule, err error) {
+	parts := strings.Split(r, ":")
+	if len(parts) != 2 {
+		err = errors.New("malformed rule")
+		return
+	}
+
+	rule.low, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return
+	}
+
+	rule.high, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Match returns true when the index is accepted by the rule, false
+// otherwise.
+func (r bucketRule) Match(index int) bool {
+	return index >= r.low && index < r.high
+}
+
+type bucketRules []bucketRule
+
+// Match returns true when at least one of the rule accepts the host
+// index.
+func (rr bucketRules) Match(host int) bool {
+	if host < 0 {
+		// a value below is considered as an invalid host index
+		return false
+	}
+
+	for _, rule := range rr {
+		if rule.Match(host) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// BucketStats split the statistics into buckets according to network addresses
+// and associated rules
+type BucketStats struct {
+	rules   map[int]bucketRules
+	buckets map[int]*Stats
+}
+
+func newBucketStats() *BucketStats {
+	return &BucketStats{
+		rules:   make(map[int]bucketRules),
+		buckets: make(map[int]*Stats),
+	}
+}
+
+// Set creates a new bucket at the given index that uses the rules to filter
+// incoming measures
+func (bs *BucketStats) Set(index int, rules []string, stats *Stats) error {
+	bs.rules[index] = make(bucketRules, len(rules))
+	for i, str := range rules {
+		rule, err := newBucketRule(str)
+		if err != nil {
+			return err
+		}
+
+		bs.rules[index][i] = rule
+	}
+
+	bs.buckets[index] = stats
+	return nil
+}
+
+// Get returns the bucket at the given index if it exists, nil otherwise
+func (bs *BucketStats) Get(index int) *Stats {
+	s := bs.buckets[index]
+	if s != nil {
+		s.Collect()
+	}
+
+	return s
+}
+
+// Update takes a single measure and fill the buckets that will match
+// the host index if defined in the measure
+func (bs *BucketStats) Update(m *singleMeasure) {
+	for i, rr := range bs.rules {
+		if rr.Match(m.Host) {
+			bs.buckets[i].Update(m)
+		}
+	}
+}

--- a/simul/monitor/bucket_stats.go
+++ b/simul/monitor/bucket_stats.go
@@ -14,7 +14,7 @@ type bucketRule struct {
 	high int
 }
 
-// newBucketRule takes a string and parse it to instantiate
+// newBucketRule takes a string and parses it to instantiate
 // a bucket rule.
 func newBucketRule(r string) (rule bucketRule, err error) {
 	parts := strings.Split(r, ":")
@@ -61,7 +61,7 @@ func (rr bucketRules) Match(host int) bool {
 	return false
 }
 
-// BucketStats split the statistics into buckets according to network addresses
+// BucketStats splits the statistics into buckets according to network addresses
 // and associated rules
 type BucketStats struct {
 	rules   map[int]bucketRules

--- a/simul/monitor/bucket_stats_test.go
+++ b/simul/monitor/bucket_stats_test.go
@@ -1,0 +1,68 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketStats_Rules(t *testing.T) {
+	rr := bucketRules{}
+	r, err := newBucketRule("0:1")
+	require.NoError(t, err)
+	rr = append(rr, r)
+
+	r, err = newBucketRule("5:7")
+	require.NoError(t, err)
+	rr = append(rr, r)
+
+	require.True(t, rr.Match(0))
+	require.True(t, rr.Match(5))
+	require.True(t, rr.Match(6))
+	require.False(t, rr.Match(1))
+	require.False(t, rr.Match(7))
+	require.False(t, rr.Match(4))
+	require.False(t, rr.Match(-1))
+
+	_, err = newBucketRule("")
+	require.Error(t, err)
+	_, err = newBucketRule("123:")
+	require.Error(t, err)
+	_, err = newBucketRule(":123")
+	require.Error(t, err)
+	_, err = newBucketRule("a:123")
+	require.Error(t, err)
+	_, err = newBucketRule("123:a")
+	require.Error(t, err)
+}
+
+func TestBucketStats_Buckets(t *testing.T) {
+	b := newBucketStats()
+
+	err := b.Set(0, []string{"abc"}, NewStats(nil))
+	require.Error(t, err)
+
+	err = b.Set(0, []string{"10:20"}, NewStats(nil))
+	require.NoError(t, err)
+
+	err = b.Set(1, []string{"15:20"}, NewStats(nil))
+	require.NoError(t, err)
+
+	err = b.Set(2, []string{"5:10", "20:25"}, NewStats(nil))
+	require.NoError(t, err)
+
+	b.Update(newSingleMeasureWithHost("a", 5, 17))
+	b.Update(newSingleMeasureWithHost("a", 10, 10))
+
+	s := b.Get(0)
+	require.Equal(t, 7.5, s.Value("a").Avg())
+
+	s = b.Get(1)
+	require.Equal(t, 5.0, s.Value("a").Avg())
+
+	s = b.Get(2)
+	require.Nil(t, s.Value("a"))
+
+	s = b.Get(3)
+	require.Nil(t, s)
+}

--- a/simul/monitor/bucket_stats_test.go
+++ b/simul/monitor/bucket_stats_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBucketStats_Rules tests that a bucket rule can be used
+// as expected and that it matches the correct hosts only.
 func TestBucketStats_Rules(t *testing.T) {
 	rr := bucketRules{}
 	r, err := newBucketRule("0:1")
@@ -36,6 +38,8 @@ func TestBucketStats_Rules(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestBucketStats_Buckets tests that the buckets are correctly
+// created and that the measures are correctly splitted.
 func TestBucketStats_Buckets(t *testing.T) {
 	b := newBucketStats()
 

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -12,6 +12,10 @@ import (
 	"go.dedis.ch/onet/v3/log"
 )
 
+// InvalidHostIndex is the default value when the measure is not assigned
+// to a specific host
+const InvalidHostIndex = -1
+
 var global struct {
 	// Sink is the server address where all measures are transmitted to for
 	// further analysis.
@@ -87,7 +91,7 @@ func ConnectSink(addr string) error {
 
 // RecordSingleMeasure sends the pair name - value to the monitor directly.
 func RecordSingleMeasure(name string, value float64) {
-	RecordSingleMeasureWithHost(name, value, -1)
+	RecordSingleMeasureWithHost(name, value, InvalidHostIndex)
 }
 
 // RecordSingleMeasureWithHost sends the pair name - value with the host index
@@ -98,7 +102,7 @@ func RecordSingleMeasureWithHost(name string, value float64, host int) {
 }
 
 func newSingleMeasure(name string, value float64) *singleMeasure {
-	return newSingleMeasureWithHost(name, value, -1)
+	return newSingleMeasureWithHost(name, value, InvalidHostIndex)
 }
 
 func newSingleMeasureWithHost(name string, value float64, host int) *singleMeasure {
@@ -117,7 +121,7 @@ func (s *singleMeasure) Record() {
 
 // NewTimeMeasure return *TimeMeasure
 func NewTimeMeasure(name string) *TimeMeasure {
-	return NewTimeMeasureWithHost(name, -1)
+	return NewTimeMeasureWithHost(name, InvalidHostIndex)
 }
 
 // NewTimeMeasureWithHost makes a time measure bounded to a host index.
@@ -187,7 +191,7 @@ type CounterIOMeasure struct {
 // NewCounterIOMeasure returns a CounterIOMeasure fresh. The base value are set
 // to the current value of counter.Rx() and counter.Tx().
 func NewCounterIOMeasure(name string, counter CounterIO) *CounterIOMeasure {
-	return NewCounterIOMeasureWithHost(name, counter, -1)
+	return NewCounterIOMeasureWithHost(name, counter, InvalidHostIndex)
 }
 
 // NewCounterIOMeasureWithHost returns a CounterIOMeasure bounded to a host index. The

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -47,6 +47,7 @@ type Measure interface {
 type singleMeasure struct {
 	Name  string
 	Value float64
+	Host  int
 }
 
 // TimeMeasure represents a measure regarding time: It includes the wallclock
@@ -58,6 +59,7 @@ type TimeMeasure struct {
 	// non exported fields
 	// name of the time measure (basename)
 	name string
+	host int
 	// last time
 	lastWallTime time.Time
 }
@@ -85,14 +87,25 @@ func ConnectSink(addr string) error {
 
 // RecordSingleMeasure sends the pair name - value to the monitor directly.
 func RecordSingleMeasure(name string, value float64) {
-	sm := newSingleMeasure(name, value)
+	RecordSingleMeasureWithHost(name, value, -1)
+}
+
+// RecordSingleMeasureWithHost sends the pair name - value with the host index
+// to the monitor directly.
+func RecordSingleMeasureWithHost(name string, value float64, host int) {
+	sm := newSingleMeasureWithHost(name, value, host)
 	sm.Record()
 }
 
 func newSingleMeasure(name string, value float64) *singleMeasure {
+	return newSingleMeasureWithHost(name, value, -1)
+}
+
+func newSingleMeasureWithHost(name string, value float64, host int) *singleMeasure {
 	return &singleMeasure{
 		Name:  name,
 		Value: value,
+		Host:  host,
 	}
 }
 
@@ -104,7 +117,12 @@ func (s *singleMeasure) Record() {
 
 // NewTimeMeasure return *TimeMeasure
 func NewTimeMeasure(name string) *TimeMeasure {
-	tm := &TimeMeasure{name: name}
+	return NewTimeMeasureWithHost(name, -1)
+}
+
+// NewTimeMeasureWithHost makes a time measure bounded to a host index.
+func NewTimeMeasureWithHost(name string, host int) *TimeMeasure {
+	tm := &TimeMeasure{name: name, host: host}
 	tm.reset()
 	return tm
 }
@@ -118,7 +136,7 @@ func NewTimeMeasure(name string) *TimeMeasure {
 // - user time: *name*_user
 func (tm *TimeMeasure) Record() {
 	// Wall time measurement
-	tm.Wall = newSingleMeasure(tm.name+"_wall", float64(time.Since(tm.lastWallTime))/1.0e9)
+	tm.Wall = newSingleMeasureWithHost(tm.name+"_wall", float64(time.Since(tm.lastWallTime))/1.0e9, tm.host)
 	// CPU time measurement
 	tm.CPU.Value, tm.User.Value = getDiffRTime(tm.CPU.Value, tm.User.Value)
 	// send data
@@ -133,8 +151,8 @@ func (tm *TimeMeasure) Record() {
 // reset reset the time fields of this time measure
 func (tm *TimeMeasure) reset() {
 	cpuTimeSys, cpuTimeUser := getRTime()
-	tm.CPU = newSingleMeasure(tm.name+"_system", cpuTimeSys)
-	tm.User = newSingleMeasure(tm.name+"_user", cpuTimeUser)
+	tm.CPU = newSingleMeasureWithHost(tm.name+"_system", cpuTimeSys, tm.host)
+	tm.User = newSingleMeasureWithHost(tm.name+"_user", cpuTimeUser, tm.host)
 	tm.lastWallTime = time.Now()
 }
 
@@ -158,6 +176,7 @@ type CounterIO interface {
 // are put back to 0 (while the CounterIO still sends increased bytes number).
 type CounterIOMeasure struct {
 	name      string
+	host      int
 	counter   CounterIO
 	baseTx    uint64
 	baseRx    uint64
@@ -165,11 +184,18 @@ type CounterIOMeasure struct {
 	baseMsgRx uint64
 }
 
-// NewCounterIOMeasure returns an CounterIOMeasure fresh. The base value are set
+// NewCounterIOMeasure returns a CounterIOMeasure fresh. The base value are set
 // to the current value of counter.Rx() and counter.Tx().
 func NewCounterIOMeasure(name string, counter CounterIO) *CounterIOMeasure {
+	return NewCounterIOMeasureWithHost(name, counter, -1)
+}
+
+// NewCounterIOMeasureWithHost returns a CounterIOMeasure bounded to a host index. The
+// base value are set to the current value of counter.Rx() and counter.Tx().
+func NewCounterIOMeasureWithHost(name string, counter CounterIO, host int) *CounterIOMeasure {
 	return &CounterIOMeasure{
 		name:      name,
+		host:      host,
 		counter:   counter,
 		baseTx:    counter.Tx(),
 		baseRx:    counter.Rx(),
@@ -185,15 +211,15 @@ func (cm *CounterIOMeasure) Record() {
 	bRx := cm.counter.Rx()
 	// TODO Later on, we might want to do a check on the conversion between
 	// uint64 -> float64, as the MAX values are not the same.
-	read := newSingleMeasure(cm.name+"_rx", float64(bRx-cm.baseRx))
+	read := newSingleMeasureWithHost(cm.name+"_rx", float64(bRx-cm.baseRx), cm.host)
 	// creates the  written measure
 	bTx := cm.counter.Tx()
-	written := newSingleMeasure(cm.name+"_tx", float64(bTx-cm.baseTx))
+	written := newSingleMeasureWithHost(cm.name+"_tx", float64(bTx-cm.baseTx), cm.host)
 
 	bMsgRx := cm.counter.MsgRx()
-	readMsg := newSingleMeasure(cm.name+"_msg_rx", float64(bMsgRx-cm.baseMsgRx))
+	readMsg := newSingleMeasureWithHost(cm.name+"_msg_rx", float64(bMsgRx-cm.baseMsgRx), cm.host)
 	bMsgTx := cm.counter.MsgTx()
-	writtenMsg := newSingleMeasure(cm.name+"_msg_tx", float64(bMsgTx-cm.baseMsgTx))
+	writtenMsg := newSingleMeasureWithHost(cm.name+"_msg_tx", float64(bMsgTx-cm.baseMsgTx), cm.host)
 
 	// send them
 	read.Record()

--- a/simul/monitor/monitor_test.go
+++ b/simul/monitor/monitor_test.go
@@ -41,6 +41,8 @@ func TestReadyNormal(t *testing.T) {
 	if updated == fresh {
 		t.Fatal("Stats not updated ?")
 	}
+
+	mon.Stop()
 }
 
 func TestKeyOrder(t *testing.T) {

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -245,6 +245,12 @@ func (d *Localhost) Wait() error {
 	case <-time.After(wait):
 		log.Lvl1("Quitting after waiting", wait)
 	}
+
+	err = os.Chdir(d.localDir)
+	if err != nil {
+		log.Error("Fail to restore the cwd: " + err.Error())
+	}
+
 	monitor.EndAndCleanup()
 	log.Lvl2("Processes finished")
 	return err

--- a/simul/platform/platform.go
+++ b/simul/platform/platform.go
@@ -253,6 +253,22 @@ func (r *RunConfig) GetDuration(field string) (time.Duration, error) {
 	return time.ParseDuration(val)
 }
 
+// GetBuckets returns the list of buckets defined in the configuration
+// file to split the statistics
+func (r *RunConfig) GetBuckets() ([][]string, error) {
+	val := r.Get("buckets")
+	if val == "" {
+		return nil, ErrorFieldNotPresent
+	}
+
+	bb := [][]string{}
+	for _, b := range strings.Fields(val) {
+		bb = append(bb, strings.Split(b, "-"))
+	}
+
+	return bb, nil
+}
+
 // Put inserts a new field - value relationship
 func (r *RunConfig) Put(field, value string) {
 	r.Lock()

--- a/simul/platform/platform_test.go
+++ b/simul/platform/platform_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
 )
 
@@ -131,4 +132,19 @@ func main() {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestBuckets(t *testing.T) {
+	cfg := NewRunConfig()
+
+	_, err := cfg.GetBuckets()
+	require.Error(t, err)
+
+	cfg.Put("buckets", "0:2-0:5 1:10 2:10")
+
+	buckets, err := cfg.GetBuckets()
+	require.NoError(t, err)
+	require.Equal(t, 3, len(buckets))
+	require.Equal(t, 2, len(buckets[0]))
+	require.Equal(t, 1, len(buckets[1]))
 }

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -53,7 +53,8 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 		server := sc.Server
 		log.Lvl3(serverAddress, "Starting server", server.ServerIdentity.Address)
 		if measureNodeBW {
-			measures[i] = monitor.NewCounterIOMeasure("bandwidth", server)
+			hostIndex, _ := sc.Roster.Search(server.ServerIdentity.ID)
+			measures[i] = monitor.NewCounterIOMeasureWithHost("bandwidth", server, hostIndex)
 		}
 		// Launch a server and notifies when it's done
 		wgServer.Add(1)


### PR DESCRIPTION
This PR adds an optional parameter to simulations to define buckets that will be filled with statistics of a subset of the hosts.

Fixes #543 