### PR TITLE
websocket: getWSHostPort uses URL if available

### DIFF
--- a/websocket_test.go
+++ b/websocket_test.go
@@ -246,15 +246,51 @@ func TestCertificateReloader(t *testing.T) {
 
 func TestGetWebHost(t *testing.T) {
 	url, err := getWSHostPort(&network.ServerIdentity{Address: "tcp://8.8.8.8"}, true)
-	require.NotNil(t, err)
+	require.Error(t, err)
+
 	url, err = getWSHostPort(&network.ServerIdentity{Address: "tcp://8.8.8.8"}, false)
-	require.NotNil(t, err)
+	require.Error(t, err)
+
 	url, err = getWSHostPort(&network.ServerIdentity{Address: "tcp://8.8.8.8:7770"}, true)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "0.0.0.0:7771", url)
+
 	url, err = getWSHostPort(&network.ServerIdentity{Address: "tcp://8.8.8.8:7770"}, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "8.8.8.8:7771", url)
+
+	url, err = getWSHostPort(&network.ServerIdentity{
+		Address: "tcp://irrelevant:7770",
+		URL:     "wrong url",
+	}, false)
+	require.Error(t, err)
+
+	url, err = getWSHostPort(&network.ServerIdentity{
+		Address: "tcp://irrelevant:7770",
+		URL:     "http://8.8.8.8:8888",
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8:8888", url)
+
+	url, err = getWSHostPort(&network.ServerIdentity{
+		Address: "tcp://irrelevant:7770",
+		URL:     "http://8.8.8.8",
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8:80", url)
+
+	url, err = getWSHostPort(&network.ServerIdentity{
+		Address: "tcp://irrelevant:7770",
+		URL:     "https://8.8.8.8",
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8:443", url)
+
+	url, err = getWSHostPort(&network.ServerIdentity{
+		Address: "tcp://irrelevant:7770",
+		URL:     "invalid://8.8.8.8:8888",
+	}, false)
+	require.Error(t, err)
 }
 
 func TestClient_Send(t *testing.T) {


### PR DESCRIPTION
Weirdly enough, when specifying an `URL` in a conode's config, it doesn't bind the WebSocket tunnel to it, but to the `Address` with its port incremented. This PR fixes that by actually taking `URL` into consideration if `!= ""`.

It will probably **break the servers using `URL` with unspecified port**, such as https://wookiee.ch/conode & https://conode.dedis.ch