### PR TITLE
SendProtobufParallel

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -571,6 +571,8 @@ func (c *Client) SendProtobufParallel(nodes []*network.ServerIdentity, msg inter
 				select {
 				case node = <-nodesChan:
 				default:
+				}
+				if node == nil {
 					return
 				}
 				log.Lvlf2("Asking %T from: %v - %v", msg, node.Address, node.URL)

--- a/websocket.go
+++ b/websocket.go
@@ -320,8 +320,6 @@ func (c *Client) closeSingleUseConn(dst *network.ServerIdentity, path string) {
 func (c *Client) newConnIfNotExist(dst *network.ServerIdentity, path string) (*websocket.Conn, error) {
 	var err error
 
-	// TODO we are opening a new connection for every new path?
-	// not possible to use an existing connection for the same service?
 	dest := destination{dst, path}
 	c.Lock()
 	conn, ok := c.connections[dest]
@@ -573,8 +571,6 @@ func (c *Client) SendProtobufParallel(nodes []*network.ServerIdentity, msg inter
 				select {
 				case node = <-nodesChan:
 				default:
-				}
-				if node == nil {
 					return
 				}
 				log.Lvlf2("Asking %T from: %v - %v", msg, node.Address, node.URL)
@@ -641,9 +637,9 @@ func (c *Client) Stream(dst *network.ServerIdentity, msg interface{}) (Streaming
 	}
 	path := strings.Split(reflect.TypeOf(msg).String(), ".")[1]
 
+	conn, err := c.newConnIfNotExist(dst, path)
 	c.Lock()
 	defer c.Unlock()
-	conn, err := c.newConnIfNotExist(dst, path)
 	if err != nil {
 		return StreamingConn{}, err
 	}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -498,6 +498,7 @@ func TestWebSocket_Streaming(t *testing.T) {
 	}
 
 	// (1) happy-path testing
+	log.Lvl1("Happy-path testing")
 	conn, err := client.Stream(servers[0].ServerIdentity, r)
 	require.NoError(t, err)
 
@@ -510,6 +511,7 @@ func TestWebSocket_Streaming(t *testing.T) {
 	// Using the same client (connection) to repeat the same request should
 	// fail because the connection should be closed by the service when
 	// there are no more messages.
+	log.Lvl1("Fail on re-use")
 	sr := &SimpleResponse{}
 	require.Error(t, conn.ReadMessage(sr))
 	require.NoError(t, client.Close())

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -22,7 +22,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"gopkg.in/satori/go.uuid.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func init() {
@@ -674,22 +674,23 @@ func TestParallelOptions_GetList(t *testing.T) {
 
 	var po *ParallelOptions
 	_, roster, _ := l.GenTree(3, false)
+	nodes := roster.List
 
-	count, list := po.GetList(roster)
+	count, list := po.GetList(nodes)
 	require.Equal(t, 2, count)
 	require.Equal(t, 3, len(list))
 	require.False(t, po.Quit())
 
 	po = &ParallelOptions{}
-	count, list = po.GetList(roster)
+	count, list = po.GetList(nodes)
 	require.Equal(t, 2, count)
 	require.Equal(t, 3, len(list))
 	require.False(t, po.Quit())
 
 	first := 0
 	for i := 0; i < 32; i++ {
-		_, list := po.GetList(roster)
-		if (<-list).Equal(roster.List[0]) {
+		_, list := po.GetList(nodes)
+		if (<-list).Equal(nodes[0]) {
 			first++
 		}
 	}
@@ -698,20 +699,20 @@ func TestParallelOptions_GetList(t *testing.T) {
 	po.DontShuffle = true
 	first = 0
 	for i := 0; i < 32; i++ {
-		_, list := po.GetList(roster)
-		if (<-list).Equal(roster.List[0]) {
+		_, list := po.GetList(nodes)
+		if (<-list).Equal(nodes[0]) {
 			first++
 		}
 	}
 	require.Equal(t, 32, first)
 
-	po.IgnoreNodes = append(po.IgnoreNodes, roster.List[0])
-	count, list = po.GetList(roster)
+	po.IgnoreNodes = append(po.IgnoreNodes, nodes[0])
+	count, list = po.GetList(nodes)
 	require.Equal(t, 2, count)
 	require.Equal(t, 2, len(list))
 
-	po.IgnoreNodes = append(po.IgnoreNodes, roster.List[1])
-	count, list = po.GetList(roster)
+	po.IgnoreNodes = append(po.IgnoreNodes, nodes[1])
+	count, list = po.GetList(nodes)
 	require.Equal(t, 2, count)
 	require.Equal(t, 1, len(list))
 
@@ -720,12 +721,12 @@ func TestParallelOptions_GetList(t *testing.T) {
 	require.True(t, po.Quit())
 
 	po.AskNodes = 1
-	count, list = po.GetList(roster)
+	count, list = po.GetList(nodes)
 	require.Equal(t, 1, count)
 	require.Equal(t, 1, len(list))
 
 	po.StartNode = 1
-	count, list = po.GetList(roster)
+	count, list = po.GetList(nodes)
 	require.Equal(t, 1, count)
 	require.Equal(t, 1, len(list))
 }


### PR DESCRIPTION
Problem: different methods started using different ways of sending messages in parallel
to more than one websocket-client. Sometimes these methods were even done in
parallel.

Solution: add `SendProtobufParallel` method to onet.Client with a unified interface that allows
the caller to precisely describe how to call the nodes, and reasonable defaults to let
it 'do the right thing'.