### PR TITLE
Improve error handling

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -57,13 +57,13 @@ type ServiceConfig struct {
 func (hc *CothorityConfig) Save(file string) error {
 	fd, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return xerrors.Errorf("opening config file: %+v", err)
+		return xerrors.Errorf("opening config file: %v", err)
 	}
 	fd.WriteString("# This file contains your private key.\n")
 	fd.WriteString("# Do not give it away lightly!\n")
 	err = toml.NewEncoder(fd).Encode(hc)
 	if err != nil {
-		return xerrors.Errorf("toml encoding: %+v", err)
+		return xerrors.Errorf("toml encoding: %v", err)
 	}
 	return nil
 }
@@ -73,7 +73,7 @@ func LoadCothority(file string) (*CothorityConfig, error) {
 	hc := &CothorityConfig{}
 	_, err := toml.DecodeFile(file, hc)
 	if err != nil {
-		return nil, xerrors.Errorf("toml decoding: %+v", err)
+		return nil, xerrors.Errorf("toml decoding: %v", err)
 	}
 
 	// Backwards compatibility with configs before we included the suite name
@@ -88,17 +88,17 @@ func LoadCothority(file string) (*CothorityConfig, error) {
 func (hc *CothorityConfig) GetServerIdentity() (*network.ServerIdentity, error) {
 	suite, err := suites.Find(hc.Suite)
 	if err != nil {
-		return nil, xerrors.Errorf("kyber suite: %+v", err)
+		return nil, xerrors.Errorf("kyber suite: %v", err)
 	}
 
 	// Try to decode the Hex values
 	private, err := encoding.StringHexToScalar(suite, hc.Private)
 	if err != nil {
-		return nil, xerrors.Errorf("parsing private key: %+v", err)
+		return nil, xerrors.Errorf("parsing private key: %v", err)
 	}
 	point, err := encoding.StringHexToPoint(suite, hc.Public)
 	if err != nil {
-		return nil, xerrors.Errorf("parsing public key: %+v", err)
+		return nil, xerrors.Errorf("parsing public key: %v", err)
 	}
 	si := network.NewServerIdentity(point, hc.Address)
 	si.SetPrivate(private)
@@ -110,7 +110,7 @@ func (hc *CothorityConfig) GetServerIdentity() (*network.ServerIdentity, error) 
 		} else {
 			p, err := strconv.Atoi(si.Address.Port())
 			if err != nil {
-				return nil, xerrors.Errorf("port conversion: %+v")
+				return nil, xerrors.Errorf("port conversion: %v")
 			}
 			si.URL = fmt.Sprintf("https://%s:%d", si.Address.Host(), p+1)
 		}
@@ -127,16 +127,16 @@ func (hc *CothorityConfig) GetServerIdentity() (*network.ServerIdentity, error) 
 func ParseCothority(file string) (*CothorityConfig, *onet.Server, error) {
 	hc, err := LoadCothority(file)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("reading config: %+v", err)
+		return nil, nil, xerrors.Errorf("reading config: %v", err)
 	}
 	suite, err := suites.Find(hc.Suite)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("kyber suite: %+v", err)
+		return nil, nil, xerrors.Errorf("kyber suite: %v", err)
 	}
 
 	si, err := hc.GetServerIdentity()
 	if err != nil {
-		return nil, nil, xerrors.Errorf("parse server identity: %+v", err)
+		return nil, nil, xerrors.Errorf("parse server identity: %v", err)
 	}
 
 	// Same as `NewServerTCP` if `hc.ListenAddress` is empty
@@ -154,7 +154,7 @@ func ParseCothority(file string) (*CothorityConfig, *onet.Server, error) {
 				hc.WebSocketTLSCertificateKey.blobPart(),
 			)
 			if err != nil {
-				return nil, nil, xerrors.Errorf("certificate: %+v", err)
+				return nil, nil, xerrors.Errorf("certificate: %v", err)
 			}
 
 			server.WebSocket.Lock()
@@ -165,15 +165,15 @@ func ParseCothority(file string) (*CothorityConfig, *onet.Server, error) {
 		} else {
 			tlsCertificate, err := hc.WebSocketTLSCertificate.Content()
 			if err != nil {
-				return nil, nil, xerrors.Errorf("getting WebSocketTLSCertificate content: %+v", err)
+				return nil, nil, xerrors.Errorf("getting WebSocketTLSCertificate content: %v", err)
 			}
 			tlsCertificateKey, err := hc.WebSocketTLSCertificateKey.Content()
 			if err != nil {
-				return nil, nil, xerrors.Errorf("getting WebSocketTLSCertificateKey content: %+v", err)
+				return nil, nil, xerrors.Errorf("getting WebSocketTLSCertificateKey content: %v", err)
 			}
 			cert, err := tls.X509KeyPair(tlsCertificate, tlsCertificateKey)
 			if err != nil {
-				return nil, nil, xerrors.Errorf("loading X509KeyPair: %+v", err)
+				return nil, nil, xerrors.Errorf("loading X509KeyPair: %v", err)
 			}
 
 			server.WebSocket.Lock()
@@ -235,7 +235,7 @@ func (g *Group) Toml(suite suites.Suite) (*GroupToml, error) {
 	for i, si := range g.Roster.List {
 		pub, err := encoding.PointToStringHex(suite, si.Public)
 		if err != nil {
-			return nil, xerrors.Errorf("encoding public key: %+v", err)
+			return nil, xerrors.Errorf("encoding public key: %v", err)
 		}
 
 		services := make(map[string]ServerServiceConfig)
@@ -244,7 +244,7 @@ func (g *Group) Toml(suite suites.Suite) (*GroupToml, error) {
 
 			pub, err := encoding.PointToStringHex(suite, sid.Public)
 			if err != nil {
-				return nil, xerrors.Errorf("encoding service key: %+v", err)
+				return nil, xerrors.Errorf("encoding service key: %v", err)
 			}
 
 			services[sid.Name] = ServerServiceConfig{Public: pub, Suite: suite.String()}
@@ -267,7 +267,7 @@ func (g *Group) Toml(suite suites.Suite) (*GroupToml, error) {
 func (g *Group) Save(suite suites.Suite, filename string) error {
 	gt, err := g.Toml(suite)
 	if err != nil {
-		return xerrors.Errorf("toml encoding: %+v", err)
+		return xerrors.Errorf("toml encoding: %v", err)
 	}
 
 	return gt.Save(filename)
@@ -281,7 +281,7 @@ func ReadGroupDescToml(f io.Reader) (*Group, error) {
 	group := &GroupToml{}
 	_, err := toml.DecodeReader(f, group)
 	if err != nil {
-		return nil, xerrors.Errorf("toml decoding: %+v", err)
+		return nil, xerrors.Errorf("toml decoding: %v", err)
 	}
 	// convert from ServerTomls to entities
 	var entities = make([]*network.ServerIdentity, len(group.Servers))
@@ -293,7 +293,7 @@ func ReadGroupDescToml(f io.Reader) (*Group, error) {
 		}
 		en, err := s.ToServerIdentity()
 		if err != nil {
-			return nil, xerrors.Errorf("server identity encoding: %+v", err)
+			return nil, xerrors.Errorf("server identity encoding: %v", err)
 		}
 		entities[i] = en
 		descs[en] = s.Description
@@ -308,12 +308,12 @@ func ReadGroupDescToml(f io.Reader) (*Group, error) {
 func (gt *GroupToml) Save(fname string) error {
 	file, err := os.Create(fname)
 	if err != nil {
-		return xerrors.Errorf("creating file: %+v", err)
+		return xerrors.Errorf("creating file: %v", err)
 	}
 	defer file.Close()
 	_, err = file.WriteString(gt.String())
 	if err != nil {
-		return xerrors.Errorf("writing file: %+v", err)
+		return xerrors.Errorf("writing file: %v", err)
 	}
 
 	return nil
@@ -338,13 +338,13 @@ func (gt *GroupToml) String() string {
 func (s *ServerToml) ToServerIdentity() (*network.ServerIdentity, error) {
 	suite, err := suites.Find(s.Suite)
 	if err != nil {
-		return nil, xerrors.Errorf("kyber suite: %+v", err)
+		return nil, xerrors.Errorf("kyber suite: %v", err)
 	}
 
 	pubR := strings.NewReader(s.Public)
 	public, err := encoding.ReadHexPoint(suite, pubR)
 	if err != nil {
-		return nil, xerrors.Errorf("encoding key: %+v", err)
+		return nil, xerrors.Errorf("encoding key: %v", err)
 	}
 	si := network.NewServerIdentity(public, s.Address)
 	si.URL = s.URL
@@ -474,7 +474,7 @@ func (cu CertificateURL) Content() ([]byte, error) {
 	if cuType == File {
 		dat, err := ioutil.ReadFile(cu.blobPart())
 		if err != nil {
-			return nil, xerrors.Errorf("reading file: %+v", err)
+			return nil, xerrors.Errorf("reading file: %v", err)
 		}
 		return dat, nil
 	}

--- a/app/io.go
+++ b/app/io.go
@@ -73,27 +73,27 @@ func Copy(dst, src string) error {
 	info, err := os.Stat(dst)
 	if err == nil && info.IsDir() {
 		if err := Copy(path.Join(dst, path.Base(src)), src); err != nil {
-			return xerrors.Errorf("copying folder: %+v", err)
+			return xerrors.Errorf("copying folder: %v", err)
 		}
 		return nil
 	}
 	fSrc, err := os.Open(src)
 	if err != nil {
-		return xerrors.Errorf("opening file: %+v", err)
+		return xerrors.Errorf("opening file: %v", err)
 	}
 	defer fSrc.Close()
 	stat, err := fSrc.Stat()
 	if err != nil {
-		return xerrors.Errorf("file info: %+v", err)
+		return xerrors.Errorf("file info: %v", err)
 	}
 	fDst, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR, stat.Mode())
 	if err != nil {
-		return xerrors.Errorf("opening file: %+v", err)
+		return xerrors.Errorf("opening file: %v", err)
 	}
 	defer fDst.Close()
 	_, err = io.Copy(fDst, fSrc)
 	if err != nil {
-		return xerrors.Errorf("copying file: %+v", err)
+		return xerrors.Errorf("copying file: %v", err)
 	}
 
 	return nil

--- a/app/io.go
+++ b/app/io.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 var in *bufio.Reader
@@ -71,22 +72,29 @@ func InputYN(def bool, args ...interface{}) bool {
 func Copy(dst, src string) error {
 	info, err := os.Stat(dst)
 	if err == nil && info.IsDir() {
-		return Copy(path.Join(dst, path.Base(src)), src)
+		if err := Copy(path.Join(dst, path.Base(src)), src); err != nil {
+			return xerrors.Errorf("copying folder: %+v", err)
+		}
+		return nil
 	}
 	fSrc, err := os.Open(src)
 	if err != nil {
-		return err
+		return xerrors.Errorf("opening file: %+v", err)
 	}
 	defer fSrc.Close()
 	stat, err := fSrc.Stat()
 	if err != nil {
-		return err
+		return xerrors.Errorf("file info: %+v", err)
 	}
 	fDst, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR, stat.Mode())
 	if err != nil {
-		return err
+		return xerrors.Errorf("opening file: %+v", err)
 	}
 	defer fDst.Close()
 	_, err = io.Copy(fDst, fSrc)
-	return err
+	if err != nil {
+		return xerrors.Errorf("copying file: %+v", err)
+	}
+
+	return nil
 }

--- a/app/server.go
+++ b/app/server.go
@@ -306,12 +306,12 @@ func tryConnect(ip, binding network.Address) error {
 
 	_, portStr, err := net.SplitHostPort(ip.NetworkAddress())
 	if err != nil {
-		return err
+		return xerrors.Errorf("invalid address: %+v", err)
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return err
+		return xerrors.Errorf("invalid port: %+v", err)
 	}
 
 	// Ask the check. Since the public adress may not be available at this time
@@ -331,12 +331,12 @@ func tryConnect(ip, binding network.Address) error {
 	buff, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return err
+		return xerrors.Errorf("reading body: %+v", err)
 	}
 
 	res := string(buff)
 	if res != "Open" {
-		return fmt.Errorf("Portscan returned: %s", res)
+		return xerrors.Errorf("Portscan returned: %s", res)
 	}
 	return nil
 }

--- a/app/server.go
+++ b/app/server.go
@@ -306,12 +306,12 @@ func tryConnect(ip, binding network.Address) error {
 
 	_, portStr, err := net.SplitHostPort(ip.NetworkAddress())
 	if err != nil {
-		return xerrors.Errorf("invalid address: %+v", err)
+		return xerrors.Errorf("invalid address: %v", err)
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return xerrors.Errorf("invalid port: %+v", err)
+		return xerrors.Errorf("invalid port: %v", err)
 	}
 
 	// Ask the check. Since the public adress may not be available at this time
@@ -331,7 +331,7 @@ func tryConnect(ip, binding network.Address) error {
 	buff, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return xerrors.Errorf("reading body: %+v", err)
+		return xerrors.Errorf("reading body: %v", err)
 	}
 
 	res := string(buff)

--- a/app/server.go
+++ b/app/server.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -18,6 +17,7 @@ import (
 	"go.dedis.ch/onet/v3/cfgpath"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 )
 
 // DefaultServerConfig is the default server configuration file-name.
@@ -294,7 +294,7 @@ func tryConnect(ip, binding network.Address) error {
 	select {
 	case <-listening:
 	case <-time.After(2 * time.Second):
-		return errors.New("timeout while listening on " + binding.NetworkAddress())
+		return xerrors.New("timeout while listening on " + binding.NetworkAddress())
 	}
 	conn, err := net.Dial("tcp", ip.NetworkAddress())
 	log.ErrFatal(err, "Could not connect itself to public address.\n"+
@@ -325,7 +325,7 @@ func tryConnect(ip, binding network.Address) error {
 	resp, err := client.Get(url)
 	// can't get the public ip then ask the user for a reachable one
 	if err != nil {
-		return errors.New("...could not get your public IP address")
+		return xerrors.New("...could not get your public IP address")
 	}
 
 	buff, err := ioutil.ReadAll(resp.Body)

--- a/context.go
+++ b/context.go
@@ -35,11 +35,11 @@ func newContext(c *Server, o *Overlay, servID ServiceID, manager *serviceManager
 	err := manager.db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(ctx.bucketName)
 		if err != nil {
-			return xerrors.Errorf("creating bucket: %+v", err)
+			return xerrors.Errorf("creating bucket: %v", err)
 		}
 		_, err = tx.CreateBucketIfNotExists(ctx.bucketVersionName)
 		if err != nil {
-			return xerrors.Errorf("creating bucket: %+v", err)
+			return xerrors.Errorf("creating bucket: %v", err)
 		}
 		return nil
 	})
@@ -60,7 +60,7 @@ func (c *Context) NewTreeNodeInstance(t *Tree, tn *TreeNode, protoName string) *
 func (c *Context) SendRaw(si *network.ServerIdentity, msg interface{}) error {
 	_, err := c.server.Send(si, msg)
 	if err != nil {
-		xerrors.Errorf("sending message: %+v", err)
+		xerrors.Errorf("sending message: %v", err)
 	}
 	return nil
 }
@@ -84,7 +84,7 @@ func (c *Context) ServiceID() ServiceID {
 func (c *Context) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	pi, err := c.overlay.CreateProtocol(name, t, c.serviceID)
 	if err != nil {
-		return nil, xerrors.Errorf("creating protocol: %+v", err)
+		return nil, xerrors.Errorf("creating protocol: %v", err)
 	}
 
 	return pi, nil
@@ -98,7 +98,7 @@ func (c *Context) CreateProtocol(name string, t *Tree) (ProtocolInstance, error)
 func (c *Context) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID, error) {
 	id, err := c.server.ProtocolRegister(name, protocol)
 	if err != nil {
-		return id, xerrors.Errorf("protocol registration: %+v", err)
+		return id, xerrors.Errorf("protocol registration: %v", err)
 	}
 	return id, nil
 }
@@ -107,7 +107,7 @@ func (c *Context) ProtocolRegister(name string, protocol NewProtocol) (ProtocolI
 func (c *Context) RegisterProtocolInstance(pi ProtocolInstance) error {
 	err := c.overlay.RegisterProtocolInstance(pi)
 	if err != nil {
-		return xerrors.Errorf("protocol instance regisration: %+v", err)
+		return xerrors.Errorf("protocol instance regisration: %v", err)
 	}
 	return nil
 }
@@ -170,14 +170,14 @@ type ContextDB interface {
 func (c *Context) Save(key []byte, data interface{}) error {
 	buf, err := network.Marshal(data)
 	if err != nil {
-		return xerrors.Errorf("marshaling: %+v", err)
+		return xerrors.Errorf("marshaling: %v", err)
 	}
 	err = c.manager.db.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(c.bucketName)
 		return b.Put(key, buf)
 	})
 	if err != nil {
-		return xerrors.Errorf("tx error: %+v", err)
+		return xerrors.Errorf("tx error: %v", err)
 	}
 	return nil
 }
@@ -197,7 +197,7 @@ func (c *Context) Load(key []byte) (interface{}, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("tx error: %+v", err)
+		return nil, xerrors.Errorf("tx error: %v", err)
 	}
 
 	if buf == nil {
@@ -206,7 +206,7 @@ func (c *Context) Load(key []byte) (interface{}, error) {
 
 	_, ret, err := network.Unmarshal(buf, c.server.suite)
 	if err != nil {
-		return nil, xerrors.Errorf("unmarshaling: %+v")
+		return nil, xerrors.Errorf("unmarshaling: %v")
 	}
 
 	return ret, nil
@@ -227,7 +227,7 @@ func (c *Context) LoadRaw(key []byte) ([]byte, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("tx error: %+v", err)
+		return nil, xerrors.Errorf("tx error: %v", err)
 	}
 	return buf, nil
 }
@@ -250,7 +250,7 @@ func (c *Context) LoadVersion() (int, error) {
 	})
 
 	if err != nil {
-		return -1, xerrors.Errorf("tx error: %+v", err)
+		return -1, xerrors.Errorf("tx error: %v", err)
 	}
 
 	if len(buf) == 0 {
@@ -259,7 +259,7 @@ func (c *Context) LoadVersion() (int, error) {
 	var version int32
 	err = binary.Read(bytes.NewReader(buf), binary.LittleEndian, &version)
 	if err != nil {
-		return -1, xerrors.Errorf("bytes to int: %+v", err)
+		return -1, xerrors.Errorf("bytes to int: %v", err)
 	}
 	return int(version), nil
 }
@@ -269,14 +269,14 @@ func (c *Context) SaveVersion(version int) error {
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, binary.LittleEndian, int32(version))
 	if err != nil {
-		return xerrors.Errorf("int to bytes: %+v", err)
+		return xerrors.Errorf("int to bytes: %v", err)
 	}
 	err = c.manager.db.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(c.bucketVersionName)
 		return b.Put(dbVersion, buf.Bytes())
 	})
 	if err != nil {
-		return xerrors.Errorf("tx error: %+v")
+		return xerrors.Errorf("tx error: %v")
 	}
 	return nil
 }
@@ -297,12 +297,12 @@ func (c *Context) GetAdditionalBucket(name []byte) (*bbolt.DB, []byte) {
 	err := c.manager.db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(fullName)
 		if err != nil {
-			return xerrors.Errorf("create bucket: %+v", err)
+			return xerrors.Errorf("create bucket: %v", err)
 		}
 		return nil
 	})
 	if err != nil {
-		panic(xerrors.Errorf("tx error: %+v", err))
+		panic(xerrors.Errorf("tx error: %v", err))
 	}
 	return c.manager.db, fullName
 }

--- a/context_test.go
+++ b/context_test.go
@@ -173,7 +173,7 @@ func createContext(t *testing.T, dbPath string) *Context {
 	err = db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucket([]byte(name))
 		if err != nil {
-			return xerrors.Errorf("creating bucket: %+v", err)
+			return xerrors.Errorf("creating bucket: %v", err)
 		}
 		return nil
 	})

--- a/context_test.go
+++ b/context_test.go
@@ -15,6 +15,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	bbolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
 )
 
 type ContextData struct {
@@ -171,7 +172,10 @@ func createContext(t *testing.T, dbPath string) *Context {
 
 	err = db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucket([]byte(name))
-		return err
+		if err != nil {
+			return xerrors.Errorf("creating bucket: %+v", err)
+		}
+		return nil
 	})
 	require.Nil(t, err)
 	sm.db = db

--- a/export_test.go
+++ b/export_test.go
@@ -5,7 +5,7 @@ import "golang.org/x/xerrors"
 func (c *Server) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	pi, err := c.overlay.CreateProtocol(name, t, NilServiceID)
 	if err != nil {
-		return nil, xerrors.Errorf("creating protocol: %+v", err)
+		return nil, xerrors.Errorf("creating protocol: %v", err)
 	}
 	return pi, nil
 }
@@ -13,7 +13,7 @@ func (c *Server) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) 
 func (c *Server) StartProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	pi, err := c.overlay.StartProtocol(name, t, NilServiceID)
 	if err != nil {
-		return nil, xerrors.Errorf("starting protocol: %+v", err)
+		return nil, xerrors.Errorf("starting protocol: %v", err)
 	}
 	return pi, nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,11 +1,21 @@
 package onet
 
+import "golang.org/x/xerrors"
+
 func (c *Server) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
-	return c.overlay.CreateProtocol(name, t, NilServiceID)
+	pi, err := c.overlay.CreateProtocol(name, t, NilServiceID)
+	if err != nil {
+		return nil, xerrors.Errorf("creating protocol: %+v", err)
+	}
+	return pi, nil
 }
 
 func (c *Server) StartProtocol(name string, t *Tree) (ProtocolInstance, error) {
-	return c.overlay.StartProtocol(name, t, NilServiceID)
+	pi, err := c.overlay.StartProtocol(name, t, NilServiceID)
+	if err != nil {
+		return nil, xerrors.Errorf("starting protocol: %+v", err)
+	}
+	return pi, nil
 }
 
 func (c *Server) Roster(id RosterID) (*Roster, bool) {

--- a/local.go
+++ b/local.go
@@ -2,7 +2,6 @@ package onet
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -17,6 +16,7 @@ import (
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 )
 
 // LeakyTestCheck represents an enum to indicate how deep CloseAll needs to
@@ -142,7 +142,7 @@ func (l *LocalTest) StartProtocol(name string, t *Tree) (ProtocolInstance, error
 			return l.Overlays[h.ServerIdentity.ID].StartProtocol(name, t, NilServiceID)
 		}
 	}
-	return nil, errors.New("Didn't find server for tree-root")
+	return nil, xerrors.New("Didn't find server for tree-root")
 }
 
 // CreateProtocol takes a name and a tree and will create a
@@ -157,7 +157,7 @@ func (l *LocalTest) CreateProtocol(name string, t *Tree) (ProtocolInstance, erro
 			return l.Overlays[h.ServerIdentity.ID].CreateProtocol(name, t, NilServiceID)
 		}
 	}
-	return nil, errors.New("Didn't find server for tree-root")
+	return nil, xerrors.New("Didn't find server for tree-root")
 }
 
 // GenServers returns n Servers with a localRouter
@@ -252,7 +252,7 @@ func (l *LocalTest) WaitDone(t time.Duration) error {
 		}
 		time.Sleep(t / 10)
 	}
-	return errors.New("still have things lingering: " + strings.Join(lingering, "\n"))
+	return xerrors.New("still have things lingering: " + strings.Join(lingering, "\n"))
 }
 
 // CloseAll closes all the servers.
@@ -369,15 +369,15 @@ func (l *LocalTest) NewTreeNodeInstance(tn *TreeNode, protName string) (*TreeNod
 	l.panicClosed()
 	o := l.Overlays[tn.ServerIdentity.ID]
 	if o == nil {
-		return nil, errors.New("Didn't find corresponding overlay")
+		return nil, xerrors.New("Didn't find corresponding overlay")
 	}
 	tree := l.getTree(tn)
 	if tree == nil {
-		return nil, errors.New("Didn't find tree corresponding to TreeNode")
+		return nil, xerrors.New("Didn't find tree corresponding to TreeNode")
 	}
 	protID := ProtocolNameToID(protName)
 	if !l.Servers[tn.ServerIdentity.ID].protocols.ProtocolExists(protID) {
-		return nil, errors.New("Didn't find protocol: " + protName)
+		return nil, xerrors.New("Didn't find protocol: " + protName)
 	}
 	tok := &Token{
 		TreeID:     tree.ID,
@@ -406,10 +406,10 @@ func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg n
 	ft := from.Tree()
 	tt := to.Tree()
 	if ft == nil || tt == nil {
-		return errors.New("cannot find tree")
+		return xerrors.New("cannot find tree")
 	}
 	if !ft.ID.Equal(tt.ID) {
-		return errors.New("Can't send from one tree to another")
+		return xerrors.New("Can't send from one tree to another")
 	}
 	onetMsg := &ProtocolMsg{
 		Msg:     msg,

--- a/local.go
+++ b/local.go
@@ -141,7 +141,7 @@ func (l *LocalTest) StartProtocol(name string, t *Tree) (ProtocolInstance, error
 			// Node, since it is already dispatched as like a TreeNode ?
 			pi, err := l.Overlays[h.ServerIdentity.ID].StartProtocol(name, t, NilServiceID)
 			if err != nil {
-				return nil, xerrors.Errorf("creating protocol: %+v", err)
+				return nil, xerrors.Errorf("creating protocol: %v", err)
 			}
 			return pi, nil
 		}
@@ -160,7 +160,7 @@ func (l *LocalTest) CreateProtocol(name string, t *Tree) (ProtocolInstance, erro
 			// Node, since it is already dispatched as like a TreeNode ?
 			pi, err := l.Overlays[h.ServerIdentity.ID].CreateProtocol(name, t, NilServiceID)
 			if err != nil {
-				return nil, xerrors.Errorf("creating protocol: %+v", err)
+				return nil, xerrors.Errorf("creating protocol: %v", err)
 			}
 			return pi, nil
 		}
@@ -428,7 +428,7 @@ func (l *LocalTest) sendTreeNode(proto string, from, to *TreeNodeInstance, msg n
 	io := l.Overlays[to.ServerIdentity().ID].protoIO.getByName(proto)
 	err := to.overlay.TransmitMsg(onetMsg, io)
 	if err != nil {
-		return xerrors.Errorf("transmitting message: %+v", err)
+		return xerrors.Errorf("transmitting message: %v", err)
 	}
 	return nil
 }
@@ -498,7 +498,7 @@ func newTCPServer(s network.Suite, port int, path string, wantsTLS bool) *Server
 		var err error
 		tcpHost, err = network.NewTCPHost(id2, s)
 		if err != nil {
-			panic(xerrors.Errorf("tcp host: %+v", err))
+			panic(xerrors.Errorf("tcp host: %v", err))
 		}
 		id.Address = tcpHost.Address()
 		if port != 0 {
@@ -506,7 +506,7 @@ func newTCPServer(s network.Suite, port int, path string, wantsTLS bool) *Server
 		}
 		port, err := strconv.Atoi(id.Address.Port())
 		if err != nil {
-			panic(xerrors.Errorf("invalid port: %+v", err))
+			panic(xerrors.Errorf("invalid port: %v", err))
 		}
 		addrWS = net.JoinHostPort(id.Address.Host(), strconv.Itoa(port+1))
 		if l, err := net.Listen("tcp", addrWS); err == nil {

--- a/log/log.go
+++ b/log/log.go
@@ -38,6 +38,7 @@
 // The log-package also takes into account the following environment-variables:
 //	DEBUG_LVL // will act like SetDebugVisible
 //	DEBUG_TIME // if 'true' it will print the date and time
+//  DEBUG_FILEPATH // if 'true' it will print the absolute filepath
 //	DEBUG_COLOR // if 'false' it will not use colors
 //	DEBUG_PADDING // if 'false' it will not use padding
 // But for this the function ParseEnv() or AddFlags() has to be called.

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	ct "github.com/daviddengcn/go-colortext"
+	"golang.org/x/xerrors"
 )
 
 // LoggerInfo is a structure that should be used when creating a logger.
@@ -107,7 +108,7 @@ func NewFileLogger(lInfo *LoggerInfo, path string) (Logger, error) {
 	// Override file if it already exists.
 	file, err := os.Create(path)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating file: %+v", err)
 	}
 	return &fileLogger{
 		lInfo: lInfo,

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -108,7 +108,7 @@ func NewFileLogger(lInfo *LoggerInfo, path string) (Logger, error) {
 	// Override file if it already exists.
 	file, err := os.Create(path)
 	if err != nil {
-		return nil, xerrors.Errorf("creating file: %+v", err)
+		return nil, xerrors.Errorf("creating file: %v", err)
 	}
 	return &fileLogger{
 		lInfo: lInfo,

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/daviddengcn/go-colortext"
+	ct "github.com/daviddengcn/go-colortext"
 )
 
 // LoggerInfo is a structure that should be used when creating a logger.
@@ -19,6 +19,9 @@ type LoggerInfo struct {
 	// If 'showTime' is true, it will print the time for each line displayed
 	// by the logger.
 	ShowTime bool
+	// If 'AbsoluteFilePath' is true, it will print the absolute file path
+	// instead of the base.
+	AbsoluteFilePath bool
 	// If 'useColors' is true, logs will be colored (defaults to monochrome
 	// output). It also controls padding, since colorful output is higly
 	// correlated with humans who like their log lines padded.
@@ -40,6 +43,8 @@ const (
 	DefaultStdDebugLvl = 1
 	// DefaultStdShowTime is the default value for 'showTime' for the standard logger
 	DefaultStdShowTime = false
+	// DefaultStdAbsoluteFilePath is the default to show absolute path for the standard logger
+	DefaultStdAbsoluteFilePath = false
 	// DefaultStdUseColors is the default value for 'useColors' for the standard logger
 	DefaultStdUseColors = false
 	// DefaultStdPadding is the default value for 'padding' for the standard logger
@@ -166,10 +171,11 @@ func (sl *stdLogger) GetLoggerInfo() *LoggerInfo {
 // multiple stdLoggers.
 func newStdLogger() (Logger, error) {
 	lInfo := &LoggerInfo{
-		DebugLvl:  DefaultStdDebugLvl,
-		UseColors: DefaultStdUseColors,
-		ShowTime:  DefaultStdShowTime,
-		Padding:   DefaultStdPadding,
+		DebugLvl:         DefaultStdDebugLvl,
+		UseColors:        DefaultStdUseColors,
+		ShowTime:         DefaultStdShowTime,
+		AbsoluteFilePath: DefaultStdAbsoluteFilePath,
+		Padding:          DefaultStdPadding,
 	}
 	return &stdLogger{lInfo: lInfo}, nil
 }

--- a/log/loggers_test.go
+++ b/log/loggers_test.go
@@ -87,6 +87,6 @@ func TestFileLogger(t *testing.T) {
 	Lvl2("testing2")
 	out, err := ioutil.ReadFile(path)
 	require.Nil(t, err)
-	require.Equal(t, "1 : fake_name.go:0 - testing1\n"+
-		"2 : fake_name.go:0 - testing2\n", string(out))
+	require.Equal(t, "1 : fake_name.go:0 (log.TestFileLogger) - testing1\n"+
+		"2 : fake_name.go:0 (log.TestFileLogger) - testing2\n", string(out))
 }

--- a/log/loggers_test.go
+++ b/log/loggers_test.go
@@ -87,6 +87,6 @@ func TestFileLogger(t *testing.T) {
 	Lvl2("testing2")
 	out, err := ioutil.ReadFile(path)
 	require.Nil(t, err)
-	require.Equal(t, "1 : (log.TestFileLogger: 0) - testing1\n"+
-		"2 : (log.TestFileLogger: 0) - testing2\n", string(out))
+	require.Equal(t, "1 : fake_name.go:0 - testing1\n"+
+		"2 : fake_name.go:0 - testing2\n", string(out))
 }

--- a/log/lvl.go
+++ b/log/lvl.go
@@ -50,6 +50,7 @@ var NamePadding = 40
 
 // LinePadding of line-numbers for a nice debug-output - used in the same way as
 // NamePadding.
+// Deprecated: the caller is merged thus no line padding is necessary anymore.
 var LinePadding = 3
 
 // StaticMsg - if this variable is set, it will be outputted between the
@@ -385,6 +386,7 @@ func ParseEnv() {
 			Error("Couldn't convert", dv, "to debug-level")
 		}
 	}
+
 	dt := os.Getenv("DEBUG_TIME")
 	if dt != "" {
 		dtInt, err := strconv.ParseBool(dt)
@@ -394,6 +396,17 @@ func ParseEnv() {
 			Error("Couldn't convert", dt, "to boolean")
 		}
 	}
+
+	dfp := os.Getenv("DEBUG_FILEPATH")
+	if dfp != "" {
+		dfpInt, err := strconv.ParseBool(dfp)
+		Lvl3("Setting absoluteFilePath to", dfp, dfpInt, err)
+		SetAbsoluteFilePath(dfpInt)
+		if err != nil {
+			Error("Couldn't convert", dfp, "to boolean")
+		}
+	}
+
 	dc := os.Getenv("DEBUG_COLOR")
 	if dc != "" {
 		ucInt, err := strconv.ParseBool(dc)
@@ -403,6 +416,7 @@ func ParseEnv() {
 			Error("Couldn't convert", dc, "to boolean")
 		}
 	}
+
 	dp := os.Getenv("DEBUG_PADDING")
 	if dp != "" {
 		dpBool, err := strconv.ParseBool(dp)
@@ -428,6 +442,7 @@ func RegisterFlags() {
 	flag.BoolVar(&loggers[0].GetLoggerInfo().ShowTime, "debug-time", defaultShowTime, "Shows the time of each message")
 	flag.BoolVar(&loggers[0].GetLoggerInfo().UseColors, "debug-color", defaultUseColors, "Colors each message")
 	flag.BoolVar(&loggers[0].GetLoggerInfo().Padding, "debug-padding", defaultPadding, "Pads each message nicely")
+	flag.BoolVar(&loggers[0].GetLoggerInfo().AbsoluteFilePath, "debug-filepath", DefaultStdAbsoluteFilePath, "extends the filename with the absolute path")
 }
 
 var timeoutFlagMutex sync.Mutex

--- a/log/lvl.go
+++ b/log/lvl.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -68,7 +69,7 @@ func init() {
 	}
 	stdKey := RegisterLogger(stdLogger)
 	if stdKey != 0 {
-		panic(errors.New("Cannot add a logger before the standard logger"))
+		panic(xerrors.New("Cannot add a logger before the standard logger"))
 	}
 	ParseEnv()
 }

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -54,6 +54,9 @@ func TestFlags(t *testing.T) {
 	if ShowTime() {
 		t.Fatal("ShowTime should be false")
 	}
+	if AbsoluteFilePath() {
+		t.Fatal("AbsoluteFilePath should be false")
+	}
 	if UseColors() {
 		t.Fatal("UseColors should be false")
 	}
@@ -63,6 +66,7 @@ func TestFlags(t *testing.T) {
 
 	os.Setenv("DEBUG_LVL", "3")
 	os.Setenv("DEBUG_TIME", "true")
+	os.Setenv("DEBUG_FILEPATH", "true")
 	os.Setenv("DEBUG_COLOR", "false")
 	os.Setenv("DEBUG_PADDING", "false")
 	ParseEnv()
@@ -71,6 +75,9 @@ func TestFlags(t *testing.T) {
 	}
 	if !ShowTime() {
 		t.Fatal("ShowTime should be true")
+	}
+	if !AbsoluteFilePath() {
+		t.Fatal("AbsoluteFilePath sgould be true")
 	}
 	if UseColors() {
 		t.Fatal("UseColors should be false")

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"errors"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -140,20 +139,20 @@ func checkOutput(f func(), wantsStd, wantsErr bool) error {
 	errStr := GetStdErr()
 	if wantsStd {
 		if len(stdStr) == 0 {
-			return errors.New("Stdout was empty")
+			return xerrors.New("Stdout was empty")
 		}
 	} else {
 		if len(stdStr) > 0 {
-			return errors.New("Stdout was full")
+			return xerrors.New("Stdout was full")
 		}
 	}
 	if wantsErr {
 		if len(errStr) == 0 {
-			return errors.New("Stderr was empty")
+			return xerrors.New("Stderr was empty")
 		}
 	} else {
 		if len(errStr) > 0 {
-			return errors.New("Stderr was full")
+			return xerrors.New("Stderr was full")
 		}
 	}
 	return nil

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -170,8 +170,8 @@ func ExampleLvl2() {
 	SetDebugVisible(1)
 
 	// Output:
-	// 1 :                             fake_name.go:0 - Level1
-	// 2 :                             fake_name.go:0 - Level2
+	// 1 : fake_name.go:0 (log.ExampleLvl2)         - Level1
+	// 2 : fake_name.go:0 (log.ExampleLvl2)         - Level2
 }
 
 func ExampleLvl1() {
@@ -180,7 +180,7 @@ func ExampleLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 :                             fake_name.go:0 - Multiple parameters
+	// 1 : fake_name.go:0 (log.ExampleLvl1)         - Multiple parameters
 }
 
 func ExampleLLvl1() {
@@ -192,10 +192,10 @@ func ExampleLLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 :                             fake_name.go:0 - Lvl output
-	// 1!:                             fake_name.go:0 - LLvl output
-	// 1 :                             fake_name.go:0 - Lvlf output
-	// 1!:                             fake_name.go:0 - LLvlf output
+	// 1 : fake_name.go:0 (log.ExampleLLvl1)        - Lvl output
+	// 1!: fake_name.go:0 (log.ExampleLLvl1)        - LLvl output
+	// 1 : fake_name.go:0 (log.ExampleLLvl1)        - Lvlf output
+	// 1!: fake_name.go:0 (log.ExampleLLvl1)        - LLvlf output
 }
 
 func thisIsAVeryLongFunctionNameThatWillOverflow() {
@@ -211,9 +211,9 @@ func ExampleLvlf1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 :                             fake_name.go:0 - Before
-	// 1 :                             fake_name.go:0 - Overflow
-	// 1 :                             fake_name.go:0 - After
+	// 1 : fake_name.go:0 (log.ExampleLvlf1)        - Before
+	// 1 : fake_name.go:0 (log.thisIsAVeryLongFunctionNameThatWillOverflow) - Overflow
+	// 1 : fake_name.go:0 (log.ExampleLvlf1)        - After
 }
 
 func ExampleLvl3() {
@@ -225,9 +225,9 @@ func ExampleLvl3() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : fake_name.go:0 - Before
-	// 1 : fake_name.go:0 - Overflow
-	// 1 : fake_name.go:0 - After
+	// 1 : fake_name.go:0 (log.ExampleLvl3) - Before
+	// 1 : fake_name.go:0 (log.thisIsAVeryLongFunctionNameThatWillOverflow) - Overflow
+	// 1 : fake_name.go:0 (log.ExampleLvl3) - After
 }
 
 func clearEnv() {

--- a/log/lvl_test.go
+++ b/log/lvl_test.go
@@ -23,12 +23,12 @@ func TestTime(t *testing.T) {
 	SetDebugVisible(1)
 	GetStdOut()
 	Lvl1("No time")
-	assert.True(t, containsStdOut("1 : ("))
+	assert.True(t, containsStdOut("1 : "))
 	SetShowTime(true)
 	defer func() { SetShowTime(false) }()
 	Lvl1("With time")
 	str := GetStdOut()
-	if strings.Contains(str, "1 : (") {
+	if strings.Contains(str, "1 : ") {
 		t.Fatal("Didn't get correct string: ", str)
 	}
 	if strings.Contains(str, " +") {
@@ -170,8 +170,8 @@ func ExampleLvl2() {
 	SetDebugVisible(1)
 
 	// Output:
-	// 1 : (                         log.ExampleLvl2:   0) - Level1
-	// 2 : (                         log.ExampleLvl2:   0) - Level2
+	// 1 :                             fake_name.go:0 - Level1
+	// 2 :                             fake_name.go:0 - Level2
 }
 
 func ExampleLvl1() {
@@ -180,7 +180,7 @@ func ExampleLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                         log.ExampleLvl1:   0) - Multiple parameters
+	// 1 :                             fake_name.go:0 - Multiple parameters
 }
 
 func ExampleLLvl1() {
@@ -192,10 +192,10 @@ func ExampleLLvl1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                        log.ExampleLLvl1:   0) - Lvl output
-	// 1!: (                        log.ExampleLLvl1:   0) - LLvl output
-	// 1 : (                        log.ExampleLLvl1:   0) - Lvlf output
-	// 1!: (                        log.ExampleLLvl1:   0) - LLvlf output
+	// 1 :                             fake_name.go:0 - Lvl output
+	// 1!:                             fake_name.go:0 - LLvl output
+	// 1 :                             fake_name.go:0 - Lvlf output
+	// 1!:                             fake_name.go:0 - LLvlf output
 }
 
 func thisIsAVeryLongFunctionNameThatWillOverflow() {
@@ -211,9 +211,9 @@ func ExampleLvlf1() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (                        log.ExampleLvlf1:   0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
-	// 1 : (                        log.ExampleLvlf1:   0) - After
+	// 1 :                             fake_name.go:0 - Before
+	// 1 :                             fake_name.go:0 - Overflow
+	// 1 :                             fake_name.go:0 - After
 }
 
 func ExampleLvl3() {
@@ -225,9 +225,9 @@ func ExampleLvl3() {
 	OutputToBuf()
 
 	// Output:
-	// 1 : (log.ExampleLvl3:   0) - Before
-	// 1 : (log.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
-	// 1 : (log.ExampleLvl3:   0) - After
+	// 1 : fake_name.go:0 - Before
+	// 1 : fake_name.go:0 - Overflow
+	// 1 : fake_name.go:0 - After
 }
 
 func clearEnv() {

--- a/log/syslog.go
+++ b/log/syslog.go
@@ -35,7 +35,7 @@ func (sl *syslogLogger) GetLoggerInfo() *LoggerInfo {
 func NewSyslogLogger(lInfo *LoggerInfo, priority syslog.Priority, tag string) (Logger, error) {
 	writer, err := syslog.New(priority, tag)
 	if err != nil {
-		return nil, xerrors.Errorf("system log: %+v", err)
+		return nil, xerrors.Errorf("system log: %v", err)
 	}
 	return &syslogLogger{
 		lInfo:  lInfo,

--- a/log/syslog.go
+++ b/log/syslog.go
@@ -2,7 +2,11 @@
 
 package log
 
-import "log/syslog"
+import (
+	"log/syslog"
+
+	"golang.org/x/xerrors"
+)
 
 type syslogLogger struct {
 	lInfo  *LoggerInfo
@@ -31,7 +35,7 @@ func (sl *syslogLogger) GetLoggerInfo() *LoggerInfo {
 func NewSyslogLogger(lInfo *LoggerInfo, priority syslog.Priority, tag string) (Logger, error) {
 	writer, err := syslog.New(priority, tag)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("system log: %+v", err)
 	}
 	return &syslogLogger{
 		lInfo:  lInfo,

--- a/log/ui.go
+++ b/log/ui.go
@@ -29,8 +29,17 @@ func Warn(args ...interface{}) {
 	lvlUI(lvlWarning, args...)
 }
 
-// Error prints out the error message and quits
+// Error prints out the error message and quits. If the
+// argument is an error, it will print the stack trace.
 func Error(args ...interface{}) {
+	last := len(args) - 1
+	if last >= 0 {
+		err, ok := args[last].(error)
+		if ok {
+			args[last] = fmt.Sprintf("%+v", err)
+		}
+	}
+
 	lvlUI(lvlError, args...)
 }
 

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -36,11 +36,11 @@ func TestError(t *testing.T) {
 func TestLvl(t *testing.T) {
 	SetDebugVisible(1)
 	Info("TestLvl")
-	assert.Contains(t, GetStdOut(), "I :                             fake_name.go:0 - TestLvl\n")
+	assert.Contains(t, GetStdOut(), "I : fake_name.go:0 (log.TestLvl)             - TestLvl\n")
 	Print("TestLvl")
-	assert.Contains(t, GetStdOut(), "I :                             fake_name.go:0 - TestLvl\n")
+	assert.Contains(t, GetStdOut(), "I : fake_name.go:0 (log.TestLvl)             - TestLvl\n")
 	Warn("TestLvl")
-	assert.Contains(t, GetStdErr(), "W :                             fake_name.go:0 - TestLvl\n")
+	assert.Contains(t, GetStdErr(), "W : fake_name.go:0 (log.TestLvl)             - TestLvl\n")
 }
 
 func TestPanic(t *testing.T) {

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
 )
 
 func TestMain(m *testing.M) {
@@ -23,14 +24,23 @@ func TestInfo(t *testing.T) {
 	SetDebugVisible(1)
 }
 
+func TestError(t *testing.T) {
+	SetDebugVisible(1)
+	Error(xerrors.New("error with stack"))
+	assert.Contains(t, GetStdErr(), "/log/ui_test.go:")
+
+	Error(xerrors.New("test"), "and another message")
+	assert.NotContains(t, GetStdErr(), "/log/ui_test.go:")
+}
+
 func TestLvl(t *testing.T) {
 	SetDebugVisible(1)
 	Info("TestLvl")
-	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.Contains(t, GetStdOut(), "I :                             fake_name.go:0 - TestLvl\n")
 	Print("TestLvl")
-	assert.True(t, containsStdOut("I : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.Contains(t, GetStdOut(), "I :                             fake_name.go:0 - TestLvl\n")
 	Warn("TestLvl")
-	assert.True(t, containsStdErr("W : (                             log.TestLvl:   0) - TestLvl\n"))
+	assert.Contains(t, GetStdErr(), "W :                             fake_name.go:0 - TestLvl\n")
 }
 
 func TestPanic(t *testing.T) {

--- a/network/dispatch.go
+++ b/network/dispatch.go
@@ -1,10 +1,10 @@
 package network
 
 import (
-	"errors"
 	"sync"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // Dispatcher is an interface whose sole role is to distribute messages to the
@@ -89,7 +89,7 @@ func (d *BlockingDispatcher) Dispatch(packet *Envelope) error {
 	var p Processor
 	if p = d.procs[packet.MsgType]; p == nil {
 		d.Unlock()
-		return errors.New("No Processor attached to this message type " + packet.MsgType.String())
+		return xerrors.New("No Processor attached to this message type " + packet.MsgType.String())
 	}
 	d.Unlock()
 	p.Process(packet)
@@ -120,7 +120,7 @@ func (d *RoutineDispatcher) Dispatch(packet *Envelope) error {
 	defer d.Unlock()
 	var p = d.procs[packet.MsgType]
 	if p == nil {
-		return errors.New("no Processor attached to this message type")
+		return xerrors.New("no Processor attached to this message type")
 	}
 	go func() {
 		d.routinesMutex.Lock()

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -137,7 +137,7 @@ func Marshal(msg Message) ([]byte, error) {
 	}
 	b := new(bytes.Buffer)
 	if err := binary.Write(b, globalOrder, msgType); err != nil {
-		return nil, xerrors.Errorf("buffer write: %+v", err)
+		return nil, xerrors.Errorf("buffer write: %v", err)
 	}
 	var buf []byte
 	var err error
@@ -146,11 +146,11 @@ func Marshal(msg Message) ([]byte, error) {
 		if log.DebugVisible() > 0 {
 			log.Error(log.Stack())
 		}
-		return nil, xerrors.Errorf("encoding: %+v", err)
+		return nil, xerrors.Errorf("encoding: %v", err)
 	}
 	_, err = b.Write(buf)
 	if err != nil {
-		return nil, xerrors.Errorf("buffer write: %+v", err)
+		return nil, xerrors.Errorf("buffer write: %v", err)
 	}
 	return b.Bytes(), nil
 }
@@ -164,7 +164,7 @@ func Unmarshal(buf []byte, suite Suite) (MessageTypeID, Message, error) {
 	b := bytes.NewBuffer(buf)
 	var tID MessageTypeID
 	if err := binary.Read(b, globalOrder, &tID); err != nil {
-		return ErrorType, nil, xerrors.Errorf("buffer read: %+v", err)
+		return ErrorType, nil, xerrors.Errorf("buffer read: %v", err)
 	}
 	typ, ok := registry.get(tID)
 	if !ok {
@@ -174,7 +174,7 @@ func Unmarshal(buf []byte, suite Suite) (MessageTypeID, Message, error) {
 	ptr := ptrVal.Interface()
 	constructors := DefaultConstructors(suite)
 	if err := protobuf.DecodeWithConstructors(b.Bytes(), ptr, constructors); err != nil {
-		return ErrorType, nil, xerrors.Errorf("decoding: %+v", err)
+		return ErrorType, nil, xerrors.Errorf("decoding: %v", err)
 	}
 	return tID, ptrVal.Interface(), nil
 }

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"go.dedis.ch/kyber/v3/pairing/bn256"
-	"go.dedis.ch/kyber/v3/suites"
 	"reflect"
 	"sync"
+
+	"go.dedis.ch/kyber/v3/pairing/bn256"
+	"go.dedis.ch/kyber/v3/suites"
+	"golang.org/x/xerrors"
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
-	"gopkg.in/satori/go.uuid.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func init() {
@@ -131,23 +133,26 @@ func MessageType(msg Message) MessageTypeID {
 func Marshal(msg Message) ([]byte, error) {
 	var msgType MessageTypeID
 	if msgType = MessageType(msg); msgType == ErrorType {
-		return nil, fmt.Errorf("type of message %s not registered to the network library", reflect.TypeOf(msg))
+		return nil, xerrors.Errorf("type of message %s not registered to the network library", reflect.TypeOf(msg))
 	}
 	b := new(bytes.Buffer)
 	if err := binary.Write(b, globalOrder, msgType); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("buffer write: %+v", err)
 	}
 	var buf []byte
 	var err error
 	if buf, err = protobuf.Encode(msg); err != nil {
-		log.Errorf("Error for protobuf encoding: %s %+v", err, msg)
+		log.Errorf("Error for protobuf encoding: %s %+v", msg, err)
 		if log.DebugVisible() > 0 {
 			log.Error(log.Stack())
 		}
-		return nil, err
+		return nil, xerrors.Errorf("encoding: %+v", err)
 	}
 	_, err = b.Write(buf)
-	return b.Bytes(), err
+	if err != nil {
+		return nil, xerrors.Errorf("buffer write: %+v", err)
+	}
+	return b.Bytes(), nil
 }
 
 // Unmarshal returns the type and the message out of a buffer. One can cast the
@@ -159,17 +164,17 @@ func Unmarshal(buf []byte, suite Suite) (MessageTypeID, Message, error) {
 	b := bytes.NewBuffer(buf)
 	var tID MessageTypeID
 	if err := binary.Read(b, globalOrder, &tID); err != nil {
-		return ErrorType, nil, err
+		return ErrorType, nil, xerrors.Errorf("buffer read: %+v", err)
 	}
 	typ, ok := registry.get(tID)
 	if !ok {
-		return ErrorType, nil, fmt.Errorf("type %s not registered", tID.String())
+		return ErrorType, nil, xerrors.Errorf("type %s not registered", tID.String())
 	}
 	ptrVal := reflect.New(typ)
 	ptr := ptrVal.Interface()
 	constructors := DefaultConstructors(suite)
 	if err := protobuf.DecodeWithConstructors(b.Bytes(), ptr, constructors); err != nil {
-		return ErrorType, nil, err
+		return ErrorType, nil, xerrors.Errorf("decoding: %+v", err)
 	}
 	return tID, ptrVal.Interface(), nil
 }

--- a/network/local.go
+++ b/network/local.go
@@ -1,10 +1,11 @@
 package network
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 // NewLocalRouter returns a fresh router which uses only local queues. It uses
@@ -108,7 +109,7 @@ func (lm *LocalManager) connect(local, remote Address, s Suite) (*LocalConn, err
 	lm.Lock()
 	defer lm.Unlock()
 	if lm.stopped {
-		return nil, errors.New("system is stopped")
+		return nil, xerrors.New("system is stopped")
 	}
 
 	fn, ok := lm.listening[remote]
@@ -248,7 +249,7 @@ func NewLocalConnWithManager(lm *LocalManager, local, remote Address, s Suite) (
 		}
 		time.Sleep(WaitRetry)
 	}
-	return nil, errors.New("Could not connect")
+	return nil, xerrors.New("Could not connect")
 }
 
 func (lc *LocalConn) start(wg *sync.WaitGroup) {
@@ -383,7 +384,7 @@ func NewLocalListenerWithManager(lm *LocalManager, addr Address, s Suite) (*Loca
 		suite:   s,
 	}
 	if addr.ConnType() != Local {
-		return nil, errors.New("Wrong address type for local listener")
+		return nil, xerrors.New("Wrong address type for local listener")
 	}
 	if l.manager.isListening(addr) {
 		return nil, fmt.Errorf("%s is already listening: can't listen again", addr)
@@ -475,7 +476,7 @@ func NewLocalHostWithManager(lm *LocalManager, addr Address, s Suite) (*LocalHos
 // In case of an error, it will return a nil Conn.
 func (lh *LocalHost) Connect(si *ServerIdentity) (Conn, error) {
 	if si.Address.ConnType() != Local {
-		return nil, errors.New("Can't connect to non-Local address")
+		return nil, xerrors.New("Can't connect to non-Local address")
 	}
 	var finalErr error
 	for i := 0; i < MaxRetryConnect; i++ {

--- a/network/local.go
+++ b/network/local.go
@@ -14,7 +14,7 @@ import (
 func NewLocalRouter(sid *ServerIdentity, s Suite) (*Router, error) {
 	r, err := NewLocalRouterWithManager(defaultLocalManager, sid, s)
 	if err != nil {
-		return nil, xerrors.Errorf("local router: %+v", err)
+		return nil, xerrors.Errorf("local router: %v", err)
 	}
 	return r, nil
 }
@@ -25,7 +25,7 @@ func NewLocalRouter(sid *ServerIdentity, s Suite) (*Router, error) {
 func NewLocalRouterWithManager(lm *LocalManager, sid *ServerIdentity, s Suite) (*Router, error) {
 	h, err := NewLocalHostWithManager(lm, sid.Address, s)
 	if err != nil {
-		return nil, xerrors.Errorf("local router: %+v", err)
+		return nil, xerrors.Errorf("local router: %v", err)
 	}
 	r := NewRouter(sid, h)
 	r.UnauthOk = true
@@ -248,7 +248,7 @@ func NewLocalConnWithManager(lm *LocalManager, local, remote Address, s Suite) (
 		if err == nil {
 			return c, nil
 		} else if i == MaxRetryConnect-1 {
-			return nil, xerrors.Errorf("connect: %+v", err)
+			return nil, xerrors.Errorf("connect: %v", err)
 		}
 		time.Sleep(WaitRetry)
 	}
@@ -277,7 +277,7 @@ func (lc *LocalConn) start(wg *sync.WaitGroup) {
 func (lc *LocalConn) Send(msg Message) (uint64, error) {
 	buff, err := Marshal(msg)
 	if err != nil {
-		return 0, xerrors.Errorf("marshal: %+v", err)
+		return 0, xerrors.Errorf("marshal: %v", err)
 	}
 	sentLen := uint64(len(buff))
 	lc.updateTx(sentLen)
@@ -300,7 +300,7 @@ func (lc *LocalConn) Receive() (*Envelope, error) {
 
 	id, body, err := Unmarshal(buff, lc.suite)
 	if err != nil {
-		return nil, xerrors.Errorf("unmarshaling: %+v", err)
+		return nil, xerrors.Errorf("unmarshaling: %v", err)
 	}
 
 	return &Envelope{
@@ -333,7 +333,7 @@ func (lc *LocalConn) Close() error {
 	}
 	err := lc.manager.close(lc)
 	if err != nil {
-		return xerrors.Errorf("closing: %+v", err)
+		return xerrors.Errorf("closing: %v", err)
 	}
 	return nil
 }
@@ -386,7 +386,7 @@ type LocalListener struct {
 func NewLocalListener(addr Address, s Suite) (*LocalListener, error) {
 	listener, err := NewLocalListenerWithManager(defaultLocalManager, addr, s)
 	if err != nil {
-		return nil, xerrors.Errorf("local listener: %+v", err)
+		return nil, xerrors.Errorf("local listener: %v", err)
 	}
 	return listener, nil
 }
@@ -474,7 +474,7 @@ type LocalHost struct {
 func NewLocalHost(addr Address, s Suite) (*LocalHost, error) {
 	host, err := NewLocalHostWithManager(defaultLocalManager, addr, s)
 	if err != nil {
-		return nil, xerrors.Errorf("local host: %+v", err)
+		return nil, xerrors.Errorf("local host: %v", err)
 	}
 	return host, nil
 }
@@ -491,7 +491,7 @@ func NewLocalHostWithManager(lm *LocalManager, addr Address, s Suite) (*LocalHos
 	var err error
 	lh.LocalListener, err = NewLocalListenerWithManager(lm, addr, s)
 	if err != nil {
-		return nil, xerrors.Errorf("local host: %+v", err)
+		return nil, xerrors.Errorf("local host: %v", err)
 	}
 	return lh, nil
 
@@ -510,7 +510,7 @@ func (lh *LocalHost) Connect(si *ServerIdentity) (Conn, error) {
 		if err == nil {
 			return c, nil
 		}
-		finalErr = xerrors.Errorf("local connection: %+v", err)
+		finalErr = xerrors.Errorf("local connection: %v", err)
 		select {
 		case <-time.After(WaitRetry):
 			// sleep done, go try again

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -150,7 +150,7 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 	handshake := func(c Conn, sending, receiving Address) error {
 		sentLen, err := c.Send(&AddressTest{sending, int64(secret)})
 		if err != nil {
-			return xerrors.Errorf("sending: %+v", err)
+			return xerrors.Errorf("sending: %v", err)
 		}
 		if sentLen == 0 {
 			return xerrors.Errorf("sentLen is zero")

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -1,13 +1,13 @@
 package network
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
 )
 
 func TestLocalRouter(t *testing.T) {
@@ -98,8 +98,8 @@ func TestLocalConnCloseReceive(t *testing.T) {
 	<-ready
 	<-ready
 	_, err = outgoing.Receive()
-	assert.Equal(t, ErrClosed, err)
-	assert.Equal(t, ErrClosed, outgoing.Close())
+	assert.True(t, xerrors.Is(err, ErrClosed))
+	assert.True(t, xerrors.Is(outgoing.Close(), ErrClosed))
 	assert.Nil(t, listener.Stop())
 }
 
@@ -150,10 +150,10 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 	handshake := func(c Conn, sending, receiving Address) error {
 		sentLen, err := c.Send(&AddressTest{sending, int64(secret)})
 		if err != nil {
-			return err
+			return xerrors.Errorf("sending: %+v", err)
 		}
 		if sentLen == 0 {
-			return fmt.Errorf("sentLen is zero")
+			return xerrors.Errorf("sentLen is zero")
 		}
 
 		p, err := c.Receive()
@@ -163,10 +163,10 @@ func testConnListener(ctx *LocalManager, done chan error, listenA, connA *Server
 
 		at := p.Msg.(*AddressTest)
 		if at.Addr != receiving {
-			return fmt.Errorf("Receiveid wrong address")
+			return xerrors.New("Receiveid wrong address")
 		}
 		if at.Val != int64(secret) {
-			return fmt.Errorf("Received wrong secret")
+			return xerrors.New("Received wrong secret")
 		}
 		return nil
 	}
@@ -284,10 +284,10 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 	<-incomingConn
 	// close the incoming conn, so Receive here should return an error
 	nm, err = outgoing.Receive()
-	if err != ErrClosed {
+	if !xerrors.Is(err, ErrClosed) {
 		t.Error("Receive should have returned an error")
 	}
-	assert.Equal(t, ErrClosed, outgoing.Close())
+	assert.True(t, xerrors.Is(outgoing.Close(), ErrClosed))
 	// close the listener
 	assert.Nil(t, listener.Stop())
 	<-ready

--- a/network/router.go
+++ b/network/router.go
@@ -99,7 +99,7 @@ func (r *Router) Unpause() {
 // blocking call until r.Stop() is called.
 func (r *Router) Start() {
 	if !r.Quiet {
-		log.Lvlf1("New router with address %s and public key %s", r.address, r.ServerIdentity.Public)
+		log.Lvlf3("New router with address %s and public key %s", r.address, r.ServerIdentity.Public)
 	}
 
 	// Any incoming connection waits for the remote server identity
@@ -160,7 +160,7 @@ func (r *Router) Stop() error {
 	r.wg.Wait()
 
 	if err != nil {
-		return xerrors.Errorf("stopping: %+v", err)
+		return xerrors.Errorf("stopping: %v", err)
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 		// Marshal the message to get its length
 		b, err := Marshal(msg)
 		if err != nil {
-			return 0, xerrors.Errorf("marshaling: %+v", err)
+			return 0, xerrors.Errorf("marshaling: %v", err)
 		}
 		log.Lvl5("Message sent")
 
@@ -203,7 +203,7 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 		c, sentLen, err = r.connect(e)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, xerrors.Errorf("connecting: %+v", err)
+			return totSentLen, xerrors.Errorf("connecting: %v", err)
 		}
 	}
 
@@ -215,12 +215,12 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 		c, sentLen, err := r.connect(e)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, xerrors.Errorf("connecting: %+v", err)
+			return totSentLen, xerrors.Errorf("connecting: %v", err)
 		}
 		sentLen, err = c.Send(msg)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, xerrors.Errorf("connecting: %+v", err)
+			return totSentLen, xerrors.Errorf("connecting: %v", err)
 		}
 	}
 	log.Lvl5("Message sent")
@@ -234,20 +234,20 @@ func (r *Router) connect(si *ServerIdentity) (Conn, uint64, error) {
 	c, err := r.host.Connect(si)
 	if err != nil {
 		log.Lvl3("Could not connect to", si.Address, err)
-		return nil, 0, xerrors.Errorf("connecting: %+v", err)
+		return nil, 0, xerrors.Errorf("connecting: %v", err)
 	}
 	log.Lvl3(r.address, "Connected to", si.Address)
 	var sentLen uint64
 	if sentLen, err = c.Send(r.ServerIdentity); err != nil {
-		return nil, sentLen, xerrors.Errorf("sending: %+v", err)
+		return nil, sentLen, xerrors.Errorf("sending: %v", err)
 	}
 
 	if err = r.registerConnection(si, c); err != nil {
-		return nil, sentLen, xerrors.Errorf("register connection: %+v", err)
+		return nil, sentLen, xerrors.Errorf("register connection: %v", err)
 	}
 
 	if err = r.launchHandleRoutine(si, c); err != nil {
-		return nil, sentLen, xerrors.Errorf("handling routine: %+v", err)
+		return nil, sentLen, xerrors.Errorf("handling routine: %v", err)
 	}
 	return c, sentLen, nil
 
@@ -479,7 +479,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 			}
 			pub, err := pubFromCN(tcpConn.suite, cs.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
-				return nil, xerrors.Errorf("decoding key: %+v", err)
+				return nil, xerrors.Errorf("decoding key: %v", err)
 			}
 
 			if !pub.Equal(dst.Public) {

--- a/network/router.go
+++ b/network/router.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"crypto/tls"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -161,7 +160,7 @@ func (r *Router) Stop() error {
 	r.wg.Wait()
 
 	if err != nil {
-		return err
+		return xerrors.Errorf("stopping: %+v", err)
 	}
 	return nil
 }
@@ -184,12 +183,12 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 			Msg:            msg,
 		}
 		if err := r.Dispatch(packet); err != nil {
-			return 0, fmt.Errorf("Error dispatching: %s", err)
+			return 0, xerrors.Errorf("Error dispatching: %s", err)
 		}
 		// Marshal the message to get its length
 		b, err := Marshal(msg)
 		if err != nil {
-			return 0, err
+			return 0, xerrors.Errorf("marshaling: %+v", err)
 		}
 		log.Lvl5("Message sent")
 
@@ -204,7 +203,7 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 		c, sentLen, err = r.connect(e)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, err
+			return totSentLen, xerrors.Errorf("connecting: %+v", err)
 		}
 	}
 
@@ -216,12 +215,12 @@ func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 		c, sentLen, err := r.connect(e)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, err
+			return totSentLen, xerrors.Errorf("connecting: %+v", err)
 		}
 		sentLen, err = c.Send(msg)
 		totSentLen += sentLen
 		if err != nil {
-			return totSentLen, err
+			return totSentLen, xerrors.Errorf("connecting: %+v", err)
 		}
 	}
 	log.Lvl5("Message sent")
@@ -235,20 +234,20 @@ func (r *Router) connect(si *ServerIdentity) (Conn, uint64, error) {
 	c, err := r.host.Connect(si)
 	if err != nil {
 		log.Lvl3("Could not connect to", si.Address, err)
-		return nil, 0, err
+		return nil, 0, xerrors.Errorf("connecting: %+v", err)
 	}
 	log.Lvl3(r.address, "Connected to", si.Address)
 	var sentLen uint64
 	if sentLen, err = c.Send(r.ServerIdentity); err != nil {
-		return nil, sentLen, err
+		return nil, sentLen, xerrors.Errorf("sending: %+v", err)
 	}
 
 	if err = r.registerConnection(si, c); err != nil {
-		return nil, sentLen, err
+		return nil, sentLen, xerrors.Errorf("register connection: %+v", err)
 	}
 
 	if err = r.launchHandleRoutine(si, c); err != nil {
-		return nil, sentLen, err
+		return nil, sentLen, xerrors.Errorf("handling routine: %+v", err)
 	}
 	return c, sentLen, nil
 
@@ -322,19 +321,19 @@ func (r *Router) handleConn(remote *ServerIdentity, c Conn) {
 		}
 
 		if err != nil {
-			if err == ErrTimeout {
+			if xerrors.Is(err, ErrTimeout) {
 				log.Lvlf5("%s drops %s connection: timeout", r.ServerIdentity.Address, remote.Address)
 				r.triggerConnectionErrorHandlers(remote)
 				return
 			}
 
-			if err == ErrClosed || err == ErrEOF {
+			if xerrors.Is(err, ErrClosed) || xerrors.Is(err, ErrEOF) {
 				// Connection got closed.
 				log.Lvlf5("%s drops %s connection: closed", r.ServerIdentity.Address, remote.Address)
 				r.triggerConnectionErrorHandlers(remote)
 				return
 			}
-			if err == ErrUnknown {
+			if xerrors.Is(err, ErrUnknown) {
 				// The error might not be recoverable so the connection is dropped
 				log.Lvlf5("%v drops %v connection: unknown", r.ServerIdentity, remote)
 				r.triggerConnectionErrorHandlers(remote)
@@ -377,7 +376,7 @@ func (r *Router) registerConnection(remote *ServerIdentity, c Conn) error {
 	r.Lock()
 	defer r.Unlock()
 	if r.isClosed {
-		return ErrClosed
+		return xerrors.Errorf("closing: %w", ErrClosed)
 	}
 	_, okc := r.connections[remote.ID]
 	if okc {
@@ -391,7 +390,7 @@ func (r *Router) launchHandleRoutine(dst *ServerIdentity, c Conn) error {
 	r.Lock()
 	defer r.Unlock()
 	if r.isClosed {
-		return ErrClosed
+		return xerrors.Errorf("closing: %w", ErrClosed)
 	}
 	r.wg.Add(1)
 	go r.handleConn(dst, c)
@@ -460,11 +459,11 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 	// Receive the other ServerIdentity
 	nm, err := c.Receive()
 	if err != nil {
-		return nil, fmt.Errorf("Error while receiving ServerIdentity during negotiation %s", err)
+		return nil, xerrors.Errorf("Error while receiving ServerIdentity during negotiation %s", err)
 	}
 	// Check if it is correct
 	if nm.MsgType != ServerIdentityType {
-		return nil, fmt.Errorf("Received wrong type during negotiation %s", nm.MsgType.String())
+		return nil, xerrors.Errorf("Received wrong type during negotiation %s", nm.MsgType.String())
 	}
 
 	// Set the ServerIdentity for this connection
@@ -480,7 +479,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 			}
 			pub, err := pubFromCN(tcpConn.suite, cs.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
-				return nil, err
+				return nil, xerrors.Errorf("decoding key: %+v", err)
 			}
 
 			if !pub.Equal(dst.Public) {

--- a/network/router.go
+++ b/network/router.go
@@ -2,12 +2,12 @@ package network
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // Router handles all networking operations such as:
@@ -169,7 +169,7 @@ func (r *Router) Stop() error {
 // Send sends to an ServerIdentity without wrapping the msg into a ProtocolMsg
 func (r *Router) Send(e *ServerIdentity, msg Message) (uint64, error) {
 	if msg == nil {
-		return 0, errors.New("Can't send nil-packet")
+		return 0, xerrors.New("Can't send nil-packet")
 	}
 
 	// Update the message counter with the new message about to be sent.
@@ -476,7 +476,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 		if tlsConn, ok := tcpConn.conn.(*tls.Conn); ok {
 			cs := tlsConn.ConnectionState()
 			if len(cs.PeerCertificates) == 0 {
-				return nil, errors.New("TLS connection with no peer certs?")
+				return nil, xerrors.New("TLS connection with no peer certs?")
 			}
 			pub, err := pubFromCN(tcpConn.suite, cs.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
@@ -484,7 +484,7 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 			}
 
 			if !pub.Equal(dst.Public) {
-				return nil, errors.New("mismatch between certificate CommonName and ServerIdentity.Public")
+				return nil, xerrors.New("mismatch between certificate CommonName and ServerIdentity.Public")
 			}
 			log.Lvl4(r.address, "Public key from CommonName and ServerIdentity match:", pub)
 		} else {

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -13,7 +13,7 @@ import (
 func NewTestRouterTCP(port int) (*Router, error) {
 	h, err := NewTestTCPHost(port)
 	if err != nil {
-		return nil, xerrors.Errorf("tcp host: %+v", err)
+		return nil, xerrors.Errorf("tcp host: %v", err)
 	}
 	h.sid.Address = h.TCPListener.Address()
 	r := NewRouter(h.sid, h)
@@ -24,7 +24,7 @@ func NewTestRouterTCP(port int) (*Router, error) {
 func NewTestRouterLocal(port int) (*Router, error) {
 	h, err := NewTestLocalHost(port)
 	if err != nil {
-		return nil, xerrors.Errorf("local host: %+v", err)
+		return nil, xerrors.Errorf("local host: %v", err)
 	}
 	id := NewTestServerIdentity(h.addr)
 	return NewRouter(id, h), nil

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 func NewTestRouterTCP(port int) (*Router, error) {
 	h, err := NewTestTCPHost(port)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("tcp host: %+v", err)
 	}
 	h.sid.Address = h.TCPListener.Address()
 	r := NewRouter(h.sid, h)
@@ -23,7 +24,7 @@ func NewTestRouterTCP(port int) (*Router, error) {
 func NewTestRouterLocal(port int) (*Router, error) {
 	h, err := NewTestLocalHost(port)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("local host: %+v", err)
 	}
 	id := NewTestServerIdentity(h.addr)
 	return NewRouter(id, h), nil

--- a/network/struct.go
+++ b/network/struct.go
@@ -276,7 +276,7 @@ func (si *ServerIdentityToml) ServerIdentity(suite Suite) *ServerIdentity {
 func GlobalBind(address string) (string, error) {
 	_, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return "", xerrors.Errorf("invalid address: %+v", err)
+		return "", xerrors.Errorf("invalid address: %v", err)
 	}
 	return ":" + port, nil
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -276,7 +276,7 @@ func (si *ServerIdentityToml) ServerIdentity(suite Suite) *ServerIdentity {
 func GlobalBind(address string) (string, error) {
 	_, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return "", err
+		return "", xerrors.Errorf("invalid address: %+v", err)
 	}
 	return ":" + port, nil
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"bytes"
-	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -14,6 +13,7 @@ import (
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -27,20 +27,20 @@ const MaxIdentityExchange = 5 * time.Second
 const WaitRetry = 20 * time.Millisecond
 
 // ErrClosed is when a connection has been closed.
-var ErrClosed = errors.New("Connection Closed")
+var ErrClosed = xerrors.New("Connection Closed")
 
 // ErrEOF is when the connection sends an EOF signal (mostly because it has
 // been shut down).
-var ErrEOF = errors.New("EOF")
+var ErrEOF = xerrors.New("EOF")
 
 // ErrCanceled means something went wrong in the sending or receiving part.
-var ErrCanceled = errors.New("Operation Canceled")
+var ErrCanceled = xerrors.New("Operation Canceled")
 
 // ErrTimeout is raised if the timeout has been reached.
-var ErrTimeout = errors.New("Timeout Error")
+var ErrTimeout = xerrors.New("Timeout Error")
 
 // ErrUnknown is an unknown error.
-var ErrUnknown = errors.New("Unknown Error")
+var ErrUnknown = xerrors.New("Unknown Error")
 
 // Size is a type to reprensent the size that is sent before every packet to
 // correctly decode it.

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -3,7 +3,6 @@ package network
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -39,7 +38,11 @@ func NewTCPAddress(addr string) Address {
 
 // NewTCPRouter returns a new Router using TCPHost as the underlying Host.
 func NewTCPRouter(sid *ServerIdentity, suite Suite) (*Router, error) {
-	return NewTCPRouterWithListenAddr(sid, suite, "")
+	r, err := NewTCPRouterWithListenAddr(sid, suite, "")
+	if err != nil {
+		return nil, xerrors.Errorf("tcp router: %+v", err)
+	}
+	return r, nil
 }
 
 // NewTCPRouterWithListenAddr returns a new Router using TCPHost with the
@@ -48,7 +51,7 @@ func NewTCPRouterWithListenAddr(sid *ServerIdentity, suite Suite,
 	listenAddr string) (*Router, error) {
 	h, err := NewTCPHostWithListenAddr(sid, suite, listenAddr)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("tcp router: %+v", err)
 	}
 	r := NewRouter(sid, h)
 	return r, nil
@@ -96,12 +99,13 @@ func NewTCPConn(addr Address, suite Suite) (conn *TCPConn, err error) {
 			}
 			return
 		}
+		err = xerrors.Errorf("dial: %+v", err)
 		if i < MaxRetryConnect {
 			time.Sleep(WaitRetry)
 		}
 	}
 	if err == nil {
-		err = ErrTimeout
+		err = xerrors.Errorf("timeout: %w", ErrTimeout)
 	}
 	return
 }
@@ -112,7 +116,7 @@ func NewTCPConn(addr Address, suite Suite) (conn *TCPConn, err error) {
 func (c *TCPConn) Receive() (env *Envelope, e error) {
 	buff, err := c.receiveRaw()
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("receiving: %w", err)
 	}
 
 	id, body, err := Unmarshal(buff, c.suite)
@@ -144,10 +148,10 @@ func (c *TCPConn) receiveRawProd() ([]byte, error) {
 	// First read the size
 	var total Size
 	if err := binary.Read(c.conn, globalOrder, &total); err != nil {
-		return nil, handleError(err)
+		return nil, xerrors.Errorf("buffer read: %w", handleError(err))
 	}
 	if total > MaxPacketSize {
-		return nil, fmt.Errorf("%v sends too big packet: %v>%v",
+		return nil, xerrors.Errorf("%v sends too big packet: %v>%v",
 			c.conn.RemoteAddr().String(), total, MaxPacketSize)
 	}
 
@@ -163,7 +167,7 @@ func (c *TCPConn) receiveRawProd() ([]byte, error) {
 		// Quit if there is an error.
 		if err != nil {
 			c.updateRx(4 + uint64(read))
-			return nil, handleError(err)
+			return nil, xerrors.Errorf("reading: %w", handleError(err))
 		}
 		// Append the read bytes into the buffer.
 		if _, err := buffer.Write(b[:n]); err != nil {
@@ -188,9 +192,13 @@ func (c *TCPConn) Send(msg Message) (uint64, error) {
 
 	b, err := Marshal(msg)
 	if err != nil {
-		return 0, fmt.Errorf("Error marshaling  message: %s", err.Error())
+		return 0, xerrors.Errorf("Error marshaling  message: %s", err.Error())
 	}
-	return c.sendRaw(b)
+	len, err := c.sendRaw(b)
+	if err != nil {
+		return len, xerrors.Errorf("sending: %w", err)
+	}
+	return len, nil
 }
 
 // sendRaw writes the number of bytes of the message to the network then the
@@ -204,7 +212,7 @@ func (c *TCPConn) sendRaw(b []byte) (uint64, error) {
 	// First write the size
 	packetSize := Size(len(b))
 	if err := binary.Write(c.conn, globalOrder, packetSize); err != nil {
-		return 0, err
+		return 0, xerrors.Errorf("buffer write: %+v", err)
 	}
 	// Then send everything through the connection
 	// Send chunk by chunk
@@ -215,7 +223,7 @@ func (c *TCPConn) sendRaw(b []byte) (uint64, error) {
 		if err != nil {
 			sentLen := 4 + uint64(sent)
 			c.updateTx(sentLen)
-			return sentLen, handleError(err)
+			return sentLen, xerrors.Errorf("sending: %w", handleError(err))
 		}
 		sent += Size(n)
 	}
@@ -247,12 +255,12 @@ func (c *TCPConn) Close() error {
 	c.closedMut.Lock()
 	defer c.closedMut.Unlock()
 	if c.closed == true {
-		return ErrClosed
+		return xerrors.Errorf("closing: %w", ErrClosed)
 	}
 	err := c.conn.Close()
 	c.closed = true
 	if err != nil {
-		handleError(err)
+		return xerrors.Errorf("closing: %w", handleError(err))
 	}
 	return nil
 }
@@ -315,7 +323,11 @@ type TCPListener struct {
 // A subsequent call to Address() gives the actual listening
 // address which is different if you gave it a ":0"-address.
 func NewTCPListener(addr Address, s Suite) (*TCPListener, error) {
-	return NewTCPListenerWithListenAddr(addr, s, "")
+	l, err := NewTCPListenerWithListenAddr(addr, s, "")
+	if err != nil {
+		return nil, xerrors.Errorf("tcp listener: %+v", err)
+	}
+	return l, nil
 }
 
 // NewTCPListenerWithListenAddr returns a TCPListener. This function binds to the
@@ -338,7 +350,7 @@ func NewTCPListenerWithListenAddr(addr Address,
 	}
 	listenOn, err := getListenAddress(addr, listenAddr)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("listener: %+v", err)
 	}
 	for i := 0; i < MaxRetryConnect; i++ {
 		ln, err := net.Listen("tcp", listenOn)
@@ -361,7 +373,11 @@ func (t *TCPListener) Listen(fn func(Conn)) error {
 	receiver := func(tc Conn) {
 		go fn(tc)
 	}
-	return t.listen(receiver)
+	err := t.listen(receiver)
+	if err != nil {
+		return xerrors.Errorf("listening: %+v", err)
+	}
+	return nil
 }
 
 // listen is the private function that takes a function that takes a TCPConn.
@@ -407,7 +423,7 @@ func (t *TCPListener) Stop() error {
 	if t.listener != nil {
 		if err := t.listener.Close(); err != nil {
 			if handleError(err) != ErrClosed {
-				return err
+				return xerrors.Errorf("closing: %w", handleError(err))
 			}
 		}
 	}
@@ -458,7 +474,7 @@ func getListenAddress(addr Address, listenAddr string) (string, error) {
 	}
 	_, port, err := net.SplitHostPort(addr.NetworkAddress())
 	if err != nil {
-		return "", err
+		return "", xerrors.Errorf("invalid address: %+v", err)
 	}
 
 	// If 'listenAddr' only contains the host, combine it with the port
@@ -471,13 +487,13 @@ func getListenAddress(addr Address, listenAddr string) (string, error) {
 	// If host and port in `listenAddr`, choose this one.
 	hostListen, portListen, err := net.SplitHostPort(listenAddr)
 	if err != nil {
-		return "", err
+		return "", xerrors.Errorf("invalid address: %+v", err)
 	}
 	if hostListen != "" && portListen != "" {
 		return listenAddr, nil
 	}
 
-	return "", fmt.Errorf("Invalid combination of 'addr' (%s) and 'listenAddr' (%s)", addr.NetworkAddress(), listenAddr)
+	return "", xerrors.Errorf("Invalid combination of 'addr' (%s) and 'listenAddr' (%s)", addr.NetworkAddress(), listenAddr)
 }
 
 // TCPHost implements the Host interface using TCP connections.
@@ -489,7 +505,11 @@ type TCPHost struct {
 
 // NewTCPHost returns a new Host using TCP connection based type.
 func NewTCPHost(sid *ServerIdentity, s Suite) (*TCPHost, error) {
-	return NewTCPHostWithListenAddr(sid, s, "")
+	host, err := NewTCPHostWithListenAddr(sid, s, "")
+	if err != nil {
+		return nil, xerrors.Errorf("tcp host: %+v", err)
+	}
+	return host, nil
 }
 
 // NewTCPHostWithListenAddr returns a new Host using TCP connection based type
@@ -506,7 +526,10 @@ func NewTCPHostWithListenAddr(sid *ServerIdentity, s Suite,
 	} else {
 		h.TCPListener, err = NewTCPListenerWithListenAddr(sid.Address, s, listenAddr)
 	}
-	return h, err
+	if err != nil {
+		return nil, xerrors.Errorf("tcp host: %+v", err)
+	}
+	return h, nil
 }
 
 // Connect can only connect to PlainTCP connections.
@@ -515,11 +538,18 @@ func (t *TCPHost) Connect(si *ServerIdentity) (Conn, error) {
 	switch si.Address.ConnType() {
 	case PlainTCP:
 		c, err := NewTCPConn(si.Address, t.suite)
-		return c, err
+		if err != nil {
+			return nil, xerrors.Errorf("tcp connection: %+v", err)
+		}
+		return c, nil
 	case TLS:
-		return NewTLSConn(t.sid, si, t.suite)
+		c, err := NewTLSConn(t.sid, si, t.suite)
+		if err != nil {
+			return nil, xerrors.Errorf("tcp connection: %+v", err)
+		}
+		return c, nil
 	case InvalidConnType:
 		return nil, xerrors.New("This address is not correctly formatted: " + si.Address.String())
 	}
-	return nil, fmt.Errorf("TCPHost %s can't handle this type of connection: %s", si.Address, si.Address.ConnType())
+	return nil, xerrors.Errorf("TCPHost %s can't handle this type of connection: %s", si.Address, si.Address.ConnType())
 }

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -40,7 +40,7 @@ func NewTCPAddress(addr string) Address {
 func NewTCPRouter(sid *ServerIdentity, suite Suite) (*Router, error) {
 	r, err := NewTCPRouterWithListenAddr(sid, suite, "")
 	if err != nil {
-		return nil, xerrors.Errorf("tcp router: %+v", err)
+		return nil, xerrors.Errorf("tcp router: %v", err)
 	}
 	return r, nil
 }
@@ -51,7 +51,7 @@ func NewTCPRouterWithListenAddr(sid *ServerIdentity, suite Suite,
 	listenAddr string) (*Router, error) {
 	h, err := NewTCPHostWithListenAddr(sid, suite, listenAddr)
 	if err != nil {
-		return nil, xerrors.Errorf("tcp router: %+v", err)
+		return nil, xerrors.Errorf("tcp router: %v", err)
 	}
 	r := NewRouter(sid, h)
 	return r, nil
@@ -99,7 +99,7 @@ func NewTCPConn(addr Address, suite Suite) (conn *TCPConn, err error) {
 			}
 			return
 		}
-		err = xerrors.Errorf("dial: %+v", err)
+		err = xerrors.Errorf("dial: %v", err)
 		if i < MaxRetryConnect {
 			time.Sleep(WaitRetry)
 		}
@@ -212,7 +212,7 @@ func (c *TCPConn) sendRaw(b []byte) (uint64, error) {
 	// First write the size
 	packetSize := Size(len(b))
 	if err := binary.Write(c.conn, globalOrder, packetSize); err != nil {
-		return 0, xerrors.Errorf("buffer write: %+v", err)
+		return 0, xerrors.Errorf("buffer write: %v", err)
 	}
 	// Then send everything through the connection
 	// Send chunk by chunk
@@ -325,7 +325,7 @@ type TCPListener struct {
 func NewTCPListener(addr Address, s Suite) (*TCPListener, error) {
 	l, err := NewTCPListenerWithListenAddr(addr, s, "")
 	if err != nil {
-		return nil, xerrors.Errorf("tcp listener: %+v", err)
+		return nil, xerrors.Errorf("tcp listener: %v", err)
 	}
 	return l, nil
 }
@@ -350,7 +350,7 @@ func NewTCPListenerWithListenAddr(addr Address,
 	}
 	listenOn, err := getListenAddress(addr, listenAddr)
 	if err != nil {
-		return nil, xerrors.Errorf("listener: %+v", err)
+		return nil, xerrors.Errorf("listener: %v", err)
 	}
 	for i := 0; i < MaxRetryConnect; i++ {
 		ln, err := net.Listen("tcp", listenOn)
@@ -375,7 +375,7 @@ func (t *TCPListener) Listen(fn func(Conn)) error {
 	}
 	err := t.listen(receiver)
 	if err != nil {
-		return xerrors.Errorf("listening: %+v", err)
+		return xerrors.Errorf("listening: %v", err)
 	}
 	return nil
 }
@@ -474,7 +474,7 @@ func getListenAddress(addr Address, listenAddr string) (string, error) {
 	}
 	_, port, err := net.SplitHostPort(addr.NetworkAddress())
 	if err != nil {
-		return "", xerrors.Errorf("invalid address: %+v", err)
+		return "", xerrors.Errorf("invalid address: %v", err)
 	}
 
 	// If 'listenAddr' only contains the host, combine it with the port
@@ -487,7 +487,7 @@ func getListenAddress(addr Address, listenAddr string) (string, error) {
 	// If host and port in `listenAddr`, choose this one.
 	hostListen, portListen, err := net.SplitHostPort(listenAddr)
 	if err != nil {
-		return "", xerrors.Errorf("invalid address: %+v", err)
+		return "", xerrors.Errorf("invalid address: %v", err)
 	}
 	if hostListen != "" && portListen != "" {
 		return listenAddr, nil
@@ -507,7 +507,7 @@ type TCPHost struct {
 func NewTCPHost(sid *ServerIdentity, s Suite) (*TCPHost, error) {
 	host, err := NewTCPHostWithListenAddr(sid, s, "")
 	if err != nil {
-		return nil, xerrors.Errorf("tcp host: %+v", err)
+		return nil, xerrors.Errorf("tcp host: %v", err)
 	}
 	return host, nil
 }
@@ -527,7 +527,7 @@ func NewTCPHostWithListenAddr(sid *ServerIdentity, s Suite,
 		h.TCPListener, err = NewTCPListenerWithListenAddr(sid.Address, s, listenAddr)
 	}
 	if err != nil {
-		return nil, xerrors.Errorf("tcp host: %+v", err)
+		return nil, xerrors.Errorf("tcp host: %v", err)
 	}
 	return h, nil
 }
@@ -539,13 +539,13 @@ func (t *TCPHost) Connect(si *ServerIdentity) (Conn, error) {
 	case PlainTCP:
 		c, err := NewTCPConn(si.Address, t.suite)
 		if err != nil {
-			return nil, xerrors.Errorf("tcp connection: %+v", err)
+			return nil, xerrors.Errorf("tcp connection: %v", err)
 		}
 		return c, nil
 	case TLS:
 		c, err := NewTLSConn(t.sid, si, t.suite)
 		if err != nil {
-			return nil, xerrors.Errorf("tcp connection: %+v", err)
+			return nil, xerrors.Errorf("tcp connection: %v", err)
 		}
 		return c, nil
 	case InvalidConnType:

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -3,7 +3,6 @@ package network
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // a connection will return an io.EOF after networkTimeout if nothing has been
@@ -328,7 +328,7 @@ func NewTCPListener(addr Address, s Suite) (*TCPListener, error) {
 func NewTCPListenerWithListenAddr(addr Address,
 	s Suite, listenAddr string) (*TCPListener, error) {
 	if addr.ConnType() != PlainTCP && addr.ConnType() != TLS {
-		return nil, errors.New("TCPListener can only listen on TCP and TLS addresses")
+		return nil, xerrors.New("TCPListener can only listen on TCP and TLS addresses")
 	}
 	t := &TCPListener{
 		conntype:     addr.ConnType(),
@@ -346,7 +346,7 @@ func NewTCPListenerWithListenAddr(addr Address,
 			t.listener = ln
 			break
 		} else if i == MaxRetryConnect-1 {
-			return nil, errors.New("Error opening listener: " + err.Error())
+			return nil, xerrors.New("Error opening listener: " + err.Error())
 		}
 		time.Sleep(WaitRetry)
 	}
@@ -519,7 +519,7 @@ func (t *TCPHost) Connect(si *ServerIdentity) (Conn, error) {
 	case TLS:
 		return NewTLSConn(t.sid, si, t.suite)
 	case InvalidConnType:
-		return nil, errors.New("This address is not correctly formatted: " + si.Address.String())
+		return nil, xerrors.New("This address is not correctly formatted: " + si.Address.String())
 	}
 	return nil, fmt.Errorf("TCPHost %s can't handle this type of connection: %s", si.Address, si.Address.ConnType())
 }

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -343,7 +343,6 @@ func TestTCPConnTimeout(t *testing.T) {
 	// the timeout from send too
 	select {
 	case err := <-connStat:
-		println(err.Error())
 		assert.True(t, xerrors.Is(err, ErrTimeout))
 	case <-time.After(10 * timeoutForTest):
 		t.Error("Did not received message after timeout...")

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -3,7 +3,6 @@ package network
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -627,11 +627,11 @@ func (d *dummyErr) Error() string {
 }
 
 func TestHandleError(t *testing.T) {
-	require.Equal(t, ErrClosed, handleError(errors.New("use of closed")))
-	require.Equal(t, ErrCanceled, handleError(errors.New("canceled")))
-	require.Equal(t, ErrEOF, handleError(errors.New("EOF")))
+	require.Equal(t, ErrClosed, handleError(xerrors.New("use of closed")))
+	require.Equal(t, ErrCanceled, handleError(xerrors.New("canceled")))
+	require.Equal(t, ErrEOF, handleError(xerrors.New("EOF")))
 
-	require.Equal(t, ErrUnknown, handleError(errors.New("random error")))
+	require.Equal(t, ErrUnknown, handleError(xerrors.New("random error")))
 
 	de := dummyErr{true, true}
 	de.temporary = false
@@ -717,14 +717,14 @@ func sendrcvProc(from, to *Router) error {
 		return err
 	}
 	if sentLen == 0 {
-		return errors.New("sentLen is zero")
+		return xerrors.New("sentLen is zero")
 	}
 
 	select {
 	case <-sp.relay:
 		err = nil
 	case <-time.After(1 * time.Second):
-		err = errors.New("timeout")
+		err = xerrors.New("timeout")
 	}
 	// delete the processing
 	to.RegisterProcessor(nil, statusMsgID)

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -343,7 +343,8 @@ func TestTCPConnTimeout(t *testing.T) {
 	// the timeout from send too
 	select {
 	case err := <-connStat:
-		assert.Equal(t, ErrTimeout, err)
+		println(err.Error())
+		assert.True(t, xerrors.Is(err, ErrTimeout))
 	case <-time.After(10 * timeoutForTest):
 		t.Error("Did not received message after timeout...")
 	}
@@ -739,7 +740,7 @@ func waitConnections(r *Router, sid *ServerIdentity) error {
 		}
 		time.Sleep(WaitRetry)
 	}
-	return fmt.Errorf("Didn't see connection to %s in router", sid.Address)
+	return xerrors.Errorf("Didn't see connection to %s in router", sid.Address)
 }
 
 func acceptAndClose(c Conn) {

--- a/network/tls.go
+++ b/network/tls.go
@@ -81,7 +81,7 @@ func newCertMaker(s Suite, si *ServerIdentity) (*certMaker, error) {
 
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("key generation: %+v", err)
 	}
 	cm.k = k
 
@@ -92,21 +92,29 @@ func newCertMaker(s Suite, si *ServerIdentity) (*certMaker, error) {
 	cm.subj = pkix.Name{CommonName: pubToCN(cm.si.Public)}
 	der, err := asn1.Marshal(cm.subj.CommonName)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("marshaling: %+v", err)
 	}
 	cm.subjDer = der
 	return cm, nil
 }
 
 func (cm *certMaker) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return cm.get([]byte(hello.ServerName))
+	cert, err := cm.get([]byte(hello.ServerName))
+	if err != nil {
+		return nil, xerrors.Errorf("certificate: %+v", err)
+	}
+	return cert, nil
 }
 
 func (cm *certMaker) getClientCertificate(req *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	if len(req.AcceptableCAs) == 0 {
 		return nil, xerrors.New("server did not provide a nonce in AcceptableCAs")
 	}
-	return cm.get(req.AcceptableCAs[0])
+	cert, err := cm.get(req.AcceptableCAs[0])
+	if err != nil {
+		return nil, xerrors.Errorf("certififcate: %+v", err)
+	}
+	return cert, nil
 }
 
 func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
@@ -127,7 +135,7 @@ func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
 	buf.Write(cm.subjDer)
 	sig, err := schnorr.Sign(cm.suite, cm.si.GetPrivate(), buf.Bytes())
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("signature verification: %+v", err)
 	}
 
 	// Even though the serial number is not used in the DEDIS signature,
@@ -159,11 +167,11 @@ func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
 
 	cDer, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, cm.k.Public(), cm.k)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("certificate: %+v", err)
 	}
 	certs, err := x509.ParseCertificates(cDer)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("certificate: %+v", err)
 	}
 	if len(certs) < 1 {
 		return nil, xerrors.New("no certificate found")
@@ -211,7 +219,11 @@ func cloneTLSClientConfig(cfg *tls.Config) *tls.Config {
 
 // NewTLSListener makes a new TCPListener that is configured for TLS.
 func NewTLSListener(si *ServerIdentity, suite Suite) (*TCPListener, error) {
-	return NewTLSListenerWithListenAddr(si, suite, "")
+	l, err := NewTLSListenerWithListenAddr(si, suite, "")
+	if err != nil {
+		return nil, xerrors.Errorf("tls listener: %+v", err)
+	}
+	return l, nil
 }
 
 // NewTLSListenerWithListenAddr makes a new TCPListener that is configured
@@ -222,12 +234,12 @@ func NewTLSListenerWithListenAddr(si *ServerIdentity, suite Suite,
 	listenAddr string) (*TCPListener, error) {
 	tcp, err := NewTCPListenerWithListenAddr(si.Address, suite, listenAddr)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("tls listener: %+v", err)
 	}
 
 	cfg, err := tlsConfig(suite, si)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("tls config: %+v", err)
 	}
 
 	// This callback will be called for every new client, which
@@ -305,7 +317,7 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 		}
 		_, err = cert.Verify(opts)
 		if err != nil {
-			return err
+			return xerrors.Errorf("certificate verification: %+v", err)
 		}
 
 		// When we know who we are connecting to (e.g. client mode):
@@ -313,8 +325,7 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 		if them != nil {
 			err = cert.VerifyHostname(pubToCN(them.Public))
 			if err != nil {
-				println("here", err.Error())
-				return err
+				return xerrors.Errorf("certificate verification: %+v", err)
 			}
 		}
 
@@ -334,18 +345,21 @@ func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 		cn = cert.Subject.CommonName
 		pub, err := pubFromCN(suite, cn)
 		if err != nil {
-			return err
+			return xerrors.Errorf("decoding key: %+v", err)
 		}
 
 		buf := bytes.NewBuffer(nonce)
 		subAsn1, err := asn1.Marshal(cn)
 		if err != nil {
-			return err
+			return xerrors.Errorf("marshaling: %+v", err)
 		}
 		buf.Write(subAsn1)
 		err = schnorr.Verify(suite, pub, buf.Bytes(), sig)
+		if err != nil {
+			return xerrors.Errorf("certificate verification: %+v", err)
+		}
 
-		return err
+		return nil
 	}, nonce
 }
 
@@ -360,17 +374,24 @@ func pubFromCN(suite kyber.Group, cn string) (kyber.Point, error) {
 		// New style encoding: unhex and then unmarshal.
 		buf, err := hex.DecodeString(cn[1:])
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("decoding key: %+v", err)
 		}
 		r := bytes.NewBuffer(buf)
 
 		pub := suite.Point()
 		_, err = pub.UnmarshalFrom(r)
-		return pub, err
+		if err != nil {
+			return nil, xerrors.Errorf("unmarshaling: %+v", err)
+		}
+		return pub, nil
 
 	default:
 		// Old style encoding: simply StringHexToPoint
-		return encoding.StringHexToPoint(suite, cn)
+		pub, err := encoding.StringHexToPoint(suite, cn)
+		if err != nil {
+			return nil, xerrors.Errorf("encoding key: %+v", err)
+		}
+		return pub, nil
 	}
 }
 
@@ -385,7 +406,7 @@ func pubToCN(pub kyber.Point) string {
 func tlsConfig(suite Suite, us *ServerIdentity) (*tls.Config, error) {
 	cm, err := newCertMaker(suite, us)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("certificate: %+v", err)
 	}
 
 	return &tls.Config{
@@ -415,7 +436,7 @@ func NewTLSConn(us *ServerIdentity, them *ServerIdentity, suite Suite) (conn *TC
 
 	cfg, err := tlsConfig(suite, us)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("tls config: %+v", err)
 	}
 	vrf, nonce := makeVerifier(suite, them)
 	cfg.VerifyPeerCertificate = vrf
@@ -432,12 +453,13 @@ func NewTLSConn(us *ServerIdentity, them *ServerIdentity, suite Suite) (conn *TC
 			}
 			return
 		}
+		err = xerrors.Errorf("dial: %+v", err)
 		if i < MaxRetryConnect {
 			time.Sleep(WaitRetry)
 		}
 	}
 	if err == nil {
-		err = ErrTimeout
+		err = xerrors.Errorf("timeout: %w", ErrTimeout)
 	}
 	return
 }

--- a/overlay.go
+++ b/overlay.go
@@ -136,7 +136,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 		// the following routine will take care of requesting once
 		err := o.requestTree(onetMsg.ServerIdentity, onetMsg, io)
 		if err != nil {
-			return xerrors.Errorf("requesting tree: %+v", err)
+			return xerrors.Errorf("requesting tree: %v", err)
 		}
 		return nil
 	}
@@ -169,7 +169,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 			o.instancesLock.Lock()
 			o.nodeDelete(onetMsg.To)
 			o.instancesLock.Unlock()
-			return xerrors.Errorf("creating protocol: %+v", err)
+			return xerrors.Errorf("creating protocol: %v", err)
 		}
 		if pi == nil {
 			return nil
@@ -295,7 +295,7 @@ func (o *Overlay) requestTree(si *network.ServerIdentity, onetMsg *ProtocolMsg, 
 		RequestTree: &RequestTree{TreeID: onetMsg.To.TreeID, Version: 1},
 	})
 	if err != nil {
-		return xerrors.Errorf("wrapping message: %+v", err)
+		return xerrors.Errorf("wrapping message: %v", err)
 	}
 
 	if o.treeStorage.IsRegistered(onetMsg.To.TreeID) {
@@ -310,7 +310,7 @@ func (o *Overlay) requestTree(si *network.ServerIdentity, onetMsg *ProtocolMsg, 
 	_, err = o.server.Send(si, msg)
 	if err != nil {
 		o.treeStorage.Unregister(onetMsg.To.TreeID)
-		return xerrors.Errorf("sending tree request: %+v", err)
+		return xerrors.Errorf("sending tree request: %v", err)
 	}
 
 	return nil
@@ -556,7 +556,7 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message,
 		totSentLen += sentLen
 		if err != nil {
 			log.Error("sending config failed:", err)
-			return totSentLen, xerrors.Errorf("sending: %+v", err)
+			return totSentLen, xerrors.Errorf("sending: %v", err)
 		}
 	}
 	// then send the message
@@ -569,13 +569,13 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message,
 	}
 	final, err := io.Wrap(msg, info)
 	if err != nil {
-		return totSentLen, xerrors.Errorf("wrapping message: %+v", err)
+		return totSentLen, xerrors.Errorf("wrapping message: %v", err)
 	}
 
 	sentLen, err := o.server.Send(to.ServerIdentity, final)
 	totSentLen += sentLen
 	if err != nil {
-		return totSentLen, xerrors.Errorf("sending: %+v", err)
+		return totSentLen, xerrors.Errorf("sending: %v", err)
 	}
 	return totSentLen, nil
 }
@@ -654,10 +654,10 @@ func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolI
 	tni := o.NewTreeNodeInstanceFromService(t, t.Root, ProtocolNameToID(name), sid, io)
 	pi, err := o.server.protocolInstantiate(tni.token.ProtoID, tni)
 	if err != nil {
-		return nil, xerrors.Errorf("instantiating protocol: %+v", err)
+		return nil, xerrors.Errorf("instantiating protocol: %v", err)
 	}
 	if err = o.RegisterProtocolInstance(pi); err != nil {
-		return nil, xerrors.Errorf("registering protocol instance: %+v", err)
+		return nil, xerrors.Errorf("registering protocol instance: %v", err)
 	}
 	go func() {
 		defer func() {
@@ -679,7 +679,7 @@ func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolI
 func (o *Overlay) StartProtocol(name string, t *Tree, sid ServiceID) (ProtocolInstance, error) {
 	pi, err := o.CreateProtocol(name, t, sid)
 	if err != nil {
-		return nil, xerrors.Errorf("creating protocol: %+v", err)
+		return nil, xerrors.Errorf("creating protocol: %v", err)
 	}
 	go func() {
 		defer func() {
@@ -805,7 +805,7 @@ func (d *defaultProtoIO) Wrap(msg interface{}, info *OverlayMsg) (interface{}, e
 	if msg != nil {
 		buff, err := network.Marshal(msg)
 		if err != nil {
-			return nil, xerrors.Errorf("marshaling: %+v", err)
+			return nil, xerrors.Errorf("marshaling: %v", err)
 		}
 		typ := network.MessageType(msg)
 		protoMsg := &ProtocolMsg{
@@ -846,7 +846,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMsg, erro
 		var err error
 		_, protoMsg, err := network.Unmarshal(onetMsg.MsgSlice, d.suite)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("unmarshaling: %+v", err)
+			return nil, nil, xerrors.Errorf("unmarshaling: %v", err)
 		}
 		// Put the msg into ProtocolMsg
 		returnOverlay.TreeNodeInfo = &TreeNodeInfo{

--- a/overlay.go
+++ b/overlay.go
@@ -1,13 +1,13 @@
 package onet
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -154,7 +154,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 		log.Lvlf4("Creating TreeNodeInstance at %s %x", o.server.ServerIdentity, onetMsg.To.ID())
 		tn, err := o.TreeNodeFromTree(tree, onetMsg.To.TreeNodeID)
 		if err != nil {
-			return errors.New("No TreeNode defined in this tree here")
+			return xerrors.New("No TreeNode defined in this tree here")
 		}
 		tni := o.newTreeNodeInstanceFromToken(tn, onetMsg.To, io)
 		// retrieve the possible generic config for this message
@@ -187,7 +187,7 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 			}
 		}()
 		if err := o.RegisterProtocolInstance(pi); err != nil {
-			return errors.New("Error Binding TreeNodeInstance and ProtocolInstance:" +
+			return xerrors.New("Error Binding TreeNodeInstance and ProtocolInstance:" +
 				err.Error())
 		}
 		log.Lvl4(o.server.Address(), "Overlay created new ProtocolInstace msg => ",
@@ -323,7 +323,7 @@ func (o *Overlay) RegisterTree(t *Tree) {
 func (o *Overlay) TreeNodeFromTree(tree *Tree, id TreeNodeID) (*TreeNode, error) {
 	tn := tree.Search(id)
 	if tn == nil {
-		return nil, errors.New("didn't find treenode")
+		return nil, xerrors.New("didn't find treenode")
 	}
 
 	return tn, nil
@@ -334,15 +334,15 @@ func (o *Overlay) TreeNodeFromTree(tree *Tree, id TreeNodeID) (*TreeNode, error)
 // TreeNodeFromTree if you need to create one treeNode
 func (o *Overlay) TreeNodeFromToken(t *Token) (*TreeNode, error) {
 	if t == nil {
-		return nil, errors.New("didn't find tree-node: No token given")
+		return nil, xerrors.New("didn't find tree-node: No token given")
 	}
 	tree := o.treeStorage.Get(t.TreeID)
 	if tree == nil {
-		return nil, errors.New("didn't find tree")
+		return nil, xerrors.New("didn't find tree")
 	}
 	tn := tree.Search(t.TreeNodeID)
 	if tn == nil {
-		return nil, errors.New("didn't find treenode")
+		return nil, xerrors.New("didn't find treenode")
 	}
 
 	return tn, nil
@@ -744,11 +744,11 @@ func (o *Overlay) newTreeNodeInstanceFromToken(tn *TreeNode, tok *Token, io Mess
 }
 
 // ErrWrongTreeNodeInstance is returned when you already binded a TNI with a PI.
-var ErrWrongTreeNodeInstance = errors.New("This TreeNodeInstance doesn't exist")
+var ErrWrongTreeNodeInstance = xerrors.New("This TreeNodeInstance doesn't exist")
 
 // ErrProtocolRegistered is when the protocolinstance is already registered to
 // the overlay
-var ErrProtocolRegistered = errors.New("a ProtocolInstance already has been registered using this TreeNodeInstance")
+var ErrProtocolRegistered = xerrors.New("a ProtocolInstance already has been registered using this TreeNodeInstance")
 
 // RegisterProtocolInstance takes a PI and stores it for dispatching the message
 // to it.
@@ -858,7 +858,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMsg, erro
 	case *Roster:
 		returnOverlay.Roster = inner
 	default:
-		err = errors.New("default protoIO: unwraping an unknown message type")
+		err = xerrors.New("default protoIO: unwraping an unknown message type")
 	}
 	return returnMsg, returnOverlay, err
 }

--- a/processor.go
+++ b/processor.go
@@ -57,12 +57,12 @@ var errType = reflect.TypeOf((*error)(nil)).Elem()
 // network.Body will be converted to Body.
 func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 	if err := handlerInputCheck(f); err != nil {
-		return xerrors.Errorf("input check: %+v", err)
+		return xerrors.Errorf("input check: %v", err)
 	}
 
 	pm, sh, err := createServiceHandler(f)
 	if err != nil {
-		return xerrors.Errorf("creating handler: %+v", err)
+		return xerrors.Errorf("creating handler: %v", err)
 	}
 	p.handlers[pm] = sh
 
@@ -200,27 +200,27 @@ func (p *ServiceProcessor) RegisterRESTHandler(f interface{}, namespace, method 
 		return xerrors.New("earliest supported API level must be greater or equal to 3")
 	}
 	if err := handlerInputCheck(f); err != nil {
-		return xerrors.Errorf("input check: %+v", err)
+		return xerrors.Errorf("input check: %v", err)
 	}
 	resource, sh, err := createServiceHandler(f)
 	if err != nil {
-		return xerrors.Errorf("creating handler: %+v", err)
+		return xerrors.Errorf("creating handler: %v", err)
 	}
 	var k kindGET
 	if method == "GET" {
 		k, _, err = prepareHandlerGET(f)
 		if err != nil {
-			return xerrors.Errorf("preparing get handler: %+v", err)
+			return xerrors.Errorf("preparing get handler: %v", err)
 		}
 	}
 
 	intRegex, err := regexp.Compile(fmt.Sprintf(`^/v\d/%s/%s/\d+$`, namespace, resource))
 	if err != nil {
-		return xerrors.Errorf("regex: %+v", err)
+		return xerrors.Errorf("regex: %v", err)
 	}
 	sliceRegex, err := regexp.Compile(fmt.Sprintf(`^/v\d/%s/%s/[0-9a-f]+$`, namespace, resource))
 	if err != nil {
-		return xerrors.Errorf("regex: %+v", err)
+		return xerrors.Errorf("regex: %v", err)
 	}
 	val0 := reflect.New(sh.msgType)
 
@@ -368,7 +368,7 @@ func handlerInputCheck(f interface{}) error {
 func (p *ServiceProcessor) RegisterHandlers(procs ...interface{}) error {
 	for _, pr := range procs {
 		if err := p.RegisterHandler(pr); err != nil {
-			return xerrors.Errorf("registering handler: %+v", err)
+			return xerrors.Errorf("registering handler: %v", err)
 		}
 	}
 	return nil
@@ -379,7 +379,7 @@ func (p *ServiceProcessor) RegisterHandlers(procs ...interface{}) error {
 func (p *ServiceProcessor) RegisterStreamingHandlers(procs ...interface{}) error {
 	for _, pr := range procs {
 		if err := p.RegisterStreamingHandler(pr); err != nil {
-			return xerrors.Errorf("registering handler: %+v", err)
+			return xerrors.Errorf("registering handler: %v", err)
 		}
 	}
 	return nil
@@ -407,8 +407,6 @@ type StreamingTunnel struct {
 	close chan bool
 }
 
-// Note: errors returned without the details as it will be used in the HTTP
-// response.
 func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interface{}, ch chan bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -426,7 +424,7 @@ func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interfa
 	if streaming {
 		ierr := ret[2].Interface()
 		if ierr != nil {
-			err = xerrors.Errorf("response: %v", ierr)
+			err = xerrors.Errorf("processing error: %v", ierr)
 			return
 		}
 
@@ -436,7 +434,7 @@ func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interfa
 	}
 	ierr := ret[1].Interface()
 	if ierr != nil {
-		err = xerrors.Errorf("response: %v", ierr)
+		err = xerrors.Errorf("processing error: %v", ierr)
 		return
 	}
 
@@ -457,7 +455,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		msg := reflect.New(mh.msgType).Interface()
 		if err := protobuf.DecodeWithConstructors(buf, msg,
 			network.DefaultConstructors(p.Context.server.Suite())); err != nil {
-			return nil, nil, xerrors.Errorf("decoding: %+v", err)
+			return nil, nil, xerrors.Errorf("decoding: %v", err)
 		}
 		return callInterfaceFunc(mh.handler, msg, mh.streaming)
 	}()
@@ -509,7 +507,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 	buf, err = protobuf.Encode(reply)
 	if err != nil {
 		log.Error(err)
-		return nil, nil, xerrors.Errorf("encoding: %+v", err)
+		return nil, nil, xerrors.Errorf("encoding: %v", err)
 	}
 	return buf, nil, nil
 }

--- a/processor.go
+++ b/processor.go
@@ -57,12 +57,12 @@ var errType = reflect.TypeOf((*error)(nil)).Elem()
 // network.Body will be converted to Body.
 func (p *ServiceProcessor) RegisterHandler(f interface{}) error {
 	if err := handlerInputCheck(f); err != nil {
-		return err
+		return xerrors.Errorf("input check: %+v", err)
 	}
 
 	pm, sh, err := createServiceHandler(f)
 	if err != nil {
-		return err
+		return xerrors.Errorf("creating handler: %+v", err)
 	}
 	p.handlers[pm] = sh
 
@@ -200,27 +200,27 @@ func (p *ServiceProcessor) RegisterRESTHandler(f interface{}, namespace, method 
 		return xerrors.New("earliest supported API level must be greater or equal to 3")
 	}
 	if err := handlerInputCheck(f); err != nil {
-		return err
+		return xerrors.Errorf("input check: %+v", err)
 	}
 	resource, sh, err := createServiceHandler(f)
 	if err != nil {
-		return err
+		return xerrors.Errorf("creating handler: %+v", err)
 	}
 	var k kindGET
 	if method == "GET" {
 		k, _, err = prepareHandlerGET(f)
 		if err != nil {
-			return err
+			return xerrors.Errorf("preparing get handler: %+v", err)
 		}
 	}
 
 	intRegex, err := regexp.Compile(fmt.Sprintf(`^/v\d/%s/%s/\d+$`, namespace, resource))
 	if err != nil {
-		return err
+		return xerrors.Errorf("regex: %+v", err)
 	}
 	sliceRegex, err := regexp.Compile(fmt.Sprintf(`^/v\d/%s/%s/[0-9a-f]+$`, namespace, resource))
 	if err != nil {
-		return err
+		return xerrors.Errorf("regex: %+v", err)
 	}
 	val0 := reflect.New(sh.msgType)
 
@@ -368,7 +368,7 @@ func handlerInputCheck(f interface{}) error {
 func (p *ServiceProcessor) RegisterHandlers(procs ...interface{}) error {
 	for _, pr := range procs {
 		if err := p.RegisterHandler(pr); err != nil {
-			return err
+			return xerrors.Errorf("registering handler: %+v", err)
 		}
 	}
 	return nil
@@ -379,7 +379,7 @@ func (p *ServiceProcessor) RegisterHandlers(procs ...interface{}) error {
 func (p *ServiceProcessor) RegisterStreamingHandlers(procs ...interface{}) error {
 	for _, pr := range procs {
 		if err := p.RegisterStreamingHandler(pr); err != nil {
-			return err
+			return xerrors.Errorf("registering handler: %+v", err)
 		}
 	}
 	return nil
@@ -407,10 +407,12 @@ type StreamingTunnel struct {
 	close chan bool
 }
 
+// Note: errors returned without the details as it will be used in the HTTP
+// response.
 func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interface{}, ch chan bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic with %v", r)
+			err = xerrors.Errorf("panic with %v", r)
 		}
 	}()
 
@@ -424,7 +426,7 @@ func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interfa
 	if streaming {
 		ierr := ret[2].Interface()
 		if ierr != nil {
-			err = ierr.(error)
+			err = xerrors.Errorf("response: %v", ierr)
 			return
 		}
 
@@ -434,7 +436,7 @@ func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interfa
 	}
 	ierr := ret[1].Interface()
 	if ierr != nil {
-		err = ierr.(error)
+		err = xerrors.Errorf("response: %v", ierr)
 		return
 	}
 
@@ -455,7 +457,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 		msg := reflect.New(mh.msgType).Interface()
 		if err := protobuf.DecodeWithConstructors(buf, msg,
 			network.DefaultConstructors(p.Context.server.Suite())); err != nil {
-			return nil, nil, err
+			return nil, nil, xerrors.Errorf("decoding: %+v", err)
 		}
 		return callInterfaceFunc(mh.handler, msg, mh.streaming)
 	}()
@@ -507,7 +509,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 	buf, err = protobuf.Encode(reply)
 	if err != nil {
 		log.Error(err)
-		return nil, nil, xerrors.New("")
+		return nil, nil, xerrors.Errorf("encoding: %+v", err)
 	}
 	return buf, nil, nil
 }

--- a/processor.go
+++ b/processor.go
@@ -3,7 +3,6 @@ package onet
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 )
 
 // ServiceProcessor allows for an easy integration of external messages
@@ -93,32 +93,32 @@ func (p *ServiceProcessor) RegisterStreamingHandler(f interface{}) error {
 	// check output
 	ft := reflect.TypeOf(f)
 	if ft.NumOut() != 3 {
-		return errors.New("Need 3 return values: chan interface{}, chan bool and error")
+		return xerrors.New("Need 3 return values: chan interface{}, chan bool and error")
 	}
 	// first output
 	ret0 := ft.Out(0)
 	if ret0.Kind() != reflect.Chan {
-		return errors.New("1st return value must be a channel")
+		return xerrors.New("1st return value must be a channel")
 	}
 	if ret0.Elem().Kind() != reflect.Interface {
 		if ret0.Elem().Kind() != reflect.Ptr {
-			return errors.New("1st return value must be a channel of a *pointer* to a struct")
+			return xerrors.New("1st return value must be a channel of a *pointer* to a struct")
 		}
 		if ret0.Elem().Elem().Kind() != reflect.Struct {
-			return errors.New("1st return value must be a channel of a pointer to a *struct*")
+			return xerrors.New("1st return value must be a channel of a pointer to a *struct*")
 		}
 	}
 	// second output
 	ret1 := ft.Out(1)
 	if ret1.Kind() != reflect.Chan {
-		return errors.New("2nd return value must be a channel")
+		return xerrors.New("2nd return value must be a channel")
 	}
 	if ret1.Elem().Kind() != reflect.Bool {
-		return errors.New("2nd return value must be a boolean channel")
+		return xerrors.New("2nd return value must be a boolean channel")
 	}
 	// third output
 	if !ft.Out(2).Implements(errType) {
-		return errors.New("3rd return value has to implement error, but is: " +
+		return xerrors.New("3rd return value has to implement error, but is: " +
 			ft.Out(2).String())
 	}
 
@@ -151,7 +151,7 @@ const (
 func prepareHandlerGET(f interface{}) (kindGET, string, error) {
 	in0 := reflect.TypeOf(f).In(0).Elem()
 	if in0.Kind() != reflect.Struct {
-		return invalidGET, "", errors.New("input argument must be a struct")
+		return invalidGET, "", xerrors.New("input argument must be a struct")
 	}
 	if in0.NumField() == 0 {
 		return emptyGET, "", nil
@@ -162,9 +162,9 @@ func prepareHandlerGET(f interface{}) (kindGET, string, error) {
 		} else if in0.Field(0).Type.Kind() == reflect.Int {
 			return intGET, in0.Field(0).Name, nil
 		}
-		return invalidGET, "", errors.New("only byte slices and int are supported")
+		return invalidGET, "", xerrors.New("only byte slices and int are supported")
 	}
-	return invalidGET, "", errors.New("number of fields must be 0 or 1")
+	return invalidGET, "", xerrors.New("number of fields must be 0 or 1")
 }
 
 // RegisterRESTHandler takes a callback of type
@@ -191,13 +191,13 @@ func prepareHandlerGET(f interface{}) (kindGET, string, error) {
 func (p *ServiceProcessor) RegisterRESTHandler(f interface{}, namespace, method string, minVersion, maxVersion int) error {
 	// TODO support more methods
 	if method != "GET" && method != "POST" && method != "PUT" {
-		return errors.New("invalid REST method")
+		return xerrors.New("invalid REST method")
 	}
 	if minVersion > maxVersion {
-		return errors.New("min version is greater than max version")
+		return xerrors.New("min version is greater than max version")
 	}
 	if minVersion < 3 {
-		return errors.New("earliest supported API level must be greater or equal to 3")
+		return xerrors.New("earliest supported API level must be greater or equal to 3")
 	}
 	if err := handlerInputCheck(f); err != nil {
 		return err
@@ -318,24 +318,24 @@ func createServiceHandler(f interface{}) (string, serviceHandler, error) {
 	// check output
 	ft := reflect.TypeOf(f)
 	if ft.NumOut() != 2 {
-		return "", serviceHandler{}, errors.New("Need 2 return values: network.Body and error")
+		return "", serviceHandler{}, xerrors.New("Need 2 return values: network.Body and error")
 	}
 	// first output
 	ret := ft.Out(0)
 	if ret.Kind() != reflect.Interface {
 		if ret.Kind() != reflect.Ptr {
 			return "", serviceHandler{},
-				errors.New("1st return value must be a *pointer* to a struct or an interface")
+				xerrors.New("1st return value must be a *pointer* to a struct or an interface")
 		}
 		if ret.Elem().Kind() != reflect.Struct {
 			return "", serviceHandler{},
-				errors.New("1st return value must be a pointer to a *struct* or an interface")
+				xerrors.New("1st return value must be a pointer to a *struct* or an interface")
 		}
 	}
 	// second output
 	if !ft.Out(1).Implements(errType) {
 		return "", serviceHandler{},
-			errors.New("2nd return value has to implement error, but is: " + ft.Out(1).String())
+			xerrors.New("2nd return value has to implement error, but is: " + ft.Out(1).String())
 	}
 
 	cr := ft.In(0)
@@ -348,17 +348,17 @@ func createServiceHandler(f interface{}) (string, serviceHandler, error) {
 func handlerInputCheck(f interface{}) error {
 	ft := reflect.TypeOf(f)
 	if ft.Kind() != reflect.Func {
-		return errors.New("Input is not a function")
+		return xerrors.New("Input is not a function")
 	}
 	if ft.NumIn() != 1 {
-		return errors.New("Need one argument: *struct")
+		return xerrors.New("Need one argument: *struct")
 	}
 	cr := ft.In(0)
 	if cr.Kind() != reflect.Ptr {
-		return errors.New("Argument must be a *pointer* to a struct")
+		return xerrors.New("Argument must be a *pointer* to a struct")
 	}
 	if cr.Elem().Kind() != reflect.Struct {
-		return errors.New("Argument must be a pointer to *struct*")
+		return xerrors.New("Argument must be a pointer to *struct*")
 	}
 	return nil
 }
@@ -448,7 +448,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 	mh, ok := p.handlers[path]
 	reply, stopServiceChan, err := func() (interface{}, chan bool, error) {
 		if !ok {
-			err := errors.New("The requested message hasn't been registered: " + path)
+			err := xerrors.New("The requested message hasn't been registered: " + path)
 			log.Error(err)
 			return nil, nil, err
 		}
@@ -507,7 +507,7 @@ func (p *ServiceProcessor) ProcessClientRequest(req *http.Request, path string, 
 	buf, err = protobuf.Encode(reply)
 	if err != nil {
 		log.Error(err)
-		return nil, nil, errors.New("")
+		return nil, nil, xerrors.New("")
 	}
 	return buf, nil, nil
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,6 +22,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 )
 
 const testServiceName = "testService"
@@ -241,7 +241,7 @@ type testPanicMsg struct{}
 func procMsg(msg *testMsg) (network.Message, error) {
 	// Return an error for testing
 	if msg.I == 42 {
-		return nil, errors.New("42 is NOT the answer")
+		return nil, xerrors.New("42 is NOT the answer")
 	}
 	return msg, nil
 }
@@ -249,7 +249,7 @@ func procMsg(msg *testMsg) (network.Message, error) {
 func procMsg2(msg *testMsg2) (network.Message, error) {
 	// Return an error for testing
 	if msg.I == 42 {
-		return nil, errors.New("42 is NOT the answer")
+		return nil, xerrors.New("42 is NOT the answer")
 	}
 	return nil, nil
 }
@@ -618,7 +618,7 @@ func procRestMsgGETWrong3(s *restMsgGETWrong3) (*testMsg, error) {
 
 func procRestMsgPOSTString(s *restMsgPOSTString) (*testMsg, error) {
 	if s.S != "42" {
-		return nil, errors.New("not the right answer")
+		return nil, xerrors.New("not the right answer")
 	}
 	return &testMsg{}, nil
 }

--- a/protocol.go
+++ b/protocol.go
@@ -132,7 +132,7 @@ func GlobalProtocolRegister(name string, protocol NewProtocol) (ProtocolID, erro
 	protocols.Unlock()
 	id, err := protocols.Register(name, protocol)
 	if err != nil {
-		return id, xerrors.Errorf("registering protocol: %+v", err)
+		return id, xerrors.Errorf("registering protocol: %v", err)
 	}
 	return id, nil
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,7 +1,6 @@
 package onet
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -9,7 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
-	"gopkg.in/satori/go.uuid.v1"
+	"golang.org/x/xerrors"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var testProto = "test"
@@ -71,7 +71,7 @@ func (p *SimpleProtocol) Start() error {
 // Dispatch analyses the message and does nothing else
 func (p *SimpleProtocol) ReceiveMessage(msg MsgSimpleMessage) error {
 	if msg.I != 10 {
-		return errors.New("Not the value expected")
+		return xerrors.New("Not the value expected")
 	}
 	p.Chan <- true
 	p.Done()
@@ -221,7 +221,7 @@ func TestProtocolError(t *testing.T) {
 	<-done
 	assert.Equal(t, "", log.GetStdErr(), "This should yield no error")
 
-	protocolError = errors.New("Protocol Error")
+	protocolError = xerrors.New("Protocol Error")
 	// start the protocol
 	go func() {
 		_, err := h1.StartProtocol(simpleProto, tree)
@@ -337,13 +337,13 @@ func (t *TestMessageProxy) Wrap(msg interface{}, info *OverlayMsg) (interface{},
 func (t *TestMessageProxy) Unwrap(msg interface{}) (interface{}, *OverlayMsg, error) {
 	if msg == nil {
 		chanProtoIOFeedback <- "message nil!"
-		return nil, nil, errors.New("message nil")
+		return nil, nil, xerrors.New("message nil")
 	}
 
 	real, ok := msg.(*OuterPacket)
 	if !ok {
 		chanProtoIOFeedback <- "wrong type of message in unwrap"
-		return nil, nil, errors.New("wrong message")
+		return nil, nil, xerrors.New("wrong message")
 	}
 	chanProtoIOFeedback <- ""
 	return real.Inner, real.Info, nil

--- a/server.go
+++ b/server.go
@@ -155,14 +155,14 @@ func (c *Server) Close() error {
 
 	err := c.Router.Stop()
 	if err != nil {
-		err = xerrors.Errorf("stopping: %+v", err)
+		err = xerrors.Errorf("stopping: %v", err)
 		log.Error("While stopping router:", err)
 	}
 	c.WebSocket.stop()
 	c.overlay.Close()
 	err = c.serviceManager.closeDatabase()
 	if err != nil {
-		err = xerrors.Errorf("closing db: %+v", err)
+		err = xerrors.Errorf("closing db: %v", err)
 		log.Lvl3("Error closing database: " + err.Error())
 	}
 	log.Lvl3("Host Close", c.ServerIdentity.Address, "listening?", c.Router.Listening())
@@ -190,7 +190,7 @@ func (c *Server) GetService(name string) Service {
 func (c *Server) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID, error) {
 	id, err := c.protocols.Register(name, protocol)
 	if err != nil {
-		return id, xerrors.Errorf("registering protocol: %+v", err)
+		return id, xerrors.Errorf("registering protocol: %v", err)
 	}
 	return id, nil
 }
@@ -203,7 +203,7 @@ func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) 
 	}
 	pi, err := fn(tni)
 	if err != nil {
-		return nil, xerrors.Errorf("creating protocol: %+v", err)
+		return nil, xerrors.Errorf("creating protocol: %v", err)
 	}
 	return pi, nil
 }
@@ -214,9 +214,9 @@ func (c *Server) Start() {
 	InformServerStarted()
 	c.started = time.Now()
 	if !c.Quiet {
-		log.Lvlf1("Starting server at %s on address %s with public key %s",
+		log.Lvlf1("Starting server at %s on address %s",
 			c.started.Format("2006-01-02 15:04:05"),
-			c.ServerIdentity.Address, c.ServerIdentity.Public)
+			c.ServerIdentity.Address)
 	}
 	go c.Router.Start()
 	go c.WebSocket.start()

--- a/server.go
+++ b/server.go
@@ -1,7 +1,6 @@
 package onet
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -15,6 +14,7 @@ import (
 	"go.dedis.ch/onet/v3/cfgpath"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 	"rsc.io/goversion/version"
 )
 
@@ -192,7 +192,7 @@ func (c *Server) ProtocolRegister(name string, protocol NewProtocol) (ProtocolID
 func (c *Server) protocolInstantiate(protoID ProtocolID, tni *TreeNodeInstance) (ProtocolInstance, error) {
 	fn, ok := c.protocols.instantiators[c.protocols.ProtocolIDToName(protoID)]
 	if !ok {
-		return nil, errors.New("No protocol constructor with this ID")
+		return nil, xerrors.New("No protocol constructor with this ID")
 	}
 	return fn(tni)
 }

--- a/service.go
+++ b/service.go
@@ -112,7 +112,7 @@ var ServiceFactory = serviceFactory{
 // A suite can be provided to override the default one
 func (s *serviceFactory) Register(name string, suite suites.Suite, fn NewServiceFunc) (ServiceID, error) {
 	if !s.ServiceID(name).Equal(NilServiceID) {
-		return NilServiceID, fmt.Errorf("service %s already registered", name)
+		return NilServiceID, xerrors.Errorf("service %s already registered", name)
 	}
 	id := ServiceID(uuid.NewV5(uuid.NamespaceURL, name))
 	s.mutex.Lock()
@@ -147,18 +147,30 @@ func (s *serviceFactory) Unregister(name string) error {
 // RegisterNewService is a wrapper around service factory to register
 // a service with the default suite
 func RegisterNewService(name string, fn NewServiceFunc) (ServiceID, error) {
-	return ServiceFactory.Register(name, nil, fn)
+	id, err := ServiceFactory.Register(name, nil, fn)
+	if err != nil {
+		return id, xerrors.Errorf("register service: %+v", err)
+	}
+	return id, nil
 }
 
 // RegisterNewServiceWithSuite is wrapper around service factory to register
 // a service with a given suite
 func RegisterNewServiceWithSuite(name string, suite suites.Suite, fn NewServiceFunc) (ServiceID, error) {
-	return ServiceFactory.Register(name, suite, fn)
+	id, err := ServiceFactory.Register(name, suite, fn)
+	if err != nil {
+		return id, xerrors.Errorf("register service: %+v", err)
+	}
+	return id, nil
 }
 
 // UnregisterService removes a service from the global pool.
 func UnregisterService(name string) error {
-	return ServiceFactory.Unregister(name)
+	err := ServiceFactory.Unregister(name)
+	if err != nil {
+		return xerrors.Errorf("register service: %+v", err)
+	}
+	return nil
 }
 
 // registeredServiceIDs returns all the services registered
@@ -256,7 +268,7 @@ func (s *serviceFactory) start(name string, con *Context) (Service, error) {
 	// Checks if we need a key pair and if it is available
 	suite := s.Suite(name)
 	if suite != nil && !con.ServerIdentity().HasServiceKeyPair(name) {
-		return nil, fmt.Errorf("Service `%s` requires a key pair. "+
+		return nil, xerrors.Errorf("Service `%s` requires a key pair. "+
 			"Use the interactive setup to generate a new file that will include this service.", name)
 	}
 
@@ -264,7 +276,11 @@ func (s *serviceFactory) start(name string, con *Context) (Service, error) {
 	defer s.mutex.RUnlock()
 	for _, c := range s.constructors {
 		if name == c.name {
-			return c.constructor(con)
+			service, err := c.constructor(con)
+			if err != nil {
+				return nil, xerrors.Errorf("creating service: %+v", err)
+			}
+			return service, nil
 		}
 	}
 	return nil, xerrors.New("Didn't find service " + name)
@@ -339,7 +355,7 @@ func newServiceManager(srv *Server, o *Overlay, dbPath string, delDb bool) *serv
 func openDb(path string) (*bbolt.DB, error) {
 	db, err := bbolt.Open(path, 0600, nil)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("opening db: %+v", err)
 	}
 	return db, nil
 }
@@ -388,7 +404,7 @@ func (s *serviceManager) closeDatabase() error {
 	if s.delDb {
 		err := os.Remove(s.dbFileName())
 		if err != nil {
-			return err
+			return xerrors.Errorf("removing file: %+v", err)
 		}
 	}
 	return nil
@@ -504,7 +520,7 @@ func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfi
 	defer func() {
 		if r := recover(); r != nil {
 			pi = nil
-			err = fmt.Errorf("could not create new protocol: %v", r)
+			err = xerrors.Errorf("could not create new protocol: %v", r)
 			return
 		}
 	}()
@@ -512,6 +528,9 @@ func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfi
 	pi, err = si.NewProtocol(tni, config)
 	if pi == nil && err == nil {
 		return defaultHandle()
+	}
+	if err != nil {
+		err = xerrors.Errorf("creating protocol: %+v", err)
 	}
 	return
 }

--- a/service.go
+++ b/service.go
@@ -2,7 +2,6 @@ package onet
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	bbolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -138,7 +138,7 @@ func (s *serviceFactory) Unregister(name string) error {
 		}
 	}
 	if index < 0 {
-		return errors.New("Didn't find service " + name)
+		return xerrors.New("Didn't find service " + name)
 	}
 	s.constructors = append(s.constructors[:index], s.constructors[index+1:]...)
 	return nil
@@ -267,7 +267,7 @@ func (s *serviceFactory) start(name string, con *Context) (Service, error) {
 			return c.constructor(con)
 		}
 	}
-	return nil, errors.New("Didn't find service " + name)
+	return nil, xerrors.New("Didn't find service " + name)
 }
 
 // serviceManager is the place where all instantiated services are stored
@@ -491,7 +491,7 @@ func (s *serviceManager) serviceByID(id ServiceID) (Service, bool) {
 // the PI.
 func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfig) (pi ProtocolInstance, err error) {
 	if s.server.Closed() {
-		err = errors.New("will not pass protocol once the server is closed")
+		err = xerrors.New("will not pass protocol once the server is closed")
 		return
 	}
 	si, ok := s.serviceByID(tni.Token().ServiceID)

--- a/service.go
+++ b/service.go
@@ -149,7 +149,7 @@ func (s *serviceFactory) Unregister(name string) error {
 func RegisterNewService(name string, fn NewServiceFunc) (ServiceID, error) {
 	id, err := ServiceFactory.Register(name, nil, fn)
 	if err != nil {
-		return id, xerrors.Errorf("register service: %+v", err)
+		return id, xerrors.Errorf("register service: %v", err)
 	}
 	return id, nil
 }
@@ -159,7 +159,7 @@ func RegisterNewService(name string, fn NewServiceFunc) (ServiceID, error) {
 func RegisterNewServiceWithSuite(name string, suite suites.Suite, fn NewServiceFunc) (ServiceID, error) {
 	id, err := ServiceFactory.Register(name, suite, fn)
 	if err != nil {
-		return id, xerrors.Errorf("register service: %+v", err)
+		return id, xerrors.Errorf("register service: %v", err)
 	}
 	return id, nil
 }
@@ -168,7 +168,7 @@ func RegisterNewServiceWithSuite(name string, suite suites.Suite, fn NewServiceF
 func UnregisterService(name string) error {
 	err := ServiceFactory.Unregister(name)
 	if err != nil {
-		return xerrors.Errorf("register service: %+v", err)
+		return xerrors.Errorf("register service: %v", err)
 	}
 	return nil
 }
@@ -278,7 +278,7 @@ func (s *serviceFactory) start(name string, con *Context) (Service, error) {
 		if name == c.name {
 			service, err := c.constructor(con)
 			if err != nil {
-				return nil, xerrors.Errorf("creating service: %+v", err)
+				return nil, xerrors.Errorf("creating service: %v", err)
 			}
 			return service, nil
 		}
@@ -355,7 +355,7 @@ func newServiceManager(srv *Server, o *Overlay, dbPath string, delDb bool) *serv
 func openDb(path string) (*bbolt.DB, error) {
 	db, err := bbolt.Open(path, 0600, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("opening db: %+v", err)
+		return nil, xerrors.Errorf("opening db: %v", err)
 	}
 	return db, nil
 }
@@ -404,7 +404,7 @@ func (s *serviceManager) closeDatabase() error {
 	if s.delDb {
 		err := os.Remove(s.dbFileName())
 		if err != nil {
-			return xerrors.Errorf("removing file: %+v", err)
+			return xerrors.Errorf("removing file: %v", err)
 		}
 	}
 	return nil
@@ -530,7 +530,7 @@ func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfi
 		return defaultHandle()
 	}
 	if err != nil {
-		err = xerrors.Errorf("creating protocol: %+v", err)
+		err = xerrors.Errorf("creating protocol: %v", err)
 	}
 	return
 }

--- a/service_test.go
+++ b/service_test.go
@@ -2,7 +2,6 @@ package onet
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"sync"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 )
 
 const dummyServiceName = "dummyService"
@@ -644,7 +644,7 @@ func (ds *DummyService) ProcessClientRequest(req *http.Request, path string, buf
 	err := protobuf.Decode(buf, msg)
 	if err != nil {
 		ds.link <- false
-		return nil, nil, errors.New("wrong message")
+		return nil, nil, xerrors.New("wrong message")
 	}
 	if ds.firstTni == nil {
 		ds.firstTni = ds.c.NewTreeNodeInstance(ds.fakeTree, ds.fakeTree.Root, dummyServiceName)

--- a/simul/build.go
+++ b/simul/build.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"strings"
 
-	"errors"
 	"math"
 	"time"
 
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/simul/monitor"
 	"go.dedis.ch/onet/v3/simul/platform"
+	"golang.org/x/xerrors"
 )
 
 // Configuration-variables
@@ -262,7 +262,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 		}
 		return stats, nil
 	case <-time.After(timeout):
-		return nil, errors.New("simulation timeout")
+		return nil, xerrors.New("simulation timeout")
 	}
 }
 

--- a/simul/build.go
+++ b/simul/build.go
@@ -193,12 +193,12 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 
 	if err := deployP.Cleanup(); err != nil {
 		log.Error(err)
-		return nil, xerrors.Errorf("cleanup: %+v", err)
+		return nil, xerrors.Errorf("cleanup: %v", err)
 	}
 
 	if err := deployP.Deploy(rc); err != nil {
 		log.Error(err)
-		return nil, xerrors.Errorf("deploy: %+v", err)
+		return nil, xerrors.Errorf("deploy: %v", err)
 	}
 
 	m := monitor.NewMonitor(stats[0])
@@ -210,7 +210,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 	buckets, err := rc.GetBuckets()
 	if err != nil {
 		if err != platform.ErrorFieldNotPresent {
-			return nil, xerrors.Errorf("db bucket: %+v", err)
+			return nil, xerrors.Errorf("db bucket: %v", err)
 		}
 
 		// Do nothing, there won't be any bucket.
@@ -258,7 +258,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 	select {
 	case err := <-done:
 		if err != nil {
-			return nil, xerrors.Errorf("simulation error: %+v", err)
+			return nil, xerrors.Errorf("simulation error: %v", err)
 		}
 		return stats, nil
 	case <-time.After(timeout):

--- a/simul/build.go
+++ b/simul/build.go
@@ -193,12 +193,12 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 
 	if err := deployP.Cleanup(); err != nil {
 		log.Error(err)
-		return nil, err
+		return nil, xerrors.Errorf("cleanup: %+v", err)
 	}
 
 	if err := deployP.Deploy(rc); err != nil {
 		log.Error(err)
-		return nil, err
+		return nil, xerrors.Errorf("deploy: %+v", err)
 	}
 
 	m := monitor.NewMonitor(stats[0])
@@ -210,7 +210,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 	buckets, err := rc.GetBuckets()
 	if err != nil {
 		if err != platform.ErrorFieldNotPresent {
-			return nil, err
+			return nil, xerrors.Errorf("db bucket: %+v", err)
 		}
 
 		// Do nothing, there won't be any bucket.
@@ -258,7 +258,7 @@ func RunTest(deployP platform.Platform, rc *platform.RunConfig) ([]*monitor.Stat
 	select {
 	case err := <-done:
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("simulation error: %+v", err)
 		}
 		return stats, nil
 	case <-time.After(timeout):

--- a/simul/manage/close_all.go
+++ b/simul/manage/close_all.go
@@ -54,10 +54,10 @@ func NewCloseAll(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 	p := &ProtocolCloseAll{TreeNodeInstance: n}
 	p.Done = make(chan bool, 1)
 	if err := p.RegisterHandler(p.FuncPrepareClose); err != nil {
-		return nil, xerrors.Errorf("registering handler: %+v", err)
+		return nil, xerrors.Errorf("registering handler: %v", err)
 	}
 	if err := p.RegisterHandler(p.FuncClose); err != nil {
-		return nil, xerrors.Errorf("registering handler: %+v", err)
+		return nil, xerrors.Errorf("registering handler: %v", err)
 	}
 	return p, nil
 }

--- a/simul/manage/close_all.go
+++ b/simul/manage/close_all.go
@@ -6,6 +6,7 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 )
 
 /*
@@ -53,10 +54,10 @@ func NewCloseAll(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 	p := &ProtocolCloseAll{TreeNodeInstance: n}
 	p.Done = make(chan bool, 1)
 	if err := p.RegisterHandler(p.FuncPrepareClose); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("registering handler: %+v", err)
 	}
 	if err := p.RegisterHandler(p.FuncClose); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("registering handler: %+v", err)
 	}
 	return p, nil
 }

--- a/simul/manage/count.go
+++ b/simul/manage/count.go
@@ -1,13 +1,13 @@
 package manage
 
 import (
-	"errors"
 	"sync"
 	"time"
 
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 )
 
 /*
@@ -76,7 +76,7 @@ func NewCount(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 	p.Count = make(chan int, 1)
 	t := n.Tree()
 	if t == nil {
-		return nil, errors.New("cannot find tree")
+		return nil, xerrors.New("cannot find tree")
 	}
 	if err := p.RegisterChannelsLength(len(t.List()),
 		&p.CountChan, &p.PrepareCountChan, &p.NodeIsUpChan); err != nil {

--- a/simul/manage/simulation/simul.go
+++ b/simul/manage/simulation/simul.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"strconv"
 
 	"github.com/BurntSushi/toml"
@@ -10,6 +9,7 @@ import (
 	"go.dedis.ch/onet/v3/simul"
 	"go.dedis.ch/onet/v3/simul/manage"
 	"go.dedis.ch/onet/v3/simul/monitor"
+	"golang.org/x/xerrors"
 )
 
 /*
@@ -67,7 +67,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		children := <-p.(*manage.ProtocolCount).Count
 		round.Record()
 		if children != size {
-			return errors.New("Didn't get " + strconv.Itoa(size) +
+			return xerrors.New("Didn't get " + strconv.Itoa(size) +
 				" children")
 		}
 	}

--- a/simul/manage/simulation/simul.go
+++ b/simul/manage/simulation/simul.go
@@ -34,7 +34,7 @@ func NewSimulation(config string) (onet.Simulation, error) {
 
 	_, err := toml.Decode(config, es)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding: %+v", err)
+		return nil, xerrors.Errorf("decoding: %v", err)
 	}
 	return es, nil
 }
@@ -46,7 +46,7 @@ func (e *simulation) Setup(dir string, hosts []string) (
 	e.CreateRoster(sc, hosts, 2000)
 	err := e.CreateTree(sc)
 	if err != nil {
-		return nil, xerrors.Errorf("creating tree: %+v", err)
+		return nil, xerrors.Errorf("creating tree: %v", err)
 	}
 	return sc, nil
 }
@@ -61,7 +61,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		round := monitor.NewTimeMeasure("round")
 		p, err := config.Overlay.CreateProtocol("Count", config.Tree, onet.NilServiceID)
 		if err != nil {
-			return xerrors.Errorf("creating protocol: %+v", err)
+			return xerrors.Errorf("creating protocol: %v", err)
 		}
 		go p.Start()
 		children := <-p.(*manage.ProtocolCount).Count

--- a/simul/manage/simulation/simul.go
+++ b/simul/manage/simulation/simul.go
@@ -34,7 +34,7 @@ func NewSimulation(config string) (onet.Simulation, error) {
 
 	_, err := toml.Decode(config, es)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("decoding: %+v", err)
 	}
 	return es, nil
 }
@@ -46,7 +46,7 @@ func (e *simulation) Setup(dir string, hosts []string) (
 	e.CreateRoster(sc, hosts, 2000)
 	err := e.CreateTree(sc)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating tree: %+v", err)
 	}
 	return sc, nil
 }
@@ -61,7 +61,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		round := monitor.NewTimeMeasure("round")
 		p, err := config.Overlay.CreateProtocol("Count", config.Tree, onet.NilServiceID)
 		if err != nil {
-			return err
+			return xerrors.Errorf("creating protocol: %+v", err)
 		}
 		go p.Start()
 		children := <-p.(*manage.ProtocolCount).Count

--- a/simul/monitor/bucket_stats.go
+++ b/simul/monitor/bucket_stats.go
@@ -26,11 +26,13 @@ func newBucketRule(r string) (rule bucketRule, err error) {
 
 	rule.low, err = strconv.Atoi(parts[0])
 	if err != nil {
+		err = xerrors.Errorf("atoi: %+v", err)
 		return
 	}
 
 	rule.high, err = strconv.Atoi(parts[1])
 	if err != nil {
+		err = xerrors.Errorf("atoi: %+v", err)
 		return
 	}
 
@@ -83,7 +85,7 @@ func (bs *BucketStats) Set(index int, rules []string, stats *Stats) error {
 	for i, str := range rules {
 		rule, err := newBucketRule(str)
 		if err != nil {
-			return err
+			return xerrors.Errorf("bucket rule: %+v", err)
 		}
 
 		bs.rules[index][i] = rule

--- a/simul/monitor/bucket_stats.go
+++ b/simul/monitor/bucket_stats.go
@@ -1,9 +1,10 @@
 package monitor
 
 import (
-	"errors"
 	"strconv"
 	"strings"
+
+	"golang.org/x/xerrors"
 )
 
 // bucketRule represents a filter that will tell if a measure must
@@ -19,7 +20,7 @@ type bucketRule struct {
 func newBucketRule(r string) (rule bucketRule, err error) {
 	parts := strings.Split(r, ":")
 	if len(parts) != 2 {
-		err = errors.New("malformed rule")
+		err = xerrors.New("malformed rule")
 		return
 	}
 

--- a/simul/monitor/bucket_stats.go
+++ b/simul/monitor/bucket_stats.go
@@ -26,13 +26,13 @@ func newBucketRule(r string) (rule bucketRule, err error) {
 
 	rule.low, err = strconv.Atoi(parts[0])
 	if err != nil {
-		err = xerrors.Errorf("atoi: %+v", err)
+		err = xerrors.Errorf("atoi: %v", err)
 		return
 	}
 
 	rule.high, err = strconv.Atoi(parts[1])
 	if err != nil {
-		err = xerrors.Errorf("atoi: %+v", err)
+		err = xerrors.Errorf("atoi: %v", err)
 		return
 	}
 
@@ -85,7 +85,7 @@ func (bs *BucketStats) Set(index int, rules []string, stats *Stats) error {
 	for i, str := range rules {
 		rule, err := newBucketRule(str)
 		if err != nil {
-			return xerrors.Errorf("bucket rule: %+v", err)
+			return xerrors.Errorf("bucket rule: %v", err)
 		}
 
 		bs.rules[index][i] = rule

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -2,7 +2,6 @@ package monitor
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"sync"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // InvalidHostIndex is the default value when the measure is not assigned
@@ -75,7 +75,7 @@ func ConnectSink(addr string) error {
 	global.Lock()
 	defer global.Unlock()
 	if global.connection != nil {
-		return errors.New("Already connected to an endpoint")
+		return xerrors.New("Already connected to an endpoint")
 	}
 	log.Lvl3("Connecting to:", addr)
 	conn, err := net.Dial("tcp", addr)
@@ -268,7 +268,7 @@ func send(v interface{}) error {
 		continue
 	}
 	if !ok {
-		return errors.New("Could not send any measures")
+		return xerrors.New("Could not send any measures")
 	}
 	return nil
 }

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -79,7 +79,7 @@ func ConnectSink(addr string) error {
 	log.Lvl3("Connecting to:", addr)
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
-		return xerrors.Errorf("dial: %+v", err)
+		return xerrors.Errorf("dial: %v", err)
 	}
 	log.Lvl3("Connected to sink:", addr)
 	global.sink = addr

--- a/simul/monitor/measure.go
+++ b/simul/monitor/measure.go
@@ -2,7 +2,6 @@ package monitor
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"time"
 
@@ -80,7 +79,7 @@ func ConnectSink(addr string) error {
 	log.Lvl3("Connecting to:", addr)
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
-		return err
+		return xerrors.Errorf("dial: %+v", err)
 	}
 	log.Lvl3("Connected to sink:", addr)
 	global.sink = addr
@@ -251,7 +250,7 @@ func send(v interface{}) error {
 	global.Lock()
 	defer global.Unlock()
 	if global.connection == nil {
-		return fmt.Errorf("monitor's sink connection not initialized")
+		return xerrors.New("monitor's sink connection not initialized")
 	}
 	// For a large number of clients (˜10'000), the connection phase
 	// can take some time. This is a linear backoff to enable connection

--- a/simul/monitor/monitor.go
+++ b/simul/monitor/monitor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // This file handles the collection of measurements, aggregates them and
@@ -88,7 +89,7 @@ func (m *Monitor) InsertBucket(index int, rules []string, stats *Stats) {
 func (m *Monitor) Listen() error {
 	ln, err := net.Listen("tcp", Sink+":"+strconv.Itoa(int(m.SinkPort)))
 	if err != nil {
-		return fmt.Errorf("Error while monitor is binding address: %v", err)
+		return xerrors.Errorf("Error while monitor is binding address: %v", err)
 	}
 	if m.SinkPort == 0 {
 		_, p, _ := net.SplitHostPort(ln.Addr().String())

--- a/simul/monitor/proxy.go
+++ b/simul/monitor/proxy.go
@@ -3,6 +3,8 @@ package monitor
 import (
 	"fmt"
 	"net"
+
+	"golang.org/x/xerrors"
 )
 
 // NewProxy returns a new TCP proxy listening on addr:listenPort, which forwards
@@ -10,7 +12,7 @@ import (
 func NewProxy(toPort uint16, addr string, listenPort uint16) (*TCPProxy, error) {
 	ln, err := net.Listen("tcp", fmt.Sprintf("%v:%v", addr, listenPort))
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("listening: %+v", err)
 	}
 
 	e := make([]*net.SRV, 1)

--- a/simul/monitor/proxy.go
+++ b/simul/monitor/proxy.go
@@ -12,7 +12,7 @@ import (
 func NewProxy(toPort uint16, addr string, listenPort uint16) (*TCPProxy, error) {
 	ln, err := net.Listen("tcp", fmt.Sprintf("%v:%v", addr, listenPort))
 	if err != nil {
-		return nil, xerrors.Errorf("listening: %+v", err)
+		return nil, xerrors.Errorf("listening: %v", err)
 	}
 
 	e := make([]*net.SRV, 1)

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -1,7 +1,6 @@
 package monitor
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/montanaflynn/stats"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // Stats contains all structures that are related to the computations of stats
@@ -129,7 +129,7 @@ func (s *Stats) WriteIndividualStats(w io.Writer) error {
 			if n == 1 {
 				n = newN
 			} else if n != newN {
-				return errors.New("Found inconsistencies in values")
+				return xerrors.New("Found inconsistencies in values")
 			}
 		}
 	}

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -154,11 +154,11 @@ func (s *Stats) WriteIndividualStats(w io.Writer) error {
 		all := append(static, values...)
 		_, err := fmt.Fprintf(w, "%s", strings.Join(all, ","))
 		if err != nil {
-			return err
+			return xerrors.Errorf("formatting: %+v", err)
 		}
 		_, err = fmt.Fprintf(w, "\n")
 		if err != nil {
-			return err
+			return xerrors.Errorf("formatting: %+v", err)
 		}
 
 	}

--- a/simul/monitor/stats.go
+++ b/simul/monitor/stats.go
@@ -154,11 +154,11 @@ func (s *Stats) WriteIndividualStats(w io.Writer) error {
 		all := append(static, values...)
 		_, err := fmt.Fprintf(w, "%s", strings.Join(all, ","))
 		if err != nil {
-			return xerrors.Errorf("formatting: %+v", err)
+			return xerrors.Errorf("formatting: %v", err)
 		}
 		_, err = fmt.Fprintf(w, "\n")
 		if err != nil {
-			return xerrors.Errorf("formatting: %+v", err)
+			return xerrors.Errorf("formatting: %v", err)
 		}
 
 	}

--- a/simul/monitor/tcpproxy.go
+++ b/simul/monitor/tcpproxy.go
@@ -42,7 +42,7 @@ func (r *remote) inactivate() {
 func (r *remote) tryReactivate() error {
 	conn, err := net.Dial("tcp", r.addr)
 	if err != nil {
-		return xerrors.Errorf("dial: %+v", err)
+		return xerrors.Errorf("dial: %v", err)
 	}
 	conn.Close()
 	r.mu.Lock()
@@ -91,7 +91,7 @@ func (tp *TCPProxy) Run() error {
 	for {
 		in, err := tp.Listener.Accept()
 		if err != nil {
-			return xerrors.Errorf("listening: %+v", err)
+			return xerrors.Errorf("listening: %v", err)
 		}
 
 		go tp.serve(in)

--- a/simul/monitor/tcpproxy.go
+++ b/simul/monitor/tcpproxy.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 type remote struct {
@@ -41,7 +42,7 @@ func (r *remote) inactivate() {
 func (r *remote) tryReactivate() error {
 	conn, err := net.Dial("tcp", r.addr)
 	if err != nil {
-		return err
+		return xerrors.Errorf("dial: %+v", err)
 	}
 	conn.Close()
 	r.mu.Lock()
@@ -90,7 +91,7 @@ func (tp *TCPProxy) Run() error {
 	for {
 		in, err := tp.Listener.Accept()
 		if err != nil {
-			return err
+			return xerrors.Errorf("listening: %+v", err)
 		}
 
 		go tp.serve(in)

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -25,7 +25,7 @@ func Scp(username, host, file, dest string) error {
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if err != nil {
-		return xerrors.Errorf("cmd: %+v", err)
+		return xerrors.Errorf("cmd: %v", err)
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func Rsync(username, host, file, dest string) error {
 	}
 	err := cmd.Run()
 	if err != nil {
-		return xerrors.Errorf("cmd: %+v", err)
+		return xerrors.Errorf("cmd: %v", err)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func SSHRun(username, host, command string) ([]byte, error) {
 		"eval '"+command+"'")
 	buf, err := cmd.Output()
 	if err != nil {
-		return nil, xerrors.Errorf("cmd: %+v", err)
+		return nil, xerrors.Errorf("cmd: %v", err)
 	}
 	return buf, nil
 }
@@ -80,7 +80,7 @@ func SSHRunStdout(username, host, command string) error {
 	cmd.Stdout = os.Stdout
 	err := cmd.Run()
 	if err != nil {
-		return xerrors.Errorf("cmd: %+v", err)
+		return xerrors.Errorf("cmd: %v", err)
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func Build(path, out, goarch, goos string, buildArgs ...string) (string, error) 
 	log.Lvl4("Command:", cmd.Args)
 	err = cmd.Run()
 	if err != nil {
-		err = xerrors.Errorf("cmd: %+v", err)
+		err = xerrors.Errorf("cmd: %v", err)
 	}
 	log.Lvl4(b.String())
 	return b.String(), err

--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -141,10 +141,10 @@ func (d *Deterlab) Build(build string, arg ...string) error {
 	var wg sync.WaitGroup
 
 	if err := os.RemoveAll(d.buildDir); err != nil {
-		return xerrors.Errorf("removing folders: %+v", err)
+		return xerrors.Errorf("removing folders: %v", err)
 	}
 	if err := os.Mkdir(d.buildDir, 0777); err != nil {
-		return xerrors.Errorf("making folder: %+v", err)
+		return xerrors.Errorf("making folder: %v", err)
 	}
 
 	// start building the necessary binaries - it's always the same,
@@ -240,10 +240,10 @@ func (d *Deterlab) Cleanup() error {
 // deterlab-installation.
 func (d *Deterlab) Deploy(rc *RunConfig) error {
 	if err := os.RemoveAll(d.deployDir); err != nil {
-		return xerrors.Errorf("removing folders: %+v", err)
+		return xerrors.Errorf("removing folders: %v", err)
 	}
 	if err := os.Mkdir(d.deployDir, 0777); err != nil {
-		return xerrors.Errorf("making folder: %+v", err)
+		return xerrors.Errorf("making folder: %v", err)
 	}
 
 	// Check for PreScript and copy it to the deploy-dir
@@ -252,7 +252,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 		_, err := os.Stat(d.PreScript)
 		if !os.IsNotExist(err) {
 			if err := app.Copy(d.deployDir, d.PreScript); err != nil {
-				return xerrors.Errorf("copying: %+v", err)
+				return xerrors.Errorf("copying: %v", err)
 			}
 		}
 	}
@@ -262,7 +262,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 	log.Lvl2("Localhost: Deploying and writing config-files")
 	sim, err := onet.NewSimulation(d.Simulation, string(rc.Toml()))
 	if err != nil {
-		return xerrors.Errorf("simulation: %+v", err)
+		return xerrors.Errorf("simulation: %v", err)
 	}
 	// Initialize the deter-struct with our current structure (for debug-levels
 	// and such), then read in the app-configuration to overwrite eventual
@@ -271,7 +271,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 	deterConfig := d.deployDir + "/deter.toml"
 	_, err = toml.Decode(string(rc.Toml()), &deter)
 	if err != nil {
-		return xerrors.Errorf("decoding toml: %+v", err)
+		return xerrors.Errorf("decoding toml: %v", err)
 	}
 	log.Lvl3("Creating hosts")
 	deter.createHosts()
@@ -280,7 +280,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 
 	simulConfig, err = sim.Setup(d.deployDir, deter.Virt)
 	if err != nil {
-		return xerrors.Errorf("simulation setup: %+v", err)
+		return xerrors.Errorf("simulation setup: %v", err)
 	}
 	simulConfig.Config = string(rc.Toml())
 	log.Lvl3("Saving configuration")

--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -17,7 +17,6 @@ package platform
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,6 +34,7 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // Deterlab holds all fields necessary for a Deterlab-run
@@ -385,16 +385,16 @@ func (d *Deterlab) parseHosts(str string) error {
 	// Get the link-information, which is the second block in `expinfo`-output
 	infos := strings.Split(str, "\n\n")
 	if len(infos) < 2 {
-		return errors.New("didn't recognize output of 'expinfo'")
+		return xerrors.New("didn't recognize output of 'expinfo'")
 	}
 	linkInfo := infos[1]
 	// Test for correct version in case the API-output changes
 	if !strings.HasPrefix(linkInfo, "Virtual Lan/Link Info:") {
-		return errors.New("didn't recognize output of 'expinfo'")
+		return xerrors.New("didn't recognize output of 'expinfo'")
 	}
 	linkLines := strings.Split(linkInfo, "\n")
 	if len(linkLines) < 5 {
-		return errors.New("didn't recognice output of 'expinfo'")
+		return xerrors.New("didn't recognice output of 'expinfo'")
 	}
 	nodes := linkLines[3:]
 
@@ -408,7 +408,7 @@ func (d *Deterlab) parseHosts(str string) error {
 		}
 		matches := strings.Fields(node)
 		if len(matches) != 6 {
-			return errors.New("expinfo-output seems to have changed")
+			return xerrors.New("expinfo-output seems to have changed")
 		}
 		// Convert client-0:0 to client-0
 		name := strings.Split(matches[1], ":")[0]

--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -141,10 +141,10 @@ func (d *Deterlab) Build(build string, arg ...string) error {
 	var wg sync.WaitGroup
 
 	if err := os.RemoveAll(d.buildDir); err != nil {
-		return err
+		return xerrors.Errorf("removing folders: %+v", err)
 	}
 	if err := os.Mkdir(d.buildDir, 0777); err != nil {
-		return err
+		return xerrors.Errorf("making folder: %+v", err)
 	}
 
 	// start building the necessary binaries - it's always the same,
@@ -240,10 +240,10 @@ func (d *Deterlab) Cleanup() error {
 // deterlab-installation.
 func (d *Deterlab) Deploy(rc *RunConfig) error {
 	if err := os.RemoveAll(d.deployDir); err != nil {
-		return err
+		return xerrors.Errorf("removing folders: %+v", err)
 	}
 	if err := os.Mkdir(d.deployDir, 0777); err != nil {
-		return err
+		return xerrors.Errorf("making folder: %+v", err)
 	}
 
 	// Check for PreScript and copy it to the deploy-dir
@@ -252,7 +252,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 		_, err := os.Stat(d.PreScript)
 		if !os.IsNotExist(err) {
 			if err := app.Copy(d.deployDir, d.PreScript); err != nil {
-				return err
+				return xerrors.Errorf("copying: %+v", err)
 			}
 		}
 	}
@@ -262,7 +262,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 	log.Lvl2("Localhost: Deploying and writing config-files")
 	sim, err := onet.NewSimulation(d.Simulation, string(rc.Toml()))
 	if err != nil {
-		return err
+		return xerrors.Errorf("simulation: %+v", err)
 	}
 	// Initialize the deter-struct with our current structure (for debug-levels
 	// and such), then read in the app-configuration to overwrite eventual
@@ -271,7 +271,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 	deterConfig := d.deployDir + "/deter.toml"
 	_, err = toml.Decode(string(rc.Toml()), &deter)
 	if err != nil {
-		return err
+		return xerrors.Errorf("decoding toml: %+v", err)
 	}
 	log.Lvl3("Creating hosts")
 	deter.createHosts()
@@ -280,7 +280,7 @@ func (d *Deterlab) Deploy(rc *RunConfig) error {
 
 	simulConfig, err = sim.Setup(d.deployDir, deter.Virt)
 	if err != nil {
-		return err
+		return xerrors.Errorf("simulation setup: %+v", err)
 	}
 	simulConfig.Config = string(rc.Toml())
 	log.Lvl3("Saving configuration")

--- a/simul/platform/fd_darwin.go
+++ b/simul/platform/fd_darwin.go
@@ -1,11 +1,11 @@
 package platform
 
 import (
-	"errors"
 	"syscall"
 
 	"go.dedis.ch/onet/v3/log"
 	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -50,13 +50,13 @@ func CheckOutOfFileDescriptors() error {
 	// Check if we're out of file descriptors
 	newFS, err := syscall.Dup(syscall.Stdout)
 	if err != nil {
-		return errors.New(`Out of file descriptors. You might want to do something like this for Mac OSX:
+		return xerrors.New(`Out of file descriptors. You might want to do something like this for Mac OSX:
     sudo sysctl -w kern.maxfiles=122880
     sudo sysctl -w kern.maxfilesperproc=102400
     sudo sysctl -w kern.ipc.somaxconn=20480`)
 	}
 	if err = syscall.Close(newFS); err != nil {
-		return errors.New("Couldn't close new file descriptor: " + err.Error())
+		return xerrors.New("Couldn't close new file descriptor: " + err.Error())
 	}
 	return nil
 }

--- a/simul/platform/fd_unix.go
+++ b/simul/platform/fd_unix.go
@@ -3,10 +3,10 @@
 package platform
 
 import (
-	"errors"
 	"syscall"
 
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // By default in simulation we update the per-process file descriptor limit
@@ -40,13 +40,13 @@ func CheckOutOfFileDescriptors() error {
 	// Check if we're out of file descriptors
 	newFS, err := syscall.Dup(syscall.Stdout)
 	if err != nil {
-		return errors.New(`Out of file descriptors. You might want to do something like this for Mac OSX:
+		return xerrors.New(`Out of file descriptors. You might want to do something like this for Mac OSX:
     sudo sysctl -w kern.maxfiles=122880
     sudo sysctl -w kern.maxfilesperproc=102400
     sudo sysctl -w kern.ipc.somaxconn=20480`)
 	}
 	if err = syscall.Close(newFS); err != nil {
-		return errors.New("Couldn't close new file descriptor: " + err.Error())
+		return xerrors.New("Couldn't close new file descriptor: " + err.Error())
 	}
 	return nil
 }

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -113,11 +113,11 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	if runtime.GOOS == "darwin" {
 		files, err := exec.Command("ulimit", "-n").Output()
 		if err != nil {
-			return xerrors.Errorf("ulimit: %+v", err)
+			return xerrors.Errorf("ulimit: %v", err)
 		}
 		filesNbr, err := strconv.Atoi(strings.TrimSpace(string(files)))
 		if err != nil {
-			return xerrors.Errorf("atoi: %+v", err)
+			return xerrors.Errorf("atoi: %v", err)
 		}
 		hosts, _ := strconv.Atoi(rc.Get("hosts"))
 		if filesNbr < hosts*2 {
@@ -137,7 +137,7 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 		_, err := os.Stat(d.PreScript)
 		if !os.IsNotExist(err) {
 			if err := app.Copy(d.runDir, d.PreScript); err != nil {
-				return xerrors.Errorf("copying: %+v", err)
+				return xerrors.Errorf("copying: %v", err)
 			}
 		}
 	}
@@ -146,7 +146,7 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	log.Lvl2("Localhost: Deploying and writing config-files for", d.servers, "servers")
 	sim, err := onet.NewSimulation(d.Simulation, string(rc.Toml()))
 	if err != nil {
-		return xerrors.Errorf("simulation error: %+v", err)
+		return xerrors.Errorf("simulation error: %v", err)
 	}
 	d.addresses = make([]string, d.servers)
 	for i := range d.addresses {
@@ -154,11 +154,11 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	}
 	d.sc, err = sim.Setup(d.runDir, d.addresses)
 	if err != nil {
-		return xerrors.Errorf("simulation setup: %+v", err)
+		return xerrors.Errorf("simulation setup: %v", err)
 	}
 	d.sc.Config = string(rc.Toml())
 	if err := d.sc.Save(d.runDir); err != nil {
-		return xerrors.Errorf("saving folder: %+v", err)
+		return xerrors.Errorf("saving folder: %v", err)
 	}
 	log.Lvl2("Localhost: Done deploying")
 	d.wgRun.Add(d.servers)
@@ -193,7 +193,7 @@ func (d *Localhost) Start(args ...string) error {
 
 	err := monitor.ConnectSink("localhost:" + strconv.Itoa(d.monitorPort))
 	if err != nil {
-		return xerrors.Errorf("monitor: %+v", err)
+		return xerrors.Errorf("monitor: %v", err)
 	}
 
 	for index := 0; index < d.servers; index++ {
@@ -240,7 +240,7 @@ func (d *Localhost) Wait() error {
 			if err := d.Cleanup(); err != nil {
 				log.Errorf("Couldn't cleanup running instances: %+v", err)
 			}
-			err = xerrors.Errorf("localhost error: %+v", err)
+			err = xerrors.Errorf("localhost error: %v", err)
 		}
 	case <-time.After(wait):
 		log.Lvl1("Quitting after waiting", wait)

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -16,6 +16,7 @@ import (
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/simul/monitor"
+	"golang.org/x/xerrors"
 )
 
 // Localhost is responsible for launching the app with the specified number of nodes
@@ -112,16 +113,16 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	if runtime.GOOS == "darwin" {
 		files, err := exec.Command("ulimit", "-n").Output()
 		if err != nil {
-			return err
+			return xerrors.Errorf("ulimit: %+v", err)
 		}
 		filesNbr, err := strconv.Atoi(strings.TrimSpace(string(files)))
 		if err != nil {
-			return err
+			return xerrors.Errorf("atoi: %+v", err)
 		}
 		hosts, _ := strconv.Atoi(rc.Get("hosts"))
 		if filesNbr < hosts*2 {
 			maxfiles := 10000 + hosts*2
-			return fmt.Errorf("Maximum open files is too small. Please run the following command:\n"+
+			return xerrors.Errorf("Maximum open files is too small. Please run the following command:\n"+
 				"sudo sysctl -w kern.maxfiles=%d\n"+
 				"sudo sysctl -w kern.maxfilesperproc=%d\n"+
 				"ulimit -n %d\n"+
@@ -136,7 +137,7 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 		_, err := os.Stat(d.PreScript)
 		if !os.IsNotExist(err) {
 			if err := app.Copy(d.runDir, d.PreScript); err != nil {
-				return err
+				return xerrors.Errorf("copying: %+v", err)
 			}
 		}
 	}
@@ -145,7 +146,7 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	log.Lvl2("Localhost: Deploying and writing config-files for", d.servers, "servers")
 	sim, err := onet.NewSimulation(d.Simulation, string(rc.Toml()))
 	if err != nil {
-		return err
+		return xerrors.Errorf("simulation error: %+v", err)
 	}
 	d.addresses = make([]string, d.servers)
 	for i := range d.addresses {
@@ -153,11 +154,11 @@ func (d *Localhost) Deploy(rc *RunConfig) error {
 	}
 	d.sc, err = sim.Setup(d.runDir, d.addresses)
 	if err != nil {
-		return err
+		return xerrors.Errorf("simulation setup: %+v", err)
 	}
 	d.sc.Config = string(rc.Toml())
 	if err := d.sc.Save(d.runDir); err != nil {
-		return err
+		return xerrors.Errorf("saving folder: %+v", err)
 	}
 	log.Lvl2("Localhost: Done deploying")
 	d.wgRun.Add(d.servers)
@@ -185,14 +186,14 @@ func (d *Localhost) Start(args ...string) error {
 		out, err := exec.Command("sh", "-c", "./"+d.PreScript+" localhost").CombinedOutput()
 		outStr := strings.TrimRight(string(out), "\n")
 		if err != nil {
-			return fmt.Errorf("error deploying PreScript: " + err.Error() + " " + outStr)
+			return xerrors.Errorf("error deploying PreScript: " + err.Error() + " " + outStr)
 		}
 		log.Lvl1(outStr)
 	}
 
 	err := monitor.ConnectSink("localhost:" + strconv.Itoa(d.monitorPort))
 	if err != nil {
-		return err
+		return xerrors.Errorf("monitor: %+v", err)
 	}
 
 	for index := 0; index < d.servers; index++ {
@@ -237,10 +238,9 @@ func (d *Localhost) Wait() error {
 		log.Lvl3("Finished waiting for hosts:", e)
 		if e != nil {
 			if err := d.Cleanup(); err != nil {
-				log.Error("Couldn't cleanup running instances",
-					err)
+				log.Error("Couldn't cleanup running instances", err)
 			}
-			err = e
+			err = xerrors.Errorf("localhost error: %+v", err)
 		}
 	case <-time.After(wait):
 		log.Lvl1("Quitting after waiting", wait)

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -238,7 +238,7 @@ func (d *Localhost) Wait() error {
 		log.Lvl3("Finished waiting for hosts:", e)
 		if e != nil {
 			if err := d.Cleanup(); err != nil {
-				log.Error("Couldn't cleanup running instances", err)
+				log.Errorf("Couldn't cleanup running instances: %+v", err)
 			}
 			err = xerrors.Errorf("localhost error: %+v", err)
 		}

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -142,7 +142,7 @@ func (m *MiniNet) Build(build string, arg ...string) error {
 	system := "linux"
 	srcRel, err := filepath.Rel(m.wd, m.simulDir)
 	if err != nil {
-		return xerrors.Errorf("relative path: %+v", err)
+		return xerrors.Errorf("relative path: %v", err)
 	}
 
 	log.Lvl3("Relative-path is", srcRel, ". Will build into", m.buildDir)
@@ -172,7 +172,7 @@ func (m *MiniNet) Cleanup() error {
 	log.Lvl3("Going to stop everything")
 	err = m.parseServers()
 	if err != nil {
-		return xerrors.Errorf("parsing servers: %+v", err)
+		return xerrors.Errorf("parsing servers: %v", err)
 	}
 	for _, h := range m.HostIPs {
 		log.Lvl3("Cleaning up server", h)
@@ -190,7 +190,7 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 	log.Lvl2("Localhost: Deploying and writing config-files")
 	sim, err := onet.NewSimulation(m.Simulation, string(rc.Toml()))
 	if err != nil {
-		return xerrors.Errorf("creating simulation: %+v", err)
+		return xerrors.Errorf("creating simulation: %v", err)
 	}
 
 	// Check for PreScript and copy it to the deploy-dir
@@ -199,7 +199,7 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 		_, err := os.Stat(m.PreScript)
 		if !os.IsNotExist(err) {
 			if err := app.Copy(m.deployDir, m.PreScript); err != nil {
-				return xerrors.Errorf("copying: %+v", err)
+				return xerrors.Errorf("copying: %v", err)
 			}
 		}
 	}
@@ -211,28 +211,28 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 	mininetConfig := m.deployDir + "/mininet.toml"
 	_, err = toml.Decode(string(rc.Toml()), &mininet)
 	if err != nil {
-		return xerrors.Errorf("decoding toml: %+v", err)
+		return xerrors.Errorf("decoding toml: %v", err)
 	}
 	log.Lvl3("Writing the config file :", mininet)
 	onet.WriteTomlConfig(mininet, mininetConfig, m.deployDir)
 
 	log.Lvl3("Creating hosts")
 	if err = m.parseServers(); err != nil {
-		return xerrors.Errorf("parsing servers: %+v", err)
+		return xerrors.Errorf("parsing servers: %v", err)
 	}
 	hosts, list, err := m.getHostList(rc)
 	if err != nil {
-		return xerrors.Errorf("hosts list: %+v", err)
+		return xerrors.Errorf("hosts list: %v", err)
 	}
 	log.Lvl3("Hosts are:", hosts)
 	log.Lvl3("List is:", list)
 	err = ioutil.WriteFile(m.deployDir+"/list", []byte(list), 0660)
 	if err != nil {
-		return xerrors.Errorf("writing file: %+v", err)
+		return xerrors.Errorf("writing file: %v", err)
 	}
 	simulConfig, err := sim.Setup(m.deployDir, hosts)
 	if err != nil {
-		return xerrors.Errorf("simulation setup: %+v", err)
+		return xerrors.Errorf("simulation setup: %v", err)
 	}
 	simulConfig.Config = string(rc.Toml())
 	m.config = simulConfig.Config
@@ -253,14 +253,14 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 	err = app.Copy(m.deployDir, m.mininetDir+"/start.py")
 	if err != nil {
 		log.Error(err)
-		return xerrors.Errorf("copying: %+v", err)
+		return xerrors.Errorf("copying: %v", err)
 	}
 
 	// Copy conode-binary
 	err = app.Copy(m.deployDir, m.buildDir+"/conode")
 	if err != nil {
 		log.Error(err)
-		return xerrors.Errorf("copying: %+v", err)
+		return xerrors.Errorf("copying: %v", err)
 	}
 
 	// Copy everything over to MiniNet
@@ -379,7 +379,7 @@ func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err e
 	physicalServers := len(m.HostIPs)
 	nbrServers, err := rc.GetInt("Servers")
 	if err != nil {
-		err = xerrors.Errorf("config: %+v", err)
+		err = xerrors.Errorf("config: %v", err)
 		return
 	}
 	if nbrServers > physicalServers {
@@ -394,7 +394,7 @@ func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err e
 	for n := range nets {
 		ips[n], nets[n], err = net.ParseCIDR(fmt.Sprintf("10.%d.0.0/16", n+1))
 		if err != nil {
-			err = xerrors.Errorf("parsing cidr: %+v", err)
+			err = xerrors.Errorf("parsing cidr: %v", err)
 			return
 		}
 		// We'll have to start with 10.1.0.2 as the first host.
@@ -404,7 +404,7 @@ func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err e
 	hosts = []string{}
 	nbrHosts, err := rc.GetInt("Hosts")
 	if err != nil {
-		err = xerrors.Errorf("config: %+v", err)
+		err = xerrors.Errorf("config: %v", err)
 		return
 	}
 

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -5,7 +5,6 @@
 package platform
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -22,6 +21,7 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // MiniNet represents all the configuration that is necessary to run a simulation
@@ -347,9 +347,9 @@ func (m *MiniNet) parseServers() error {
 			ips, err := net.LookupIP(h)
 			if err != nil {
 				if err2 := CheckOutOfFileDescriptors(); err2 != nil {
-					return errors.New("couldn't look up hostname: " + err2.Error())
+					return xerrors.New("couldn't look up hostname: " + err2.Error())
 				}
-				return errors.New("error while looking up hostname: " + err.Error())
+				return xerrors.New("error while looking up hostname: " + err.Error())
 			}
 			log.Lvl3("Found IP for", h, ":", ips[0])
 			m.HostIPs = append(m.HostIPs, ips[0].String())

--- a/simul/platform/platform.go
+++ b/simul/platform/platform.go
@@ -6,7 +6,6 @@ package platform
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"go/build"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // The Life of a simulation:
@@ -234,7 +234,7 @@ func (r *RunConfig) Delete(field string) {
 }
 
 // ErrorFieldNotPresent signals that a field is not in the RunConfig.
-var ErrorFieldNotPresent = errors.New("field not present")
+var ErrorFieldNotPresent = xerrors.New("field not present")
 
 // GetInt returns the integer of the field, or error if not defined
 func (r *RunConfig) GetInt(field string) (int, error) {

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/onet/v3/simul/manage"
 	"go.dedis.ch/onet/v3/simul/monitor"
+	"golang.org/x/xerrors"
 )
 
 type simulInit struct{}
@@ -27,7 +27,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 	if monitorAddress != "" {
 		if err := monitor.ConnectSink(monitorAddress); err != nil {
 			log.Error("Couldn't connect monitor to sink:", err)
-			return errors.New("couldn't connect monitor to sink: " + err.Error())
+			return xerrors.New("couldn't connect monitor to sink: " + err.Error())
 		}
 	}
 	sims := make([]onet.Simulation, len(scs))
@@ -45,7 +45,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 		cfg := &conf{}
 		_, err := toml.Decode(scs[0].Config, cfg)
 		if err != nil {
-			return errors.New("error while decoding config: " + err.Error())
+			return xerrors.New("error while decoding config: " + err.Error())
 		}
 		measureNodeBW = cfg.IndividualStats == ""
 	}
@@ -78,7 +78,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 
 		sim, err := onet.NewSimulation(simul, sc.Config)
 		if err != nil {
-			return errors.New("couldn't create new simulation: " + err.Error())
+			return xerrors.New("couldn't create new simulation: " + err.Error())
 		}
 		sims[i] = sim
 		// Need to store sc in a tmp-variable so it's correctly passed
@@ -133,7 +133,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 		for wait {
 			p, err := rootSC.Overlay.CreateProtocol("Count", rootSC.Tree, onet.NilServiceID)
 			if err != nil {
-				return errors.New("couldn't create protocol: " + err.Error())
+				return xerrors.New("couldn't create protocol: " + err.Error())
 			}
 			proto := p.(*manage.ProtocolCount)
 			proto.SetTimeout(timeout)
@@ -181,7 +181,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 		closeTree := rootSC.Roster.GenerateBinaryTree()
 		pi, err := rootSC.Overlay.CreateProtocol("CloseAll", closeTree, onet.NilServiceID)
 		if err != nil {
-			return errors.New("couldn't create closeAll protocol: " + err.Error())
+			return xerrors.New("couldn't create closeAll protocol: " + err.Error())
 		}
 		pi.Start()
 	}
@@ -195,7 +195,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 
 	// Give a chance to the simulation to stop the servers and clean up but returns the simulation error anyway.
 	if simError != nil {
-		return errors.New("error from simulation run: " + simError.Error())
+		return xerrors.New("error from simulation run: " + simError.Error())
 	}
 	return nil
 }

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -99,7 +99,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 			_, err := scTmp.Server.Send(env.ServerIdentity, &simulInitDone{})
 			log.ErrFatal(err)
 			// not reached because of ErrFatal, but return it anyway.
-			return err
+			return xerrors.Errorf("sending: %+v", err)
 		})
 		server.RegisterProcessorFunc(simulInitDoneID, func(env *network.Envelope) error {
 			wgSimulInit.Done()

--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -99,7 +99,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 			_, err := scTmp.Server.Send(env.ServerIdentity, &simulInitDone{})
 			log.ErrFatal(err)
 			// not reached because of ErrFatal, but return it anyway.
-			return xerrors.Errorf("sending: %+v", err)
+			return xerrors.Errorf("sending: %v", err)
 		})
 		server.RegisterProcessorFunc(simulInitDoneID, func(env *network.Envelope) error {
 			wgSimulInit.Done()

--- a/simul/test_simul/simul.go
+++ b/simul/test_simul/simul.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"strconv"
 
 	"github.com/BurntSushi/toml"
@@ -10,6 +9,7 @@ import (
 	"go.dedis.ch/onet/v3/simul"
 	"go.dedis.ch/onet/v3/simul/manage"
 	"go.dedis.ch/onet/v3/simul/monitor"
+	"golang.org/x/xerrors"
 )
 
 /*
@@ -66,7 +66,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		children := <-p.(*manage.ProtocolCount).Count
 		round.Record()
 		if children != size {
-			return errors.New("Didn't get " + strconv.Itoa(size) +
+			return xerrors.New("Didn't get " + strconv.Itoa(size) +
 				" children")
 		}
 	}

--- a/simul/test_simul/simul.go
+++ b/simul/test_simul/simul.go
@@ -33,7 +33,7 @@ func NewSimulation(config string) (onet.Simulation, error) {
 	es := &simulation{}
 	_, err := toml.Decode(config, es)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("decoding toml: %+v", err)
 	}
 	return es, nil
 }
@@ -45,7 +45,7 @@ func (e *simulation) Setup(dir string, hosts []string) (
 	e.CreateRoster(sc, hosts, 2000)
 	err := e.CreateTree(sc)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating tree: %+v", err)
 	}
 	return sc, nil
 }
@@ -60,7 +60,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		round := monitor.NewTimeMeasure("round")
 		p, err := config.Overlay.CreateProtocol("Count", config.Tree, onet.NilServiceID)
 		if err != nil {
-			return err
+			return xerrors.Errorf("creating protocol: %+v", err)
 		}
 		go p.Start()
 		children := <-p.(*manage.ProtocolCount).Count

--- a/simul/test_simul/simul.go
+++ b/simul/test_simul/simul.go
@@ -33,7 +33,7 @@ func NewSimulation(config string) (onet.Simulation, error) {
 	es := &simulation{}
 	_, err := toml.Decode(config, es)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding toml: %+v", err)
+		return nil, xerrors.Errorf("decoding toml: %v", err)
 	}
 	return es, nil
 }
@@ -45,7 +45,7 @@ func (e *simulation) Setup(dir string, hosts []string) (
 	e.CreateRoster(sc, hosts, 2000)
 	err := e.CreateTree(sc)
 	if err != nil {
-		return nil, xerrors.Errorf("creating tree: %+v", err)
+		return nil, xerrors.Errorf("creating tree: %v", err)
 	}
 	return sc, nil
 }
@@ -60,7 +60,7 @@ func (e *simulation) Run(config *onet.SimulationConfig) error {
 		round := monitor.NewTimeMeasure("round")
 		p, err := config.Overlay.CreateProtocol("Count", config.Tree, onet.NilServiceID)
 		if err != nil {
-			return xerrors.Errorf("creating protocol: %+v", err)
+			return xerrors.Errorf("creating protocol: %v", err)
 		}
 		go p.Start()
 		children := <-p.(*manage.ProtocolCount).Count

--- a/simulation.go
+++ b/simulation.go
@@ -1,7 +1,6 @@
 package onet
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -16,6 +15,7 @@ import (
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
 )
 
 type simulationCreate func(string) (Simulation, error)
@@ -156,7 +156,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 			}
 		}
 		if len(ret) == 0 {
-			return nil, errors.New("Address not used in simulation: " + ca)
+			return nil, xerrors.New("Address not used in simulation: " + ca)
 		}
 	} else {
 		ret = append(ret, sc)
@@ -220,7 +220,7 @@ func SimulationRegister(name string, sim simulationCreate) {
 func NewSimulation(name string, conf string) (Simulation, error) {
 	sim, ok := simulationRegistered[name]
 	if !ok {
-		return nil, errors.New("Didn't find simulation " + name)
+		return nil, xerrors.New("Didn't find simulation " + name)
 	}
 	simInst, err := sim(conf)
 	if err != nil {
@@ -354,7 +354,7 @@ func (s *SimulationBFTree) CreateTree(sc *SimulationConfig) error {
 	log.Lvl3("CreateTree strarted")
 	start := time.Now()
 	if sc.Roster == nil {
-		return errors.New("Empty Roster")
+		return xerrors.New("Empty Roster")
 	}
 	sc.Tree = sc.Roster.GenerateBigNaryTree(s.BF, s.Hosts)
 	log.Lvl3("Creating tree took: " + time.Now().Sub(start).String())

--- a/simulation.go
+++ b/simulation.go
@@ -1,7 +1,6 @@
 package onet
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -107,11 +106,11 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 	network.RegisterMessage(SimulationConfigFile{})
 	bin, err := ioutil.ReadFile(dir + "/" + SimulationFileName)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("reading file: %+v", err)
 	}
 	_, msg, err := network.Unmarshal(bin, suite)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("unmarshaling: %+v", err)
 	}
 
 	scf := msg.(*SimulationConfigFile)
@@ -123,7 +122,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 	}
 	sc.Tree, err = scf.TreeMarshal.MakeTree(sc.Roster)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("making tree: %+v", err)
 	}
 
 	var ret []*SimulationConfig
@@ -141,7 +140,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 					sid := e.ServiceIdentities[i]
 					suite, err := suites.Find(sid.Suite)
 					if err != nil {
-						return nil, fmt.Errorf("Unknown suite with name %s", sid.Suite)
+						return nil, xerrors.Errorf("Unknown suite with name %s", sid.Suite)
 					}
 					e.ServiceIdentities[i] = network.NewServiceIdentity(sid.Name, suite, sid.Public, privkey)
 				}
@@ -224,11 +223,11 @@ func NewSimulation(name string, conf string) (Simulation, error) {
 	}
 	simInst, err := sim(conf)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating simulation: %+v", err)
 	}
 	_, err = toml.Decode(conf, simInst)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("decoding toml: %+v", err)
 	}
 	return simInst, nil
 }

--- a/simulation.go
+++ b/simulation.go
@@ -106,11 +106,11 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 	network.RegisterMessage(SimulationConfigFile{})
 	bin, err := ioutil.ReadFile(dir + "/" + SimulationFileName)
 	if err != nil {
-		return nil, xerrors.Errorf("reading file: %+v", err)
+		return nil, xerrors.Errorf("reading file: %v", err)
 	}
 	_, msg, err := network.Unmarshal(bin, suite)
 	if err != nil {
-		return nil, xerrors.Errorf("unmarshaling: %+v", err)
+		return nil, xerrors.Errorf("unmarshaling: %v", err)
 	}
 
 	scf := msg.(*SimulationConfigFile)
@@ -122,7 +122,7 @@ func LoadSimulationConfig(s, dir, ca string) ([]*SimulationConfig, error) {
 	}
 	sc.Tree, err = scf.TreeMarshal.MakeTree(sc.Roster)
 	if err != nil {
-		return nil, xerrors.Errorf("making tree: %+v", err)
+		return nil, xerrors.Errorf("making tree: %v", err)
 	}
 
 	var ret []*SimulationConfig
@@ -223,11 +223,11 @@ func NewSimulation(name string, conf string) (Simulation, error) {
 	}
 	simInst, err := sim(conf)
 	if err != nil {
-		return nil, xerrors.Errorf("creating simulation: %+v", err)
+		return nil, xerrors.Errorf("creating simulation: %v", err)
 	}
 	_, err = toml.Decode(conf, simInst)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding toml: %+v", err)
+		return nil, xerrors.Errorf("decoding toml: %v", err)
 	}
 	return simInst, nil
 }

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -1,7 +1,6 @@
 package onet
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/kyber/v3/suites"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 var pairingSuite = suites.MustFind("bn256.adapter")
@@ -151,14 +151,14 @@ func createBFTree(hosts, bf int, tls bool, addresses []string) (*SimulationConfi
 	}
 	sb.CreateRoster(sc, addresses, 2000)
 	if len(sc.Roster.List) != hosts {
-		return nil, nil, errors.New("Didn't get correct number of entities")
+		return nil, nil, xerrors.New("Didn't get correct number of entities")
 	}
 	err := sb.CreateTree(sc)
 	if err != nil {
 		return nil, nil, err
 	}
 	if !sc.Tree.IsNary(sc.Tree.Root, bf) {
-		return nil, nil, errors.New("Tree isn't " + strconv.Itoa(bf) + "-ary")
+		return nil, nil, xerrors.New("Tree isn't " + strconv.Itoa(bf) + "-ary")
 	}
 
 	return sc, sb, nil

--- a/tree.go
+++ b/tree.go
@@ -109,7 +109,7 @@ func NewTreeFromMarshal(s network.Suite, buf []byte, el *Roster) (*Tree, error) 
 	}
 	t, err := pm.(*TreeMarshal).MakeTree(el)
 	if err != nil {
-		return nil, xerrors.Errorf("making tree: %+v", err)
+		return nil, xerrors.Errorf("making tree: %v", err)
 	}
 	t.computeSubtreeAggregate(t.Root)
 	return t, nil
@@ -135,7 +135,7 @@ func (t *Tree) MakeTreeMarshal() *TreeMarshal {
 func (t *Tree) Marshal() ([]byte, error) {
 	buf, err := network.Marshal(t.MakeTreeMarshal())
 	if err != nil {
-		return nil, xerrors.Errorf("making tree marshal: %+v", err)
+		return nil, xerrors.Errorf("making tree marshal: %v", err)
 	}
 	return buf, nil
 }
@@ -149,7 +149,7 @@ type tbmStruct struct {
 func (t *Tree) BinaryMarshaler() ([]byte, error) {
 	bt, err := t.Marshal()
 	if err != nil {
-		return nil, xerrors.Errorf("marshaling: %+v", err)
+		return nil, xerrors.Errorf("marshaling: %v", err)
 	}
 	tbm := &tbmStruct{
 		T:  bt,
@@ -157,7 +157,7 @@ func (t *Tree) BinaryMarshaler() ([]byte, error) {
 	}
 	b, err := network.Marshal(tbm)
 	if err != nil {
-		return nil, xerrors.Errorf("marshaling: %+v", err)
+		return nil, xerrors.Errorf("marshaling: %v", err)
 	}
 	return b, nil
 }
@@ -171,7 +171,7 @@ func (t *Tree) BinaryUnmarshaler(s network.Suite, b []byte) error {
 	}
 	tree, err := NewTreeFromMarshal(s, tbm.T, tbm.Ro)
 	if err != nil {
-		return xerrors.Errorf("making tree marshal: %+v", err)
+		return xerrors.Errorf("making tree marshal: %v", err)
 	}
 	t.Roster = tbm.Ro
 	t.ID = tree.ID
@@ -353,7 +353,7 @@ func (tm TreeMarshal) MakeTree(ro *Roster) (*Tree, error) {
 	var err error
 	tree.Root, err = tm.Children[0].MakeTreeFromList(nil, ro)
 	if err != nil {
-		return nil, xerrors.Errorf("making tree: %+v", err)
+		return nil, xerrors.Errorf("making tree: %v", err)
 	}
 	tree.computeSubtreeAggregate(tree.Root)
 	return tree, nil
@@ -374,7 +374,7 @@ func (tm *TreeMarshal) MakeTreeFromList(parent *TreeNode, ro *Roster) (*TreeNode
 	for _, c := range tm.Children {
 		ntn, err := c.MakeTreeFromList(tn, ro)
 		if err != nil {
-			return nil, xerrors.Errorf("making tree: %+v", err)
+			return nil, xerrors.Errorf("making tree: %v", err)
 		}
 		tn.Children = append(tn.Children, ntn)
 	}
@@ -465,7 +465,7 @@ func (ro *Roster) GetID() (RosterID, error) {
 	for _, id := range ro.List {
 		_, err := id.Public.MarshalTo(h)
 		if err != nil {
-			return RosterID{}, xerrors.Errorf("marshaling: %+v", err)
+			return RosterID{}, xerrors.Errorf("marshaling: %v", err)
 		}
 
 		// order is important for the hash
@@ -473,7 +473,7 @@ func (ro *Roster) GetID() (RosterID, error) {
 		for _, srvid := range id.ServiceIdentities {
 			_, err = srvid.Public.MarshalTo(h)
 			if err != nil {
-				return RosterID{}, xerrors.Errorf("marshaling: %+v", err)
+				return RosterID{}, xerrors.Errorf("marshaling: %v", err)
 			}
 		}
 	}
@@ -806,12 +806,12 @@ func (ro *Roster) Contains(pubs []kyber.Point) bool {
 func (ro *Roster) Equal(other *Roster) (bool, error) {
 	roID, err := ro.GetID()
 	if err != nil {
-		return false, xerrors.Errorf("roster id: %+v", err)
+		return false, xerrors.Errorf("roster id: %v", err)
 	}
 
 	otherID, err := other.GetID()
 	if err != nil {
-		return false, xerrors.Errorf("roster id: %+v", err)
+		return false, xerrors.Errorf("roster id: %v", err)
 	}
 
 	return roID.Equal(otherID), nil

--- a/treenode.go
+++ b/treenode.go
@@ -170,7 +170,7 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 	sentLen, err := n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, c)
 	n.tx.add(sentLen)
 	if err != nil {
-		return xerrors.Errorf("sending: %+v", err)
+		return xerrors.Errorf("sending: %v", err)
 	}
 	return nil
 }
@@ -210,7 +210,7 @@ func (n *TreeNodeInstance) Suite() network.Suite {
 func (n *TreeNodeInstance) RegisterChannel(c interface{}) error {
 	err := n.RegisterChannelLength(c, DefaultChannelLength)
 	if err != nil {
-		return xerrors.Errorf("registering channel length: %+v", err)
+		return xerrors.Errorf("registering channel length: %v", err)
 	}
 	return nil
 }
@@ -373,7 +373,7 @@ func (n *TreeNodeInstance) closeDispatch() error {
 	}
 	err := pni.Shutdown()
 	if err != nil {
-		return xerrors.Errorf("shutdown: %+v", err)
+		return xerrors.Errorf("shutdown: %v", err)
 	}
 	return nil
 }
@@ -393,7 +393,7 @@ func (n *TreeNodeInstance) dispatchHandler(msgSlice []*ProtocolMsg) error {
 		for i, msg := range msgSlice {
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return xerrors.Errorf("processing message: %+v", err)
+				return xerrors.Errorf("processing message: %v", err)
 			}
 			msgs.Index(i).Set(m)
 		}
@@ -410,14 +410,14 @@ func (n *TreeNodeInstance) dispatchHandler(msgSlice []*ProtocolMsg) error {
 			log.Lvl4("Dispatching", msg, "to", n.ServerIdentity().Address)
 			m, err := n.createValueAndVerify(to, msg)
 			if err != nil {
-				return xerrors.Errorf("processing message: %+v", err)
+				return xerrors.Errorf("processing message: %v", err)
 			}
 			errV = f.Call([]reflect.Value{m})[0]
 		}
 	}
 	log.Lvlf4("%s Done with handler for %s", n.Name(), f.Type())
 	if !errV.IsNil() {
-		return xerrors.Errorf("handler: %+v", errV.Interface())
+		return xerrors.Errorf("handler: %v", errV.Interface())
 	}
 	return nil
 }
@@ -461,7 +461,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 			log.Lvl4("Dispatching aggregated to", to)
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return xerrors.Errorf("processing message: %+v", err)
+				return xerrors.Errorf("processing message: %v", err)
 			}
 			log.Lvl4("Adding msg", m, "to", n.ServerIdentity().Address)
 			out.Index(i).Set(m)
@@ -472,7 +472,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 			out := reflect.ValueOf(n.channels[mt])
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return xerrors.Errorf("processing message: %+v", err)
+				return xerrors.Errorf("processing message: %v", err)
 			}
 			log.Lvl4(n.Name(), "Dispatching msg type", mt, " to", to, " :", m.Field(1).Interface())
 			if out.Len() < out.Cap() {
@@ -574,7 +574,7 @@ func (n *TreeNodeInstance) dispatchMsgToProtocol(onetMsg *ProtocolMsg) error {
 		return xerrors.Errorf("message-type not handled by the protocol: %s", reflect.TypeOf(onetMsg.Msg))
 	}
 	if err != nil {
-		return xerrors.Errorf("dispatch: %+v", err)
+		return xerrors.Errorf("dispatch: %v", err)
 	}
 	return nil
 }
@@ -629,7 +629,7 @@ func (n *TreeNodeInstance) aggregate(onetMsg *ProtocolMsg) (network.MessageTypeI
 func (n *TreeNodeInstance) startProtocol() error {
 	err := n.instance.Start()
 	if err != nil {
-		return xerrors.Errorf("starting protocol: %+v", err)
+		return xerrors.Errorf("starting protocol: %v", err)
 	}
 	return nil
 }
@@ -707,7 +707,7 @@ func (n *TreeNodeInstance) CloseHost() error {
 	n.Host().callTestClose()
 	err := n.Host().Close()
 	if err != nil {
-		return xerrors.Errorf("closing host: %+v", err)
+		return xerrors.Errorf("closing host: %v", err)
 	}
 	return nil
 }
@@ -761,7 +761,7 @@ func (n *TreeNodeInstance) Broadcast(msg interface{}) []error {
 	for _, node := range n.List() {
 		if !node.Equal(n.TreeNode()) {
 			if err := n.SendTo(node, msg); err != nil {
-				errs = append(errs, xerrors.Errorf("sending: %+v", err))
+				errs = append(errs, xerrors.Errorf("sending: %v", err))
 			}
 		}
 	}
@@ -773,7 +773,7 @@ func (n *TreeNodeInstance) Multicast(msg interface{}, nodes ...*TreeNode) []erro
 	var errs []error
 	for _, node := range nodes {
 		if err := n.SendTo(node, msg); err != nil {
-			errs = append(errs, xerrors.Errorf("sending: %+v", err))
+			errs = append(errs, xerrors.Errorf("sending: %v", err))
 		}
 	}
 	return errs
@@ -786,7 +786,7 @@ func (n *TreeNodeInstance) SendToParent(msg interface{}) error {
 	}
 	err := n.SendTo(n.Parent(), msg)
 	if err != nil {
-		return xerrors.Errorf("sending: %+v", err)
+		return xerrors.Errorf("sending: %v", err)
 	}
 	return nil
 }
@@ -801,7 +801,7 @@ func (n *TreeNodeInstance) SendToChildren(msg interface{}) error {
 	}
 	for _, node := range n.Children() {
 		if err := n.SendTo(node, msg); err != nil {
-			return xerrors.Errorf("sending: %+v", err)
+			return xerrors.Errorf("sending: %v", err)
 		}
 	}
 	return nil
@@ -828,7 +828,7 @@ func (n *TreeNodeInstance) SendToChildrenInParallel(msg interface{}) []error {
 		go func(n2 *TreeNode) {
 			if err := n.SendTo(n2, msg); err != nil {
 				eMut.Lock()
-				errs = append(errs, xerrors.Errorf("%s: %+v", name, err))
+				errs = append(errs, xerrors.Errorf("%s: %v", name, err))
 				eMut.Unlock()
 			}
 			wg.Done()
@@ -846,7 +846,7 @@ func (n *TreeNodeInstance) SendToChildrenInParallel(msg interface{}) []error {
 func (n *TreeNodeInstance) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	pi, err := n.overlay.CreateProtocol(name, t, n.Token().ServiceID)
 	if err != nil {
-		return nil, xerrors.Errorf("creating protocol: %+v", err)
+		return nil, xerrors.Errorf("creating protocol: %v", err)
 	}
 	return pi, nil
 }

--- a/treenode.go
+++ b/treenode.go
@@ -169,7 +169,10 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 
 	sentLen, err := n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, c)
 	n.tx.add(sentLen)
-	return err
+	if err != nil {
+		return xerrors.Errorf("sending: %+v", err)
+	}
+	return nil
 }
 
 // Tree returns the tree of that node. Because the storage keeps the tree around
@@ -205,7 +208,11 @@ func (n *TreeNodeInstance) Suite() network.Suite {
 // RegisterChannel is a compatibility-method for RegisterChannelLength
 // and setting up a channel with length 100.
 func (n *TreeNodeInstance) RegisterChannel(c interface{}) error {
-	return n.RegisterChannelLength(c, DefaultChannelLength)
+	err := n.RegisterChannelLength(c, DefaultChannelLength)
+	if err != nil {
+		return xerrors.Errorf("registering channel length: %+v", err)
+	}
+	return nil
 }
 
 // RegisterChannelLength takes a channel with a struct that contains two
@@ -257,7 +264,7 @@ func (n *TreeNodeInstance) RegisterChannelLength(c interface{}, length int) erro
 func (n *TreeNodeInstance) RegisterChannels(channels ...interface{}) error {
 	for _, ch := range channels {
 		if err := n.RegisterChannel(ch); err != nil {
-			return fmt.Errorf("Error, could not register channel %T: %s",
+			return xerrors.Errorf("Error, could not register channel %T: %s",
 				ch, err.Error())
 		}
 	}
@@ -269,7 +276,7 @@ func (n *TreeNodeInstance) RegisterChannels(channels ...interface{}) error {
 func (n *TreeNodeInstance) RegisterChannelsLength(length int, channels ...interface{}) error {
 	for _, ch := range channels {
 		if err := n.RegisterChannelLength(ch, length); err != nil {
-			return fmt.Errorf("Error, could not register channel %T: %s",
+			return xerrors.Errorf("Error, could not register channel %T: %s",
 				ch, err.Error())
 		}
 	}
@@ -324,7 +331,7 @@ func (n *TreeNodeInstance) RegisterHandler(c interface{}) error {
 func (n *TreeNodeInstance) RegisterHandlers(handlers ...interface{}) error {
 	for _, h := range handlers {
 		if err := n.RegisterHandler(h); err != nil {
-			return fmt.Errorf("Error, could not register handler %T: %s",
+			return xerrors.Errorf("Error, could not register handler %T: %s",
 				h, err.Error())
 		}
 	}
@@ -364,7 +371,11 @@ func (n *TreeNodeInstance) closeDispatch() error {
 	if pni == nil {
 		return xerrors.New("Can't shutdown empty ProtocolInstance")
 	}
-	return pni.Shutdown()
+	err := pni.Shutdown()
+	if err != nil {
+		return xerrors.Errorf("shutdown: %+v", err)
+	}
+	return nil
 }
 
 // ProtocolName will return the string representing that protocol
@@ -382,7 +393,7 @@ func (n *TreeNodeInstance) dispatchHandler(msgSlice []*ProtocolMsg) error {
 		for i, msg := range msgSlice {
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return err
+				return xerrors.Errorf("processing message: %+v", err)
 			}
 			msgs.Index(i).Set(m)
 		}
@@ -399,14 +410,14 @@ func (n *TreeNodeInstance) dispatchHandler(msgSlice []*ProtocolMsg) error {
 			log.Lvl4("Dispatching", msg, "to", n.ServerIdentity().Address)
 			m, err := n.createValueAndVerify(to, msg)
 			if err != nil {
-				return err
+				return xerrors.Errorf("processing message: %+v", err)
 			}
 			errV = f.Call([]reflect.Value{m})[0]
 		}
 	}
 	log.Lvlf4("%s Done with handler for %s", n.Name(), f.Type())
 	if !errV.IsNil() {
-		return errV.Interface().(error)
+		return xerrors.Errorf("handler: %+v", errV.Interface())
 	}
 	return nil
 }
@@ -424,7 +435,7 @@ func (n *TreeNodeInstance) createValueAndVerify(t reflect.Type, msg *ProtocolMsg
 		// We can trust msg.ServerIdentity, because it is written in Router.handleConn and
 		// is not writable by the sending node.
 		if msg.ServerIdentity != nil && tn != nil && !tn.ServerIdentity.Equal(msg.ServerIdentity) {
-			return m, fmt.Errorf("ServerIdentity in the tree node referenced by the message (%v) does not match the ServerIdentity of the message originator (%v)",
+			return m, xerrors.Errorf("ServerIdentity in the tree node referenced by the message (%v) does not match the ServerIdentity of the message originator (%v)",
 				tn.ServerIdentity, msg.ServerIdentity)
 		}
 	}
@@ -438,7 +449,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 		// In rare occasions we write to a closed channel which throws a panic.
 		// Catch it here so we can find out better why this happens.
 		if r := recover(); r != nil {
-			log.Error("Shouldn't happen, please report an issue:", n.Info(), r, mt)
+			log.Error("Shouldn't happen, please report an issue:", n.Info(), mt, r)
 		}
 	}()
 	to := reflect.TypeOf(n.channels[mt])
@@ -450,7 +461,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 			log.Lvl4("Dispatching aggregated to", to)
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return err
+				return xerrors.Errorf("processing message: %+v", err)
 			}
 			log.Lvl4("Adding msg", m, "to", n.ServerIdentity().Address)
 			out.Index(i).Set(m)
@@ -461,7 +472,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 			out := reflect.ValueOf(n.channels[mt])
 			m, err := n.createValueAndVerify(to.Elem(), msg)
 			if err != nil {
-				return err
+				return xerrors.Errorf("processing message: %+v", err)
 			}
 			log.Lvl4(n.Name(), "Dispatching msg type", mt, " to", to, " :", m.Field(1).Interface())
 			if out.Len() < out.Cap() {
@@ -472,7 +483,7 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 					out.Send(m)
 				}
 			} else {
-				return fmt.Errorf("channel too small for msg %s in %s: "+
+				return xerrors.Errorf("channel too small for msg %s in %s: "+
 					"please use RegisterChannelLength()",
 					mt, n.ProtocolName())
 			}
@@ -560,9 +571,12 @@ func (n *TreeNodeInstance) dispatchMsgToProtocol(onetMsg *ProtocolMsg) error {
 		log.Lvl4("Dispatching to handler", n.ServerIdentity().Address)
 		err = n.dispatchHandler(msgs)
 	default:
-		return fmt.Errorf("message-type not handled by the protocol: %s", reflect.TypeOf(onetMsg.Msg))
+		return xerrors.Errorf("message-type not handled by the protocol: %s", reflect.TypeOf(onetMsg.Msg))
 	}
-	return err
+	if err != nil {
+		return xerrors.Errorf("dispatch: %+v", err)
+	}
+	return nil
 }
 
 // setFlag makes sure a given flag is set
@@ -613,7 +627,11 @@ func (n *TreeNodeInstance) aggregate(onetMsg *ProtocolMsg) (network.MessageTypeI
 // startProtocol calls the Start() on the underlying protocol which in turn will
 // initiate the first message to its children
 func (n *TreeNodeInstance) startProtocol() error {
-	return n.instance.Start()
+	err := n.instance.Start()
+	if err != nil {
+		return xerrors.Errorf("starting protocol: %+v", err)
+	}
+	return nil
 }
 
 // Done calls onDoneCallback if available and only finishes when the return-
@@ -687,7 +705,11 @@ func (n *TreeNodeInstance) NodePublic(si *network.ServerIdentity) kyber.Point {
 // releases.
 func (n *TreeNodeInstance) CloseHost() error {
 	n.Host().callTestClose()
-	return n.Host().Close()
+	err := n.Host().Close()
+	if err != nil {
+		return xerrors.Errorf("closing host: %+v", err)
+	}
+	return nil
 }
 
 // Name returns a human readable name of this Node (IP address).
@@ -739,7 +761,7 @@ func (n *TreeNodeInstance) Broadcast(msg interface{}) []error {
 	for _, node := range n.List() {
 		if !node.Equal(n.TreeNode()) {
 			if err := n.SendTo(node, msg); err != nil {
-				errs = append(errs, err)
+				errs = append(errs, xerrors.Errorf("sending: %+v", err))
 			}
 		}
 	}
@@ -751,7 +773,7 @@ func (n *TreeNodeInstance) Multicast(msg interface{}, nodes ...*TreeNode) []erro
 	var errs []error
 	for _, node := range nodes {
 		if err := n.SendTo(node, msg); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, xerrors.Errorf("sending: %+v", err))
 		}
 	}
 	return errs
@@ -762,7 +784,11 @@ func (n *TreeNodeInstance) SendToParent(msg interface{}) error {
 	if n.IsRoot() {
 		return nil
 	}
-	return n.SendTo(n.Parent(), msg)
+	err := n.SendTo(n.Parent(), msg)
+	if err != nil {
+		return xerrors.Errorf("sending: %+v", err)
+	}
+	return nil
 }
 
 // SendToChildren sends a given message to all children of the calling node.
@@ -775,7 +801,7 @@ func (n *TreeNodeInstance) SendToChildren(msg interface{}) error {
 	}
 	for _, node := range n.Children() {
 		if err := n.SendTo(node, msg); err != nil {
-			return err
+			return xerrors.Errorf("sending: %+v", err)
 		}
 	}
 	return nil
@@ -802,7 +828,7 @@ func (n *TreeNodeInstance) SendToChildrenInParallel(msg interface{}) []error {
 		go func(n2 *TreeNode) {
 			if err := n.SendTo(n2, msg); err != nil {
 				eMut.Lock()
-				errs = append(errs, xerrors.New(name+": "+err.Error()))
+				errs = append(errs, xerrors.Errorf("%s: %+v", name, err))
 				eMut.Unlock()
 			}
 			wg.Done()
@@ -819,7 +845,10 @@ func (n *TreeNodeInstance) SendToChildrenInParallel(msg interface{}) []error {
 // be handled by onet.
 func (n *TreeNodeInstance) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	pi, err := n.overlay.CreateProtocol(name, t, n.Token().ServiceID)
-	return pi, err
+	if err != nil {
+		return nil, xerrors.Errorf("creating protocol: %+v", err)
+	}
+	return pi, nil
 }
 
 // Host returns the underlying Host of this node.

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"go.dedis.ch/onet/v3/log"
+	"golang.org/x/xerrors"
 )
 
 // WriteTomlConfig write  any structure to a toml-file
@@ -30,7 +31,7 @@ func ReadTomlConfig(conf interface{}, filename string, dirOpt ...string) error {
 	if err != nil {
 		pwd, _ := os.Getwd()
 		log.Lvl1("Didn't find", filename, "in", pwd)
-		return err
+		return xerrors.Errorf("reading file: %+v", err)
 	}
 
 	_, err = toml.Decode(string(buf), conf)

--- a/utils.go
+++ b/utils.go
@@ -31,7 +31,7 @@ func ReadTomlConfig(conf interface{}, filename string, dirOpt ...string) error {
 	if err != nil {
 		pwd, _ := os.Getwd()
 		log.Lvl1("Didn't find", filename, "in", pwd)
-		return xerrors.Errorf("reading file: %+v", err)
+		return xerrors.Errorf("reading file: %v", err)
 	}
 
 	_, err = toml.Decode(string(buf), conf)

--- a/websocket.go
+++ b/websocket.go
@@ -3,7 +3,6 @@ package onet
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -19,6 +18,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 	graceful "gopkg.in/tylerb/graceful.v1"
 )
 
@@ -190,7 +190,7 @@ func (w *WebSocket) start() {
 // path and it's sub-endpoints will be forwarded to ProcessClientRequest.
 func (w *WebSocket) registerService(service string, s Service) error {
 	if service == "ok" {
-		return errors.New("service name \"ok\" is not allowed")
+		return xerrors.New("service name \"ok\" is not allowed")
 	}
 
 	w.services[service] = s
@@ -298,7 +298,7 @@ outerReadLoop:
 						return
 					case reply, ok := <-tun.out:
 						if !ok {
-							err = errors.New("service finished streaming")
+							err = xerrors.New("service finished streaming")
 							close(tun.close)
 							break outerReadLoop
 						}
@@ -783,7 +783,7 @@ func (c *Client) SendToAll(dst *Roster, path string, buf []byte) ([][]byte, erro
 	}
 	var err error
 	if len(errstrs) > 0 {
-		err = errors.New(strings.Join(errstrs, "\n"))
+		err = xerrors.New(strings.Join(errstrs, "\n"))
 	}
 	return msgs, err
 }
@@ -806,7 +806,7 @@ func (c *Client) Close() error {
 	}
 	var err error
 	if len(errstrs) > 0 {
-		err = errors.New(strings.Join(errstrs, "\n"))
+		err = xerrors.New(strings.Join(errstrs, "\n"))
 	}
 	return err
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -26,6 +25,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -823,7 +823,7 @@ func TestClient_SendProtobufParallelWithDecoder(t *testing.T) {
 	decoderWithError := func(data []byte, ret interface{}) error {
 		// As an example, the decoder should first decode the response, and it can then make
 		// further verification like the latest block index.
-		return errors.New("decoder error")
+		return xerrors.New("decoder error")
 	}
 
 	_, err := cl.SendProtobufParallelWithDecoder(roster.List, &SimpleResponse{}, &SimpleResponse{}, nil, decoderWithError)
@@ -858,10 +858,10 @@ func (i *ServiceWebSocket) ErrorRequest(msg *ErrorRequest) (network.Message, err
 	i.Errors = 1
 	index, _ := msg.Roster.Search(i.ServerIdentity().ID)
 	if index < 0 {
-		return nil, errors.New("not in roster")
+		return nil, xerrors.New("not in roster")
 	}
 	if msg.Flags&(1<<uint(index)) > 0 {
-		return nil, errors.New("found in flags: " + i.ServerIdentity().String())
+		return nil, xerrors.New("found in flags: " + i.ServerIdentity().String())
 	}
 	i.Errors = 0
 	return &SimpleResponse{}, nil


### PR DESCRIPTION
This PR  changes the errors to make use of the [xerrors package](https://godoc.org/golang.org/x/xerrors). The `%v` policy is respected except in case where the error is reused later for comparison.

It also update the logger so that the file path replaces the function name to have precise location of the log and we can make use of the auto-resolution of the IDEs.

Note that `log.Error` will print the complete stack trace if available. The formatting is left to the user for the other functions.