### PR TITLE
Add traces to errors

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -156,7 +156,8 @@ func InteractiveConfig(suite network.Suite, binaryName string) {
 		if _, err := os.Stat(configFolder); os.IsNotExist(err) {
 			log.Info("Creating inexistant directory configuration", configFolder)
 			if err = os.MkdirAll(configFolder, 0744); err != nil {
-				log.Fatalf("Could not create directory configuration %s %v", configFolder, err)
+				log.Fatalf("Could not create directory configuration %s %+v",
+					configFolder, err)
 			}
 		}
 

--- a/network/router.go
+++ b/network/router.go
@@ -109,7 +109,7 @@ func (r *Router) Start() {
 		if err != nil {
 			if !strings.Contains(err.Error(), "EOF") {
 				// Avoid printing error message if it's just a stray connection.
-				log.Errorf("receiving server identity from %#v failed: %v",
+				log.Errorf("receiving server identity from %#v failed: %+v",
 					c.Remote().NetworkAddress(), err)
 			}
 			if err := c.Close(); err != nil {
@@ -393,7 +393,8 @@ func (r *Router) registerConnection(remote *ServerIdentity, c Conn) error {
 	}
 	_, okc := r.connections[remote.ID]
 	if okc {
-		log.Lvl5("Connection already registered. Appending new connection to same identity.")
+		log.Lvl5("Connection already registered. " +
+			"Appending new connection to same identity.")
 	}
 	r.connections[remote.ID] = append(r.connections[remote.ID], c)
 	return nil

--- a/overlay.go
+++ b/overlay.go
@@ -113,8 +113,8 @@ func (o *Overlay) Process(env *network.Envelope) {
 		}
 		err = o.TransmitMsg(protoMsg, io)
 		if err != nil {
-			log.Errorf("Msg %s from %s produced error: %s", protoMsg.MsgType,
-				protoMsg.ServerIdentity, err.Error())
+			log.Errorf("Msg %s from %s produced error: %+v", protoMsg.MsgType,
+				protoMsg.ServerIdentity, err)
 		}
 	}
 }
@@ -178,7 +178,8 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 			defer func() {
 				if r := recover(); r != nil {
 					svc := ServiceFactory.Name(tni.Token().ServiceID)
-					log.Errorf("Panic in call to protocol <%s>.Dispatch() from service <%s> at address %s: %v",
+					log.Errorf("Panic in call to protocol <%s>.Dispatch("+
+						") from service <%s> at address %s: %v",
 						tni.ProtocolName(), svc, o.server.ServerIdentity, r)
 					log.Error(log.Stack())
 				}
@@ -187,7 +188,8 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 			err := pi.Dispatch()
 			if err != nil {
 				svc := ServiceFactory.Name(tni.Token().ServiceID)
-				log.Errorf("%v %s.Dispatch() returned error %s", o.server.ServerIdentity, svc, err)
+				log.Errorf("%v %s.Dispatch() returned error %+v",
+					o.server.ServerIdentity, svc, err)
 			}
 		}()
 		if err := o.RegisterProtocolInstance(pi); err != nil {
@@ -662,6 +664,7 @@ func (o *Overlay) CreateProtocol(name string, t *Tree, sid ServiceID) (ProtocolI
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("Panic in %s.Dispatch(): %v", name, r)
+				log.Error(log.Stack())
 			}
 		}()
 
@@ -684,6 +687,7 @@ func (o *Overlay) StartProtocol(name string, t *Tree, sid ServiceID) (ProtocolIn
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("Panic in %s.Start(): %v", name, r)
+				log.Error(log.Stack())
 			}
 		}()
 

--- a/processor.go
+++ b/processor.go
@@ -286,7 +286,8 @@ func (p *ServiceProcessor) RegisterRESTHandler(f interface{}, namespace, method 
 
 		out, tun, err := callInterfaceFunc(f, val0.Interface(), false)
 		if err != nil {
-			http.Error(w, wrapJSONMsg("processing error "+err.Error()), http.StatusBadRequest)
+			http.Error(w, wrapJSONMsg("processing error "+err.Error()),
+				http.StatusBadRequest)
 			return
 		}
 		if tun != nil {
@@ -411,7 +412,8 @@ type StreamingTunnel struct {
 func callInterfaceFunc(handler, input interface{}, streaming bool) (intf interface{}, ch chan bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = xerrors.Errorf("panic with %v", r)
+			log.Errorf("Panicked with '%v' at %s", r, log.Stack())
+			err = xerrors.Errorf("panic: %v", r)
 		}
 	}()
 

--- a/service.go
+++ b/service.go
@@ -351,7 +351,7 @@ func newServiceManager(srv *Server, o *Overlay, dbPath string, delDb bool) *serv
 
 		srvc, err := ServiceFactory.start(name, cont)
 		if err != nil {
-			log.Fatalf("Trying to instantiate service %v: %v", name, err)
+			log.Fatalf("Trying to instantiate service %v: %+v", name, err)
 		}
 		log.Lvl3("Started Service", name)
 		s.servicesMutex.Lock()
@@ -534,8 +534,8 @@ func (s *serviceManager) newProtocol(tni *TreeNodeInstance, config *GenericConfi
 	defer func() {
 		if r := recover(); r != nil {
 			pi = nil
-			err = xerrors.Errorf("could not create new protocol: %v", r)
-			return
+			err = xerrors.Errorf("could not create new protocol: %v at %s",
+				r, log.Stack())
 		}
 	}()
 

--- a/simul/monitor/tcpproxy.go
+++ b/simul/monitor/tcpproxy.go
@@ -174,7 +174,8 @@ func (tp *TCPProxy) serve(in net.Conn) {
 			break
 		}
 		remote.inactivate()
-		log.Warnf("deactivated endpoint [%s] due to %v for %v", remote.addr, err, tp.MonitorInterval)
+		log.Warnf("deactivated endpoint [%s] for %v due to %+v",
+			remote.addr, tp.MonitorInterval, err)
 	}
 
 	if out == nil {
@@ -204,7 +205,8 @@ func (tp *TCPProxy) runMonitor() {
 				}
 				go func(r *remote) {
 					if err := r.tryReactivate(); err != nil {
-						log.Warnf("failed to activate endpoint [%s] due to %v (stay inactive for another %v)", r.addr, err, tp.MonitorInterval)
+						log.Warnf("failed to activate endpoint [%s] due to"+
+							" %+v (stay inactive for another %v)", r.addr, err, tp.MonitorInterval)
 					} else {
 						log.Infof("activated %s", r.addr)
 					}

--- a/simulation.go
+++ b/simulation.go
@@ -254,7 +254,7 @@ func (s *SimulationBFTree) CreateRoster(sc *SimulationConfig, addresses []string
 	sc.TLS = s.TLS
 	suite, err := suites.Find(s.Suite)
 	if err != nil {
-		log.Fatalf("Could not look up suite \"%v\": %v", s.Suite, err.Error())
+		log.Fatalf("Could not look up suite \"%v\": %+v", s.Suite, err)
 	}
 	nbrAddr := len(addresses)
 	if sc.PrivateKeys == nil {

--- a/treenode.go
+++ b/treenode.go
@@ -358,7 +358,8 @@ func (n *TreeNodeInstance) Shutdown() error {
 func (n *TreeNodeInstance) closeDispatch() error {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("Recovered panic:", r)
+			log.Errorf("Recovered panic while closing protocol: %v", r)
+			log.Error(log.Stack())
 		}
 	}()
 	log.Lvl3("Closing node", n.Info())
@@ -449,7 +450,9 @@ func (n *TreeNodeInstance) dispatchChannel(msgSlice []*ProtocolMsg) error {
 		// In rare occasions we write to a closed channel which throws a panic.
 		// Catch it here so we can find out better why this happens.
 		if r := recover(); r != nil {
-			log.Error("Shouldn't happen, please report an issue:", n.Info(), mt, r)
+			log.Errorf("Couldn't dispatch protocol-message %s in %s: %v",
+				mt, n.Info(), r)
+			log.Error(log.Stack())
 		}
 	}()
 	to := reflect.TypeOf(n.channels[mt])

--- a/websocket.go
+++ b/websocket.go
@@ -435,7 +435,8 @@ func (c *Client) closeSingleUseConn(dst *network.ServerIdentity, path string) {
 	dest := destination{dst, path}
 	if !c.keep {
 		if err := c.closeConn(dest); err != nil {
-			log.Errorf("error while closing the connection to %v : %v\n", dest, err)
+			log.Errorf("error while closing the connection to %v : %+v\n",
+				dest, err)
 		}
 	}
 }


### PR DESCRIPTION
Searched all `/log.*%v/` and `defer` in onet and made sure that:
- all log outputs use `%+v` for errors
- all recover also print the stack-trace