### PR TITLE
Use the routine dispatcher to deserve requests asynchronously

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -67,7 +67,7 @@ func NewRouter(own *ServerIdentity, h Host) *Router {
 		ServerIdentity:          own,
 		connections:             make(map[ServerIdentityID][]Conn),
 		host:                    h,
-		Dispatcher:              NewBlockingDispatcher(),
+		Dispatcher:              NewRoutineDispatcher(),
 		connectionErrorHandlers: make([]func(*ServerIdentity), 0),
 	}
 	r.address = h.Address()


### PR DESCRIPTION
In situation where a node is processing a request that needs interactions with other nodes, it
can be stuck as the blocking dispatcher only allows one at a time. This switches to the routine
dispatcher that allows multiple requests to be processed.