### PR TITLE
Fix logging with DEBUG_LVL=0

### DIFF
--- a/log/loggers.go
+++ b/log/loggers.go
@@ -130,6 +130,10 @@ type stdLogger struct {
 }
 
 func (sl *stdLogger) Log(lvl int, msg string) {
+	// If the DEBUG_LVL is 0 or -1, don't print any colors or line-info,
+	// but just print plain text.
+	// 0 is the default level
+	// -1 is FormatPython to print
 	if sl.lInfo.DebugLvl <= 0 {
 		sl.print(lvl, msg)
 		return

--- a/log/loggers_test.go
+++ b/log/loggers_test.go
@@ -3,7 +3,10 @@ package log
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
@@ -89,4 +92,16 @@ func TestFileLogger(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "1 : fake_name.go:0 (log.TestFileLogger) - testing1\n"+
 		"2 : fake_name.go:0 (log.TestFileLogger) - testing2\n", string(out))
+}
+
+func TestStdLoggerZero(t *testing.T) {
+	GetStdOut()
+	SetDebugVisible(0)
+	Info("One Line Only")
+	str := GetStdOut()
+	assert.Equal(t, 2, len(strings.Split(str, "\n")), str)
+	SetDebugVisible(1)
+	Info("One Line Only")
+	str = GetStdOut()
+	assert.Equal(t, 2, len(strings.Split(str, "\n")), str)
 }

--- a/log/lvl.go
+++ b/log/lvl.go
@@ -80,7 +80,7 @@ func lvl(lvl, skip int, args ...interface{}) {
 	debugMut.Lock()
 	defer debugMut.Unlock()
 	for _, l := range loggers {
-		// Get the *LoggerInfo that contains how should the formatting go.
+		// Get the *LoggerInfo that contains how the formatting should be done.
 		lInfo := l.GetLoggerInfo()
 
 		if lvl > lInfo.DebugLvl {
@@ -278,6 +278,7 @@ func SetDebugVisible(lvl int) {
 	debugMut.Lock()
 	defer debugMut.Unlock()
 	loggers[0].GetLoggerInfo().DebugLvl = lvl
+	loggers[0].GetLoggerInfo().RawMessage = lvl <= 0
 }
 
 // DebugVisible returns the actual visible debug-level

--- a/log/ui.go
+++ b/log/ui.go
@@ -3,13 +3,9 @@ package log
 import (
 	"fmt"
 	"os"
-	"strconv"
 )
 
 func lvlUI(l int, args ...interface{}) {
-	if DebugVisible() <= 0 {
-		print(l, args...)
-	}
 	if isVisible(l) {
 		lvl(l, 3, args...)
 	}
@@ -115,30 +111,4 @@ func TraceID(id []byte) {
 			t.TraceID(id)
 		}
 	}
-}
-
-func print(lvl int, args ...interface{}) {
-	debugMut.Lock()
-	defer debugMut.Unlock()
-	out := stdOut
-	if lvl < lvlInfo {
-		out = stdErr
-	}
-	switch loggers[0].GetLoggerInfo().DebugLvl {
-	case FormatPython:
-		prefix := []string{"[-]", "[!]", "[X]", "[Q]", "[+]", ""}
-		ind := lvl - lvlWarning
-		if ind < 0 || ind > 4 {
-			panic("index out of range " + strconv.Itoa(ind))
-		}
-		fmt.Fprint(out, prefix[ind], " ")
-	case FormatNone:
-	}
-	for i, a := range args {
-		fmt.Fprint(out, a)
-		if i != len(args)-1 {
-			fmt.Fprint(out, " ")
-		}
-	}
-	fmt.Fprint(out, "\n")
 }


### PR DESCRIPTION
After the tracing addition, DEBUG_LVL=0 produced two outputs per
log-call.

This PR fixes it and adds a test to avoid regression.