### PR TITLE
return nil error on successful registration of processor function

### DIFF
--- a/simul/platform/runsimul.go
+++ b/simul/platform/runsimul.go
@@ -98,8 +98,7 @@ func Simulate(suite, serverAddress, simul, monitorAddress string) error {
 			log.ErrFatal(err)
 			_, err := scTmp.Server.Send(env.ServerIdentity, &simulInitDone{})
 			log.ErrFatal(err)
-			// not reached because of ErrFatal, but return it anyway.
-			return xerrors.Errorf("sending: %v", err)
+			return nil
 		})
 		server.RegisterProcessorFunc(simulInitDoneID, func(env *network.Envelope) error {
 			wgSimulInit.Done()


### PR DESCRIPTION
The return statement is reached only if error is nil