### PR TITLE
Replace satori/go.uuid with google/uuid

### DIFF
--- a/context.go
+++ b/context.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"sync"
 
-	uuid "github.com/satori/go.uuid"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	bbolt "go.etcd.io/bbolt"
@@ -331,7 +330,7 @@ func (c *Context) GetValidPeers(peerID network.PeerSetID) []network.
 func (c *Context) NewPeerSetID(data []byte) network.PeerSetID {
 	// Compute the PeerSetID as hash(serviceID | data)
 	h := sha256.New()
-	h.Write(uuid.UUID(c.ServiceID()).Bytes())
+	h.Write(c.serviceID[:])
 	h.Write(data)
 
 	return network.NewPeerSetID(h.Sum(nil))

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
 	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
-	github.com/google/uuid v1.1.1
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/websocket v1.4.0
 	github.com/honeycombio/beeline-go v0.4.11
 	github.com/honeycombio/libhoney-go v1.12.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,13 @@ require (
 	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
 	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/honeycombio/beeline-go v0.4.11
 	github.com/honeycombio/libhoney-go v1.12.3 // indirect
 	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/montanaflynn/stats v0.5.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil v2.20.2+incompatible
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 h1:f5gsjBiF9tRRVomC
 github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995/go.mod h1:lJgMEyOkYFkPcDKwRXegd+iM6E7matEszMG5HhwytU8=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZPbFy2P7jH5LKJ3La+0ZeknkkmrSgqb0=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/honeycombio/beeline-go v0.4.11 h1:/VngeZrEuZyv4uRPCAAoOcz2Z2ZM4EQzSR1Wz2wpD20=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shirou/gopsutil v2.20.2+incompatible h1:ucK79BhBpgqQxPASyS2cu9HX8cfDVljBN1WWFvbNvgY=
 github.com/shirou/gopsutil v2.20.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/messages.go
+++ b/messages.go
@@ -1,7 +1,7 @@
 package onet
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/onet/v3/network"
 )
 
@@ -68,7 +68,7 @@ func (rId RoundID) String() string {
 
 // Equal returns true if and only if rID2 equals this RoundID.
 func (rId RoundID) Equal(rID2 RoundID) bool {
-	return uuid.Equal(uuid.UUID(rId), uuid.UUID(rID2))
+	return rId == rID2
 }
 
 // IsNil returns true iff the RoundID is Nil
@@ -87,7 +87,7 @@ func (t TokenID) String() string {
 
 // Equal returns true if and only if t2 equals this TokenID.
 func (t TokenID) Equal(t2 TokenID) bool {
-	return uuid.Equal(uuid.UUID(t), uuid.UUID(t2))
+	return t == t2
 }
 
 // IsNil returns true iff the TokenID is Nil
@@ -119,7 +119,7 @@ func (t *Token) ID() TokenID {
 	url := network.NamespaceURL + "token/" + t.RosterID.String() +
 		t.RoundID.String() + t.ServiceID.String() + t.ProtoID.String() + t.TreeID.String() +
 		t.TreeNodeID.String()
-	return TokenID(uuid.NewV5(uuid.NamespaceURL, url))
+	return TokenID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(url)))
 }
 
 // Clone returns a new token out of this one

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -11,7 +11,7 @@ import (
 	"go.dedis.ch/kyber/v3/suites"
 	"golang.org/x/xerrors"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
@@ -54,14 +54,14 @@ var ErrorType = MessageTypeID(uuid.Nil)
 func (mId MessageTypeID) String() string {
 	t, ok := registry.get(mId)
 	if ok {
-		return fmt.Sprintf("PTID(%s:%x)", t.String(), uuid.UUID(mId).Bytes())
+		return fmt.Sprintf("PTID(%s:%x)", t.String(), mId[:])
 	}
 	return uuid.UUID(mId).String()
 }
 
 // Equal returns true if and only if mID2 equals this MessageTypeID
 func (mId MessageTypeID) Equal(mID2 MessageTypeID) bool {
-	return uuid.Equal(uuid.UUID(mId), uuid.UUID(mID2))
+	return mId == mID2
 }
 
 // IsNil returns true iff the MessageTypeID is Nil
@@ -111,7 +111,7 @@ func computeMessageType(msg Message) MessageTypeID {
 		val = val.Elem()
 	}
 	url := NamespaceBodyType + val.Type().String()
-	u := uuid.NewV5(uuid.NamespaceURL, url)
+	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte(url))
 	return MessageTypeID(u)
 }
 

