### PR TITLE
Roster: Restore `GetID` to same hash as `ID`

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"sort"
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -468,8 +467,6 @@ func (ro *Roster) GetID() (RosterID, error) {
 			return RosterID{}, xerrors.Errorf("marshaling: %v", err)
 		}
 
-		// order is important for the hash
-		sort.Sort(network.ServiceIdentities(id.ServiceIdentities))
 		for _, srvid := range id.ServiceIdentities {
 			_, err = srvid.Public.MarshalTo(h)
 			if err != nil {

--- a/tree_test.go
+++ b/tree_test.go
@@ -457,18 +457,19 @@ func TestRoster_GetID(t *testing.T) {
 
 	roID, err := ro.GetID()
 	require.NoError(t, err)
+	require.Equal(t, ro.ID, roID)
 	ro2ID, err := ro2.GetID()
 	require.NoError(t, err)
 	require.True(t, roID.Equal(ro2ID))
 	ok, _ := ro.Equal(ro2)
 	require.True(t, ok)
 
-	// check unordered service identities
+	// check unordered service identities, which should not give the same ID
 	ro.List[0].ServiceIdentities[0], ro.List[0].ServiceIdentities[1] = ro.List[0].ServiceIdentities[1], ro.List[0].ServiceIdentities[0]
 	ro3 := NewRoster(ro.List)
 	ro3ID, err := ro3.GetID()
 	require.NoError(t, err)
-	require.True(t, roID.Equal(ro3ID))
+	require.False(t, roID.Equal(ro3ID))
 	ok, _ = ro.Equal(ro3)
 	require.True(t, ok)
 


### PR DESCRIPTION
Even though `Roster.ID` is deprecated, it is still used a lot. The `Roster.GetID` method produces hashes that are different from `ID`, so that comparisons between `ID` and `GetID` fail.

As `GetID` is currently only used for `Roster.Equal`, while `ID` is used in many other methods, this PR makes `GetID` behave the same as `ID`.