### PR TITLE
network/marshal: fix ServerIdentity unmarshalling

### DIFF
--- a/network/encoding_test.go
+++ b/network/encoding_test.go
@@ -135,5 +135,5 @@ func TestMarshalServerIdentity_IDGetsRecreated(t *testing.T) {
 
 	require.Equal(t, address, recv.Address)
 	require.True(t, public.Equal(recv.Public))
-	require.NotEqual(t, ServerIdentityID(uuid.Nil), recv.ID)
+	require.NotEqual(t, ServerIdentityID(uuid.Nil), recv.GetID())
 }

--- a/network/router.go
+++ b/network/router.go
@@ -183,7 +183,7 @@ func (r *Router) Send(e *ServerIdentity, msgs ...Message) (uint64, error) {
 	r.msgTraffic.updateTx(1)
 
 	// If sending to ourself, directly dispatch it
-	if e.ID.Equal(r.ServerIdentity.ID) {
+	if e.GetID().Equal(r.ServerIdentity.GetID()) {
 		var sent uint64
 		for _, msg := range msgs {
 			log.Lvlf4("Sending to ourself (%s) msg: %+v", e, msg)
@@ -207,7 +207,7 @@ func (r *Router) Send(e *ServerIdentity, msgs ...Message) (uint64, error) {
 	}
 
 	var totSentLen uint64
-	c := r.connection(e.ID)
+	c := r.connection(e.GetID())
 	if c == nil {
 		var sentLen uint64
 		var err error
@@ -271,7 +271,7 @@ func (r *Router) removeConnection(si *ServerIdentity, c Conn) {
 	defer r.Unlock()
 
 	var toDelete = -1
-	arr := r.connections[si.ID]
+	arr := r.connections[si.GetID()]
 	for i, cc := range arr {
 		if c == cc {
 			toDelete = i
@@ -285,7 +285,7 @@ func (r *Router) removeConnection(si *ServerIdentity, c Conn) {
 
 	arr[toDelete] = arr[len(arr)-1]
 	arr[len(arr)-1] = nil
-	r.connections[si.ID] = arr[:len(arr)-1]
+	r.connections[si.GetID()] = arr[:len(arr)-1]
 }
 
 // triggerConnectionErrorHandlers trigger all registered connectionsErrorHandlers
@@ -391,12 +391,12 @@ func (r *Router) registerConnection(remote *ServerIdentity, c Conn) error {
 	if r.isClosed {
 		return xerrors.Errorf("closing: %w", ErrClosed)
 	}
-	_, okc := r.connections[remote.ID]
+	_, okc := r.connections[remote.GetID()]
 	if okc {
 		log.Lvl5("Connection already registered. " +
 			"Appending new connection to same identity.")
 	}
-	r.connections[remote.ID] = append(r.connections[remote.ID], c)
+	r.connections[remote.GetID()] = append(r.connections[remote.GetID()], c)
 	return nil
 }
 

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -167,13 +167,13 @@ func testRouterRemoveConnection(t *testing.T) {
 	require.Zero(t, sentLen)
 
 	r1.Lock()
-	require.Equal(t, 1, len(r1.connections[r2.ServerIdentity.ID]))
+	require.Equal(t, 1, len(r1.connections[r2.ServerIdentity.GetID()]))
 	r1.Unlock()
 
 	require.Nil(t, r2.Stop())
 
 	r1.Lock()
-	require.Equal(t, 0, len(r1.connections[r2.ServerIdentity.ID]))
+	require.Equal(t, 0, len(r1.connections[r2.ServerIdentity.GetID()]))
 	r1.Unlock()
 }
 
@@ -226,8 +226,8 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 		t.Fatal("Simple message got distorted")
 	}
 
-	h12 := h1.connection(h2.ServerIdentity.ID)
-	h21 := h2.connection(h1.ServerIdentity.ID)
+	h12 := h1.connection(h2.ServerIdentity.GetID())
+	h21 := h2.connection(h1.ServerIdentity.GetID())
 	require.NotNil(t, h12)
 	require.NotNil(t, h21)
 	require.Nil(t, h21.Close())

--- a/network/struct.go
+++ b/network/struct.go
@@ -75,6 +75,7 @@ type ServerIdentity struct {
 	// This is the configuration for the services
 	ServiceIdentities []ServiceIdentity
 	// The ServerIdentityID corresponding to that public key
+	// Deprecated: use GetID
 	ID ServerIdentityID
 	// The address where that Id might be found
 	Address Address
@@ -171,11 +172,20 @@ func NewServerIdentity(public kyber.Point, address Address) *ServerIdentity {
 		Public:  public,
 		Address: address,
 	}
-	if public != nil {
-		url := NamespaceURL + "id/" + public.String()
-		si.ID = ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url))
-	}
+
+	// compat for deprecated si.ID
+	si.ID = si.GetID()
 	return si
+}
+
+// GetID returns the ServerIdentityID corresponding to that public key
+func (si ServerIdentity) GetID() ServerIdentityID {
+	if si.Public == nil {
+		return ServerIdentityID(uuid.Nil)
+	}
+
+	url := NamespaceURL + "id/" + si.Public.String()
+	return ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url))
 }
 
 // Equal tests on same public key

--- a/network/struct_test.go
+++ b/network/struct_test.go
@@ -21,7 +21,7 @@ func TestServerIdentity(t *testing.T) {
 		t.Error("Stg's wrong with ServerIdentity")
 	}
 
-	if si1.ID.Equal(si2.ID) || !si1.ID.Equal(si1.ID) {
+	if si1.GetID().Equal(si2.GetID()) || !si1.GetID().Equal(si1.GetID()) {
 		t.Error("Stg's wrong with ServerIdentityID")
 	}
 

--- a/network/tcp_test.go
+++ b/network/tcp_test.go
@@ -733,7 +733,7 @@ func sendrcvProc(from, to *Router) error {
 
 func waitConnections(r *Router, sid *ServerIdentity) error {
 	for i := 0; i < 10; i++ {
-		c := r.connection(sid.ID)
+		c := r.connection(sid.GetID())
 		if c != nil {
 			return nil
 		}


### PR DESCRIPTION
PR failing on purpose (for now).

`ServerIdentity` is not checked for consistency when unmarshaling. As such, one can create an invalid one, send it accross network and it won't be checked when deserializing it, which can yield security issues (unchecked attacker-controlled input).

To fix that, one would implement `encoding.BinaryUnmarshaler`, which I'm trying to do now, but I need some help coding it, if someone has the time :)
So, I'm adding `func (si *ServerIdentity) UnmarshalBinary(data []byte) error`; as I just want to fix ID after most deserialisation is done, I'm trying first to `Unmarshal` or `protobuf.Decode{,WithConstructors}`, which in turn calls `UnmarshalBinary` as it can now be casted to `encoding.BinaryUnmarshaler` :/
And I don't want to redo protobuf decoding by hand, so, is there a way I'm missing?
A workaround that might work is to have a `ServerIdentityWrapper` which is also registered in onet and is trivialy always correct (removed the ID field), but that still allow people to send broken `ServerIdentity` and is quite an API-breaking change.