--- a/network/encoding_test.go
+++ b/network/encoding_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"crypto/rand"
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"testing"

--- a/network/struct.go
+++ b/network/struct.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/suites"
 	"go.dedis.ch/kyber/v3/util/encoding"
@@ -143,7 +143,7 @@ func (eId ServerIdentityID) String() string {
 
 // Equal returns true if both ServerIdentityID are equal or false otherwise.
 func (eId ServerIdentityID) Equal(other ServerIdentityID) bool {
-	return uuid.Equal(uuid.UUID(eId), uuid.UUID(other))
+	return eId == other
 }
 
 // IsNil returns true iff the ServerIdentityID is Nil
@@ -185,7 +185,7 @@ func (si ServerIdentity) GetID() ServerIdentityID {
 	}
 
 	url := NamespaceURL + "id/" + si.Public.String()
-	return ServerIdentityID(uuid.NewV5(uuid.NamespaceURL, url))
+	return ServerIdentityID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(url)))
 }
 
 // Equal tests on same public key

--- a/node_test.go
+++ b/node_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"

--- a/overlay.go
+++ b/overlay.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"golang.org/x/xerrors"
@@ -732,7 +732,7 @@ func (o *Overlay) NewTreeNodeInstanceFromProtocol(t *Tree, tn *TreeNode, protoID
 		TreeID:     t.ID,
 		RosterID:   t.Roster.ID,
 		ProtoID:    protoID,
-		RoundID:    RoundID(uuid.NewV4()),
+		RoundID:    RoundID(uuid.Must(uuid.NewRandom())),
 	}
 	tni := o.newTreeNodeInstanceFromToken(tn, tok, io)
 	o.RegisterTree(t)
