### PR TITLE
Force protocol config to be sent

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ go.dedis.ch/kyber/v3 v3.0.4/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhs
 go.dedis.ch/kyber/v3 v3.0.9/go.mod h1:rhNjUUg6ahf8HEg5HUvVBYoWY4boAafX8tYxX+PS+qg=
 go.dedis.ch/kyber/v3 v3.0.11 h1:nmZQCxqcVBC8fUK1x26Z9/IhElMcCdoyRwCk1rYrarI=
 go.dedis.ch/kyber/v3 v3.0.11/go.mod h1:kXy7p3STAurkADD+/aZcsznZGKVHEqbtmdIzvPfrs1U=
+go.dedis.ch/kyber/v3 v3.0.12 h1:15d61EyBcBoFIS97kS2c/Vz4o3FR8ALnZ2ck9J/ebYM=
 go.dedis.ch/kyber/v3 v3.0.12/go.mod h1:kXy7p3STAurkADD+/aZcsznZGKVHEqbtmdIzvPfrs1U=
 go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRLo=
 go.dedis.ch/protobuf v1.0.7 h1:wRUEiq3u0/vBhLjcw9CmAVrol+BnDyq2M0XLukdphyI=

--- a/messages.go
+++ b/messages.go
@@ -2,7 +2,7 @@ package onet
 
 import (
 	"go.dedis.ch/onet/v3/network"
-	"gopkg.in/satori/go.uuid.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // ProtocolMsgID is to be embedded in every message that is made for a
@@ -47,6 +47,8 @@ type ProtocolMsg struct {
 	MsgSlice []byte
 	// The size of the data
 	Size network.Size
+	// Config is the config passed to the protocol constructor.
+	Config *GenericConfig
 }
 
 // ConfigMsg is sent by the overlay containing a generic slice of bytes to
@@ -154,6 +156,8 @@ type OverlayMsg struct {
 	ResponseTree *ResponseTree
 	// Deprecated: use ResponseTree to send the tree and the roster
 	TreeMarshal *TreeMarshal
+
+	Config *GenericConfig
 }
 
 // RequestRoster is used to ask the parent for a given Roster

--- a/overlay.go
+++ b/overlay.go
@@ -163,6 +163,12 @@ func (o *Overlay) TransmitMsg(onetMsg *ProtocolMsg, io MessageProxy) error {
 		tni := o.newTreeNodeInstanceFromToken(tn, onetMsg.To, io)
 		// retrieve the possible generic config for this message
 		config := o.getConfig(onetMsg.To.ID())
+		if config == nil {
+			config = onetMsg.Config
+		}
+
+		tni.config = config
+
 		// request the PI from the Service and binds the two
 		pi, err = o.server.serviceManager.newProtocol(tni, config)
 		if err != nil {
@@ -559,6 +565,9 @@ func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Message,
 	// then send the message
 	var final interface{}
 	info := &OverlayMsg{
+		// For backwards compatibility reason, we keep sending the config message
+		// but we also send it with the actual message to be sure it will be handled.
+		Config: c,
 		TreeNodeInfo: &TreeNodeInfo{
 			From: from,
 			To:   tokenTo,
@@ -814,6 +823,7 @@ func (d *defaultProtoIO) Wrap(msg interface{}, info *OverlayMsg) (interface{}, e
 		protoMsg := &ProtocolMsg{
 			From:     info.TreeNodeInfo.From,
 			To:       info.TreeNodeInfo.To,
+			Config:   info.Config,
 			MsgSlice: buff,
 			MsgType:  typ,
 		}

--- a/treenode.go
+++ b/treenode.go
@@ -50,6 +50,7 @@ type TreeNodeInstance struct {
 	// config is to be passed down in the first message of what the protocol is
 	// sending if it is non nil. Set with `tni.SetConfig()`.
 	config    *GenericConfig
+	sentTo    map[TreeNodeID]bool
 	configMut sync.Mutex
 
 	// used for the CounterIO interface
@@ -100,6 +101,7 @@ func newTreeNodeInstance(o *Overlay, tok *Token, tn *TreeNode, io MessageProxy) 
 		msgDispatchQueue:     make([]*ProtocolMsg, 0, 1),
 		msgDispatchQueueWait: make(chan bool, 1),
 		protoIO:              io,
+		sentTo:               make(map[TreeNodeID]bool),
 	}
 	go n.dispatchMsgReader()
 	return n
@@ -156,8 +158,16 @@ func (n *TreeNodeInstance) SendTo(to *TreeNode, msg interface{}) error {
 		return xerrors.New("is closing")
 	}
 	n.msgDispatchQueueMutex.Unlock()
+	var c *GenericConfig
+	// only sends the config once
+	n.configMut.Lock()
+	if !n.sentTo[to.ID] {
+		c = n.config
+		n.sentTo[to.ID] = true
+	}
+	n.configMut.Unlock()
 
-	sentLen, err := n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, n.config)
+	sentLen, err := n.overlay.SendToTreeNode(n.token, to, msg, n.protoIO, c)
 	n.tx.add(sentLen)
 	if err != nil {
 		return xerrors.Errorf("sending: %v", err)


### PR DESCRIPTION
It fixes the issue where a protocol requiring a configuration could receive a message from a participant (and not the leader) as the first message thus trying to create the protocol with the missing configuration.

Fixes #621 