### PR TITLE
Make websocket start correctly when cert comes from reloader

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -188,7 +188,7 @@ func (w *WebSocket) start() {
 	go func() {
 		// Check if server is configured for TLS
 		started <- true
-		if w.server.Server.TLSConfig != nil && len(w.server.Server.TLSConfig.Certificates) >= 1 {
+		if w.server.Server.TLSConfig != nil && (w.server.TLSConfig.GetCertificate != nil || len(w.server.Server.TLSConfig.Certificates) >= 1) {
 			w.server.ListenAndServeTLS("", "")
 		} else {
 			w.server.ListenAndServe()


### PR DESCRIPTION
This fixes a problem introduced by #576, where the websocket
server would be started in HTTP mode instead of TLS mode
as a result of the new certificate reloader.

Fixes #583.