@@ -748,7 +748,7 @@ func (o *Overlay) NewTreeNodeInstanceFromService(t *Tree, tn *TreeNode, protoID 
 		RosterID:   t.Roster.ID,
 		ProtoID:    protoID,
 		ServiceID:  servID,
-		RoundID:    RoundID(uuid.NewV4()),
+		RoundID:    RoundID(uuid.Must(uuid.NewRandom())),
 	}
 	tni := o.newTreeNodeInstanceFromToken(tn, tok, io)
 	o.RegisterTree(t)

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
@@ -468,17 +468,17 @@ func TestOverlayHandlersBadParameters(t *testing.T) {
 
 func TestTokenId(t *testing.T) {
 	t1 := &Token{
-		RosterID: RosterID(uuid.NewV1()),
-		TreeID:   TreeID(uuid.NewV1()),
-		ProtoID:  ProtocolID(uuid.NewV1()),
-		RoundID:  RoundID(uuid.NewV1()),
+		RosterID: RosterID(uuid.Must(uuid.NewUUID())),
+		TreeID:   TreeID(uuid.Must(uuid.NewUUID())),
+		ProtoID:  ProtocolID(uuid.Must(uuid.NewUUID())),
+		RoundID:  RoundID(uuid.Must(uuid.NewUUID())),
 	}
 	id1 := t1.ID()
 	t2 := &Token{
-		RosterID: RosterID(uuid.NewV1()),
-		TreeID:   TreeID(uuid.NewV1()),
-		ProtoID:  ProtocolID(uuid.NewV1()),
-		RoundID:  RoundID(uuid.NewV1()),
+		RosterID: RosterID(uuid.Must(uuid.NewUUID())),
+		TreeID:   TreeID(uuid.Must(uuid.NewUUID())),
+		ProtoID:  ProtocolID(uuid.Must(uuid.NewUUID())),
+		RoundID:  RoundID(uuid.Must(uuid.NewUUID())),
 	}
 	id2 := t2.ID()
 	if id1.Equal(id2) {
@@ -487,7 +487,7 @@ func TestTokenId(t *testing.T) {
 	if !id1.Equal(t1.ID()) {
 		t.Fatal("Twice the Id of the same token should be equal")
 	}
-	t3 := t1.ChangeTreeNodeID(TreeNodeID(uuid.NewV1()))
+	t3 := t1.ChangeTreeNodeID(TreeNodeID(uuid.Must(uuid.NewUUID())))
 	if t1.TreeNodeID.Equal(t3.TreeNodeID) {
 		t.Fatal("OtherToken should modify copy")
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -3,7 +3,7 @@ package onet
 import (
 	"sync"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"golang.org/x/xerrors"
@@ -19,7 +19,7 @@ func (pid ProtocolID) String() string {
 
 // Equal returns true if and only if pid2 equals this ProtocolID.
 func (pid ProtocolID) Equal(pid2 ProtocolID) bool {
-	return uuid.Equal(uuid.UUID(pid), uuid.UUID(pid2))
+	return pid == pid2
 }
 
 // IsNil returns true iff the ProtocolID is Nil
@@ -115,7 +115,7 @@ func (ps *protocolStorage) Register(name string, protocol NewProtocol) (Protocol
 // ProtocolNameToID returns the ProtocolID corresponding to the given name.
 func ProtocolNameToID(name string) ProtocolID {
 	url := network.NamespaceURL + "protocolname/" + name
-	return ProtocolID(uuid.NewV3(uuid.NamespaceURL, url))
+	return ProtocolID(uuid.NewMD5(uuid.NameSpaceURL, []byte(url)))
 }
 
 // GlobalProtocolRegister registers a protocol in the global namespace.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"

--- a/server_test.go
+++ b/server_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"

--- a/service.go
+++ b/service.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"sync"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/kyber/v3/suites"
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/log"
@@ -84,12 +84,12 @@ func (s ServiceID) String() string {
 
 // Equal returns true if and only if s2 equals this ServiceID.
 func (s ServiceID) Equal(s2 ServiceID) bool {
-	return uuid.Equal(uuid.UUID(s), uuid.UUID(s2))
+	return s == s2
 }
 
 // IsNil returns true iff the ServiceID is Nil
 func (s ServiceID) IsNil() bool {
-	return s.Equal(ServiceID(uuid.Nil))
+	return uuid.UUID(s) == uuid.Nil
 }
 
 // NilServiceID is the empty ServiceID
@@ -128,7 +128,7 @@ func (s *serviceFactory) Register(name string, suite suites.Suite, fn NewService
 	if !s.ServiceID(name).Equal(NilServiceID) {
 		return NilServiceID, xerrors.Errorf("service %s already registered", name)
 	}
-	id := ServiceID(uuid.NewV5(uuid.NamespaceURL, name))
+	id := ServiceID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(name)))
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.constructors = append(s.constructors, serviceEntry{

--- a/tree.go
+++ b/tree.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
@@ -47,7 +47,7 @@ type TreeID uuid.UUID
 
 // Equal returns true if and only if tID2 equals this TreeID.
 func (tId TreeID) Equal(tID2 TreeID) bool {
-	return uuid.Equal(uuid.UUID(tId), uuid.UUID(tID2))
+	return tId == tID2
 }
 
 // Equals will be removed!
@@ -90,7 +90,7 @@ func NewTree(roster *Roster, root *TreeNode) *Tree {
 	t := &Tree{
 		Roster: roster,
 		Root:   root,
-		ID:     TreeID(uuid.NewV5(uuid.NamespaceURL, url)),
+		ID:     TreeID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(url))),
 	}
 	t.computeSubtreeAggregate(root)
 	return t
@@ -401,7 +401,7 @@ func (roID RosterID) String() string {
 
 // Equal returns true if and only if roID2 equals this RosterID.
 func (roID RosterID) Equal(roID2 RosterID) bool {
-	return uuid.Equal(uuid.UUID(roID), uuid.UUID(roID2))
+	return roID == roID2
 }
 
 // IsNil returns true iff the RosterID is Nil
@@ -436,7 +436,7 @@ func NewRoster(ids []*network.ServerIdentity) *Roster {
 	}
 
 	r := &Roster{
-		ID: RosterID(uuid.NewV5(uuid.NamespaceURL, hex.EncodeToString(h.Sum(nil)))),
+		ID: RosterID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(hex.EncodeToString(h.Sum(nil))))),
 	}
 
 	// Take a copy of ids, in case the caller tries to change it later.
@@ -475,7 +475,7 @@ func (ro *Roster) GetID() (RosterID, error) {
 		}
 	}
 
-	return RosterID(uuid.NewV5(uuid.NamespaceURL, hex.EncodeToString(h.Sum(nil)))), nil
+	return RosterID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(hex.EncodeToString(h.Sum(nil))))), nil
 }
 
 // Search searches the Roster for the given ServerIdentityID and returns the
@@ -875,7 +875,7 @@ func (tId TreeNodeID) String() string {
 
 // Equal returns true if and only if the given TreeNodeID equals tId.
 func (tId TreeNodeID) Equal(tID2 TreeNodeID) bool {
-	return uuid.Equal(uuid.UUID(tId), uuid.UUID(tID2))
+	return tId == tID2
 }
 
 // IsNil returns true iff the TreeNodID is Nil
@@ -897,7 +897,7 @@ func NewTreeNode(entityIdx int, ni *network.ServerIdentity) *TreeNode {
 		RosterIndex:    entityIdx,
 		Parent:         nil,
 		Children:       make([]*TreeNode, 0),
-		ID:             TreeNodeID(uuid.NewV5(uuid.NamespaceURL, ni.Public.String())),
+		ID:             TreeNodeID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(ni.Public.String()))),
 	}
 	return tn
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
@@ -151,7 +150,8 @@ func TestNewWebSocket(t *testing.T) {
 	require.NotEmpty(t, c.WebSocket.services[serviceWebSocket])
 	cl := NewClientKeep(tSuite, "WebSocket")
 	req := &SimpleResponse{}
-	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
+	msgTypeID := network.MessageType(req)
+	log.Lvlf1("Sending message Request: %x", msgTypeID[:])
 	buf, err := protobuf.Encode(req)
 	require.Nil(t, err)
 	rcv, err := cl.Send(c.ServerIdentity, "SimpleResponse", buf)
@@ -183,7 +183,8 @@ func TestNewWebSocketTLS(t *testing.T) {
 	defer cl.Close()
 	cl.TLSClientConfig = &tls.Config{RootCAs: CAPool}
 	req := &SimpleResponse{}
-	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
+	msgTypeID := network.MessageType(req)
+	log.Lvlf1("Sending message Request: %x", msgTypeID[:])
 	buf, err := protobuf.Encode(req)
 	require.Nil(t, err)
 	rcv, err := cl.Send(c.ServerIdentity, "SimpleResponse", buf)
@@ -198,7 +199,7 @@ func TestNewWebSocketTLS(t *testing.T) {
 	u := &url.URL{Scheme: "https", Host: hp}
 	c.ServerIdentity.URL = u.String()
 
-	log.Lvlf1("Sending message Request: %x", uuid.UUID(network.MessageType(req)).Bytes())
+	log.Lvlf1("Sending message Request: %x", msgTypeID[:])
 	rcv, err = cl.Send(c.ServerIdentity, "SimpleResponse", buf)
 	log.Lvlf1("Received reply: %x", rcv)
 	require.Nil(t, protobuf.Decode(rcv, rcvMsg))


### PR DESCRIPTION
Replaces the uuid dependency to google/uuid which is actively maintained and uses go.mod

Closes #660 