### PR TITLE
Simulation: fix measures on multiple servers

### DIFF
--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -208,6 +208,14 @@ func NewCounterIOMeasureWithHost(name string, counter CounterIO, host int) *Coun
 	}
 }
 
+// Reset sets the base to the current value of the counter.
+func (cm *CounterIOMeasure) Reset() {
+	cm.baseTx = cm.counter.Tx()
+	cm.baseRx = cm.counter.Rx()
+	cm.baseMsgTx = cm.counter.MsgTx()
+	cm.baseMsgRx = cm.counter.MsgRx()
+}
+
 // Record send the actual number of bytes read and written (**name**_written &
 // **name**_read) and reset the counters.
 func (cm *CounterIOMeasure) Record() {

--- a/simul/monitor/measure_test.go
+++ b/simul/monitor/measure_test.go
@@ -134,3 +134,31 @@ func TestCounterIOMeasureRecord(t *testing.T) {
 	EndAndCleanup()
 	time.Sleep(100 * time.Millisecond)
 }
+
+// Test that reset sets the values to the base ones
+func TestCounterIOMeasureReset(t *testing.T) {
+	dm := &DummyCounterIO{0, 0, 0, 0}
+	cm := NewCounterIOMeasureWithHost("dummy", dm, 0)
+
+	// increase the actual
+	dm.Tx()
+	dm.Rx()
+	dm.MsgRx()
+	dm.MsgTx()
+
+	// several resets should still get the base values
+	cm.Reset()
+	cm.Reset()
+
+	if cm.baseRx != dm.rvalue || cm.baseTx != dm.wvalue {
+		t.Logf("baseRx = %d vs rvalue = %d || baseTx = %d vs wvalue = %d",
+			cm.baseRx, dm.rvalue, cm.baseTx, dm.wvalue)
+		t.Fatal("Tx() / Rx() not working ?")
+	}
+
+	if cm.baseMsgRx != dm.msgrvalue || cm.baseMsgTx != dm.msgwvalue {
+		t.Logf("baseMsgRx = %d vs msgrvalue = %d || baseMsgTx = %d vs msgwvalue = %d",
+			cm.baseMsgRx, dm.msgrvalue, cm.baseMsgTx, dm.msgwvalue)
+		t.Fatal("MsgTx() / MsgRx() not working ?")
+	}
+}


### PR DESCRIPTION
This fixes the simulation to correctly start bandwidth measures on
every server instead of only the ones with the root and reset the
measure to only get statistics after the initialization phase.

Fixes #550