### PR TITLE
Racy websocket closing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(shell go env GOPATH)/src/github.com/dedis/Coding/bin/Makefile.base
 # to `make test_playground`.
 test_playground:
 	for a in $$( seq 100 ); do \
-	  if DEBUG_TIME=true go test -v -race -short -run TestClient_SendProtobufParallel > log.txt 2>&1; then \
+	  if DEBUG_TIME=true go test -v -race -short > log.txt 2>&1; then \
 		  echo Successfully ran \#$$a at $$(date); \
 		else \
 		  echo Failed at $$(date); \

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ include $(shell go env GOPATH)/src/github.com/dedis/Coding/bin/Makefile.base
 # to `make test_playground`.
 test_playground:
 	for a in $$( seq 100 ); do \
-	  if DEBUG_TIME=true go test -v -race -short > log.txt 2>&1; then \
-		  echo Successfully ran at $$(date); \
+	  if DEBUG_TIME=true go test -v -race -short -run TestClient_SendProtobufParallel > log.txt 2>&1; then \
+		  echo Successfully ran \#$$a at $$(date); \
 		else \
 		  echo Failed at $$(date); \
 			cat log.txt; \

--- a/local.go
+++ b/local.go
@@ -308,7 +308,10 @@ func (l *LocalTest) CloseAll() {
 
 	for _, node := range l.Nodes {
 		log.Lvl3("Closing node", node)
-		node.closeDispatch()
+		err := node.closeDispatch()
+		if err != nil {
+			log.Error("Error while closing dispatcher:", err)
+		}
 	}
 	l.Nodes = make([]*TreeNodeInstance, 0)
 
@@ -334,7 +337,10 @@ func (l *LocalTest) CloseAll() {
 	l.Servers = map[network.ServerIdentityID]*Server{}
 	l.ctx.Stop()
 
-	os.RemoveAll(l.path)
+	err := os.RemoveAll(l.path)
+	if err != nil {
+		log.Error("Error while removing all db-files:", err)
+	}
 	l.closed = true
 
 	if log.DebugVisible() == 0 {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -762,6 +762,9 @@ func TestClient_SendProtobufParallel(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+		// Need to close here to make sure that all messages are being sent
+		// before going on to the next stage.
+		require.NoError(t, cl.Close())
 	}
 	var errs int
 	for _, server := range servers {
@@ -798,7 +801,7 @@ func (i *ServiceWebSocket) ErrorRequest(msg *ErrorRequest) (network.Message, err
 		return nil, errors.New("not in roster")
 	}
 	if msg.Flags&(1<<uint(index)) > 0 {
-		return nil, errors.New("found in flags")
+		return nil, errors.New("found in flags: " + i.ServerIdentity().String())
 	}
 	i.Errors = 0
 	return &SimpleResponse{}, nil


### PR DESCRIPTION
- Fix a race in the closing of the websocket
- Stop contacting other nodes in SendProtobufParallel if one node replied successfully