### PR TITLE
Recover panics when processing client requests

### DIFF
--- a/processor_test.go
+++ b/processor_test.go
@@ -215,7 +215,7 @@ func TestProcessor_ProcessClientRequest(t *testing.T) {
 	}
 }
 
-// Test that the panic will be recovered and announced with crashing the server.
+// Test that the panic will be recovered and announced without crashing the server.
 func TestProcessor_PanicClientRequest(t *testing.T) {
 	local := NewTCPTest(tSuite)
 


### PR DESCRIPTION
This makes sure that a handler panic will be recovered so that a
meaningful error message can be sent back instead of an empty error.

Fixes dedis/cothority#1934