### PR TITLE
Added AddUserInterestingGoroutine() for AfterTest

### DIFF
--- a/log/testutil.go
+++ b/log/testutil.go
@@ -31,9 +31,6 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
 			strings.Contains(stack, "graceful") ||
 			strings.Contains(stack, "sigqueue") ||
-			strings.Contains(stack, "stackimpact-go/internal") ||
-			// stackimpact uses persistent http client conns
-			strings.Contains(stack, "created by net/http.(*Transport).dialConn") ||
 			strings.Contains(stack, "log.MainTest") ||
 			matchesUserUninterestingGoroutine(stack) {
 			continue

--- a/log/testutil.go
+++ b/log/testutil.go
@@ -35,7 +35,7 @@ func interestingGoroutines() (gs []string) {
 			// stackimpact uses persistent http client conns
 			strings.Contains(stack, "created by net/http.(*Transport).dialConn") ||
 			strings.Contains(stack, "log.MainTest") ||
-			matchesUserInterestingGoroutine(stack) {
+			matchesUserUninterestingGoroutine(stack) {
 			continue
 		}
 
@@ -45,23 +45,18 @@ func interestingGoroutines() (gs []string) {
 	return
 }
 
-var userInterestingGoroutines []string
+var userUninterestingGoroutines []string
 
-// AddUserInterestingGoroutine can be called when the environment of some
-// specific tests leaks goroutines unknown to interestingGoroutines()
-func AddUserInterestingGoroutine(newGr string) {
-	// Don't add if it's already there
-	for _, gr := range userInterestingGoroutines {
-		if newGr == gr {
-			return
-		}
-	}
-
-	userInterestingGoroutines = append(userInterestingGoroutines, newGr)
+// AddUserUninterestingGoroutine can be called when the environment of some
+// specific tests leaks goroutines unknown to interestingGoroutines().
+// This function is not safe for concurrent execution. The caller should add
+// all of the desired exceptions before launching any goroutines.
+func AddUserUninterestingGoroutine(newGr string) {
+	userUninterestingGoroutines = append(userUninterestingGoroutines, newGr)
 }
 
-func matchesUserInterestingGoroutine(stack string) bool {
-	for _, gr := range userInterestingGoroutines {
+func matchesUserUninterestingGoroutine(stack string) bool {
+	for _, gr := range userUninterestingGoroutines {
 		if strings.Contains(stack, gr) {
 			return true
 		}

--- a/processor_test.go
+++ b/processor_test.go
@@ -476,6 +476,8 @@ func TestMarshalJSON_twoPoints(t *testing.T) {
 }
 
 func TestProcessor_REST_Handler(t *testing.T) {
+	log.AddUserUninterestingGoroutine("created by net/http.(*Transport).dialConn")
+
 	local := NewTCPTest(tSuite)
 
 	// generate 1 host


### PR DESCRIPTION
Performing tests in some environments sometimes leads to leaked goroutines, which are not easy to fix without modifying an external component. Such a situation came up when integrating the Go Ethereum code into an OmniLedger contract: the Ethereum code starts goroutines to perform some caching of transactions, and it never bothers to terminate them.
As a consequence, `AfterTest()` in `log/testutil` rightfully complains about these leaking goroutines and fails the test. Sometimes one can get away with using `bct.local.Check = onet.CheckNone`, but that is not ideal.

In order to avoid polluting the "known interesting goroutines" in `log/testutil`, this PR adds a function that allows to register specific goroutines to be ignored by `AfterTest()`.