### PR TITLE
Add stack-trace to panic-catcher

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -173,6 +173,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 					svc := ServiceFactory.Name(tni.Token().ServiceID)
 					log.Errorf("Panic in call to protocol <%s>.Dispatch() from service <%s> at address %s: %v",
 						tni.ProtocolName(), svc, o.server.ServerIdentity, r)
+					log.Error(log.Stack())
 				}
 			}()
 


### PR DESCRIPTION
When a panic happens, it's useful to know where it actually comes from, not only the protocol, but the line and stack-trace.