### PR TITLE
Use a custom decoder to refuse a message

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -615,7 +615,7 @@ func (c *Client) SendProtobufParallelWithDecoder(nodes []*network.ServerIdentity
 				err := decoder(reply, ret)
 				if err != nil {
 					errs = append(errs, err)
-					// Reply avorted so we empty the last entry of this channel.
+					// Reply aborted so we empty the last entry of this channel.
 					<-siChan
 					break
 				}


### PR DESCRIPTION
This adds a custom decoder when sending in parallel so that messages
can be analyzed and refused (e.g. old block index)

Related to dedis/cothority#2002