### PR TITLE
Better tracing defaults

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -86,3 +86,13 @@ Some of the traces will not be found.
 If you set `TRACING_CREATE_SINGLE_SPANS=true`, these unknown traces will be
  created as traces with a single span.
 This is not pretty, but might turn out useful sometimes.
+
+## Debugging
+
+As loggers cannot use onet/log, you can set the following environment
+ variable to output some debugging information about what's happening:
+ 
+```
+export TRACING_DEBUG=true 
+```
+

--- a/tracing/logger.go
+++ b/tracing/logger.go
@@ -32,7 +32,7 @@ type TraceLogger struct {
 	// Print spans that are not in entryPoints so that the slice can be updated.
 	PrintSingleSpans int
 	// As the TraceLogger cannot use onet/log, turn on/off debug messages here.
-	TraceDebug bool
+	Debug bool
 	// currently active traces - the keys are the traceID or the go-routine
 	// id of the current call
 	traces map[string]*traceWrapper
@@ -171,6 +171,8 @@ func (logger *TraceLogger) AddStats(c *onet.Context, repeat time.Duration) {
 //   - TRACING_CREATE_SINGLE_SPANS - whenever there is no entry point found,
 //  the system can create single spans that are not linked together.
 //   This is a fallback to regular logging when we cannot simulate traces.
+//   - TRACING_DEBUG - if true, fmt.Println is used for some additional
+//  debugging messages, as onet/log cannot be used within the logger
 //   - TRACING_ENTRY_POINTS - a "::" separated list of entry points that can
 //  be used to refine the tracing.
 //  The name of the entry points are the same as given by
@@ -201,7 +203,7 @@ func (logger *TraceLogger) AddEnvironment() error {
 			return fmt.Errorf("while reading TRACING_CREATE_SINGLE_SPANS: can" +
 				" be only \"true\" or \"false\"")
 		}
-		logger.TraceDebug = tdb == "true"
+		logger.Debug = tdb == "true"
 	}
 	logger.AddEntryPoints(strings.Split(os.Getenv("TRACING_ENTRY_POINTS"), "::")...)
 	logger.AddDoneMsgs(strings.Split(os.Getenv("TRACING_DONE_MSGS"), "::")...)
@@ -233,7 +235,7 @@ func (logger *TraceLogger) getTraceSpan(lvl int, msg string, callLvl int) (*trac
 		if ok {
 			for _, done := range logger.doneMsgs {
 				if strings.Contains(msg, done) {
-					if logger.TraceDebug {
+					if logger.Debug {
 						fmt.Println("-- found done for", se.uniqueID())
 					}
 					delete(logger.traces, se.traceID)
@@ -241,7 +243,7 @@ func (logger *TraceLogger) getTraceSpan(lvl int, msg string, callLvl int) (*trac
 					return nil, nil
 				}
 			}
-			if logger.TraceDebug {
+			if logger.Debug {
 				fmt.Println("-- adding log to", se.uniqueID(), msg)
 			}
 			sw := tr.stackToSpan(ses[i:])
@@ -251,7 +253,7 @@ func (logger *TraceLogger) getTraceSpan(lvl int, msg string, callLvl int) (*trac
 
 		// Check if there is a new trace to be generated
 		if se.checkEntryPoint(logger.entryPoints) != "" {
-			if logger.TraceDebug {
+			if logger.Debug {
 				fmt.Println("-- new trace", se.uniqueID())
 				for _, s := range ses[i:] {
 					fmt.Println("-- ", s.uniqueID())

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -297,13 +297,12 @@ func mergeLogs(known map[string]*traceWrapper,
 			}
 		}
 		// No common traceID found - check goroutine calls
-		for id, tw := range known {
+		for _, tw := range known {
 			if strings.HasPrefix(tw.root.se.traceID, "id_") ||
 				strings.HasPrefix(seIn.traceID, "id_") {
 				continue
 			}
 			if out = tw.findGoroutine(in[idIn:]); out != nil {
-				fmt.Println("merged go-routines", id, in)
 				return
 			}
 		}

--- a/tracing/trace_test.go
+++ b/tracing/trace_test.go
@@ -278,7 +278,7 @@ func TestTraceID(t *testing.T) {
 	defer log.UnregisterLogger(tr.loggerID)
 	if testing.Verbose() {
 		tr.PrintSingleSpans = 10
-		tr.TraceDebug = true
+		tr.Debug = true
 	}
 	tr.AddEntryPoints("go.dedis.ch/onet/v3/tracing.setTraceID")
 	tr.AddDoneMsgs("done trace")


### PR DESCRIPTION
By default, don't print the single spans. Also removes a remaining
debug-print. Adds TRACING_DEBUG environmental variable.

OR-review: first one to agree, please merge.