### PR TITLE
Listen for close message for streaming requests

### DIFF
--- a/websocket_test.go
+++ b/websocket_test.go
@@ -22,7 +22,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"gopkg.in/satori/go.uuid.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func init() {


### PR DESCRIPTION
This adds a listener that will allow close message to be received
so that we can shutdown streaming handler when the client closes
the connection.

Fixes #554