### PR TITLE
Got it to failing, but...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.15.x"
+  - "1.14.x"
 
 go_import_path: go.dedis.ch/onet/v3
 

--- a/network/router.go
+++ b/network/router.go
@@ -592,7 +592,8 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 	// Receive the other ServerIdentity
 	nm, err := c.Receive()
 	if err != nil {
-		return nil, xerrors.Errorf("Error while receiving ServerIdentity during negotiation %s", err)
+		return nil, xerrors.Errorf(
+			"Error while receiving ServerIdentity during negotiation: %s", err)
 	}
 	// Check if it is correct
 	if nm.MsgType != ServerIdentityType {

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -278,7 +278,7 @@ func handleError(err error) error {
 
 	netErr, ok := err.(net.Error)
 	if !ok {
-		return xerrors.Errorf("non-network error: %v", err)
+		return ErrUnknown
 	}
 	if netErr.Timeout() {
 		return ErrTimeout

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -116,7 +116,7 @@ func NewTCPConn(addr Address, suite Suite) (conn *TCPConn, err error) {
 func (c *TCPConn) Receive() (env *Envelope, e error) {
 	buff, err := c.receiveRaw()
 	if err != nil {
-		return nil, xerrors.Errorf("receiving: %w", err)
+		return nil, xerrors.Errorf("receiving: %v", err)
 	}
 
 	id, body, err := Unmarshal(buff, c.suite)
@@ -278,7 +278,7 @@ func handleError(err error) error {
 
 	netErr, ok := err.(net.Error)
 	if !ok {
-		return ErrUnknown
+		return xerrors.Errorf("non-network error: %v", err)
 	}
 	if netErr.Timeout() {
 		return ErrTimeout

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -116,7 +116,7 @@ func NewTCPConn(addr Address, suite Suite) (conn *TCPConn, err error) {
 func (c *TCPConn) Receive() (env *Envelope, e error) {
 	buff, err := c.receiveRaw()
 	if err != nil {
-		return nil, xerrors.Errorf("receiving: %v", err)
+		return nil, xerrors.Errorf("receiving: %w", err)
 	}
 
 	id, body, err := Unmarshal(buff, c.suite)

--- a/network/tls.go
+++ b/network/tls.go
@@ -308,8 +308,7 @@ type verifier func(rawCerts [][]byte, vrf [][]*x509.Certificate) (err error)
 // gives us a certificate back, crypto/tls calls the verifier with arguments we
 // can't control. But the verifier still has access to the nonce because it's in the
 // closure.
-func makeVerifier(suite Suite, them *ServerIdentity) (verifier,
-	[]byte) {
+func makeVerifier(suite Suite, them *ServerIdentity) (verifier, []byte) {
 	nonce := mkNonce(suite)
 	return func(rawCerts [][]byte, vrf [][]*x509.Certificate) (err error) {
 		var cn string
@@ -450,8 +449,7 @@ func pubToCN(pub kyber.Point) string {
 
 // tlsConfig returns a generic config that has things set as both the server
 // and client need them. The returned config is customized after tlsConfig returns.
-func tlsConfig(suite Suite, us *ServerIdentity) (*tls.Config,
-	error) {
+func tlsConfig(suite Suite, us *ServerIdentity) (*tls.Config, error) {
 	cm, err := newCertMaker(suite, us)
 	if err != nil {
 		return nil, xerrors.Errorf("certificate: %v", err)

--- a/network/tls.go
+++ b/network/tls.go
@@ -164,7 +164,6 @@ func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
 	}
 
 	tmpl := &x509.Certificate{
-		MaxPathLen:            1,
 		BasicConstraintsValid: true,
 		IsCA:                  false,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},

--- a/network/tls.go
+++ b/network/tls.go
@@ -188,6 +188,7 @@ func (cm *certMaker) get(nonce []byte) (*tls.Certificate, error) {
 	// test code to get ahold of and modify.
 	if cm.noURIs {
 		tmpl.URIs = nil
+		tmpl.MaxPathLen = 1
 	}
 
 	cDer, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, cm.k.Public(), cm.k)

--- a/network/tls_test.go
+++ b/network/tls_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"log"
 	"strconv"
 	"testing"
 	"time"
@@ -34,31 +35,35 @@ type hello struct {
 }
 
 func TestTLS(t *testing.T) {
-	testTLS(t, tSuite, false)
+	testTLS(t, tSuite, false, false)
 }
 
 func TestTLS_bn256(t *testing.T) {
 	s := suites.MustFind("bn256.g2")
-	testTLS(t, s, false)
+	testTLS(t, s, false, false)
 }
 
 func TestTLS_noURIs(t *testing.T) {
-	testTLS(t, tSuite, true)
+	testTLS(t, tSuite, true, false)
+	testTLS(t, tSuite, true, true)
+	testTLS(t, tSuite, false, true)
 }
 
-func testTLS(t *testing.T, s suites.Suite, noURIs bool) {
+func testTLS(t *testing.T, s suites.Suite, noURIs1, noURIs2 bool) {
+	log.Print(noURIs1, noURIs2)
 	// Clean up changes we might make in this test.
 	defer func() {
 		testNoURIs = false
 	}()
 
 	// R1 has URI-based handshakes unconditionally.
+	testNoURIs = noURIs1
 	r1, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router")
 
 	// R2 might have no URIs, in order to simulate old handshake to new handshake
 	// compatibility.
-	testNoURIs = noURIs
+	testNoURIs = noURIs2
 	r2, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router 2")
 

--- a/network/tls_test.go
+++ b/network/tls_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"log"
 	"strconv"
 	"testing"
 	"time"
@@ -44,25 +43,22 @@ func TestTLS_bn256(t *testing.T) {
 }
 
 func TestTLS_noURIs(t *testing.T) {
+	testTLS(t, tSuite, false, false)
 	testTLS(t, tSuite, true, false)
 	testTLS(t, tSuite, true, true)
 	testTLS(t, tSuite, false, true)
 }
 
 func testTLS(t *testing.T, s suites.Suite, noURIs1, noURIs2 bool) {
-	log.Print(noURIs1, noURIs2)
 	// Clean up changes we might make in this test.
 	defer func() {
 		testNoURIs = false
 	}()
 
-	// R1 has URI-based handshakes unconditionally.
 	testNoURIs = noURIs1
 	r1, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router")
 
-	// R2 might have no URIs, in order to simulate old handshake to new handshake
-	// compatibility.
 	testNoURIs = noURIs2
 	r2, err := NewTestRouterTLS(s, 0)
 	require.Nil(t, err, "new tcp router 2")


### PR DESCRIPTION
The update to the new TLS handshake is faulty. The test in #655 only tests old->old and new->new, but not new->old and old->new (which fails).

This PR tests all combinations, but fails. Currently I don't know why :(

The relevant test is here: https://github.com/dedis/onet/pull/656/files#diff-f183c5e9370db10aaa3413143732a5abR46