### PR TITLE
Support Ubuntu 20.04 on platform mininet

### DIFF
--- a/simul/platform/MININET.md
+++ b/simul/platform/MININET.md
@@ -39,12 +39,7 @@ other people in the same lab!
 As of Dec 2020, Ubuntu 14.04 still appears to work, but it is no longer supported by
 Ubuntu and should not be used for new work.
 4. `Customization` - chose a password (it can be very simple) for the setup.
-5. Optional: For easiest results, tick `Own %url-post-install-script%` and add
-the following line to `My Servers` -> `Environment` -> `%url-post-install-script%`:
-`https://raw.githubusercontent.com/dedis/onet/master/simul/platform/mininet/install_mininet.sh`
-This will directly install mininet on the servers, else the simulation will have
-to do so for you.
-6. `Run Setup` and confirm the setup. THIS WILL DELETE ALL DATA ON THE SERVERS!
+5. `Run Setup` and confirm the setup. THIS WILL DELETE ALL DATA ON THE SERVERS!
 
 ### Verifying everything is correctly set up
 

--- a/simul/platform/MININET.md
+++ b/simul/platform/MININET.md
@@ -21,10 +21,6 @@ Each T3-server on the iccluster is a 24-core server with 256GB of RAM and can
 run around 300 cothority nodes simultaneously. So if you want to run a
 simulation with 2000 nodes, you need at least 7 physical servers.
 
-Unfortunately we still have the restriction that _all physical servers need to be on the
-same subnet_! We know about the situation and hope to have a solution ready
-sometime in the near future.
-
 ## Setting up ICCluster
 
 Supposing you want to run your simulation using the iccluster-network, you
@@ -116,12 +112,6 @@ A faster option is to ssh to the first server and check if you can find the rogu
 Take care, there is a `sshd`-process that listens for incoming
 connections - if you kill that one, you will have to restart the server, as you
 won't have access to it.
-
-### Network problems
-
-An important restriction so far is the need of all servers to be on the *same
-subnet*. To verify if this is the case, you can use the `host` or `dig`
-command and verify that is the case.
 
 ### Other problems
 

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -81,9 +81,9 @@ func SSHRun(username, host, command string) ([]byte, error) {
 func SSHRunStdout(username, host, command string) error {
 	h, p, err := net.SplitHostPort(host)
 	if err != nil {
-	        if !strings.Contains(err.Error(), "missing port in address") {
-	                return err
-	        }
+		if !strings.Contains(err.Error(), "missing port in address") {
+			return err
+		}
 		p = "22"
 	}
 	addr := h

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -37,18 +37,17 @@ func Scp(username, host, file, dest string) error {
 // is > 1, the rsync-operation is displayed on screen.
 func Rsync(username, host, file, dest string) error {
 	h, p, err := net.SplitHostPort(host)
-	if err != nil && strings.Contains(err.Error(), "missing port in address") {
-		p = "22"
-		err = nil
-	}
 	if err != nil {
-		return err
+		if !strings.Contains(err.Error(), "missing port in address") {
+			return err
+		}
+		p = "22"
 	}
 	addr := h + ":" + dest
 	if username != "" {
 		addr = username + "@" + addr
 	}
-	cmd := exec.Command("rsync", "-Pauz", "-e", fmt.Sprintf("ssh -T -o Compression=no -x -p %v", p), file, addr)
+	cmd := exec.Command("rsync", "-Pauz", "-e", fmt.Sprintf("ssh -T -o Compression=no -x -p %s", p), file, addr)
 	cmd.Stderr = os.Stderr
 	if log.DebugVisible() > 1 {
 		cmd.Stdout = os.Stdout

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -80,12 +80,11 @@ func SSHRun(username, host, command string) ([]byte, error) {
 // stderr of the Ssh-command to the os.Stderr and os.Stdout
 func SSHRunStdout(username, host, command string) error {
 	h, p, err := net.SplitHostPort(host)
-	if err != nil && strings.Contains(err.Error(), "missing port in address") {
-		p = "22"
-		err = nil
-	}
 	if err != nil {
-		return err
+	        if !strings.Contains(err.Error(), "missing port in address") {
+	                return err
+	        }
+		p = "22"
 	}
 	addr := h
 	if username != "" {

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -396,9 +396,9 @@ func (m *MiniNet) parseServers() error {
 		if len(h0) > 0 {
 			h, p, err := net.SplitHostPort(h0)
 			if err != nil {
-			        if !strings.Contains(err.Error(), "missing port in address") {
-			                return err
-			         }
+				if !strings.Contains(err.Error(), "missing port in address") {
+					return err
+				}
 				p = "22"
 				h = h0
 			}

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -319,9 +319,7 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 
 func ssh(user, host string, args ...string) *exec.Cmd {
 	h, p, err := net.SplitHostPort(host)
-	if err != nil {
-		log.Fatal(err)
-	}
+	log.ErrFatal(err)
 	ph := []string{"-p", p, user + "@" + h}
 	return exec.Command("ssh", append(ph, args...)...)
 }
@@ -397,13 +395,12 @@ func (m *MiniNet) parseServers() error {
 		h0 := strings.Replace(hostRaw, " ", "", -1)
 		if len(h0) > 0 {
 			h, p, err := net.SplitHostPort(h0)
-			if err != nil && strings.Contains(err.Error(), "missing port in address") {
+			if err != nil {
+			        if !strings.Contains(err.Error(), "missing port in address") {
+			                return err
+			         }
 				p = "22"
 				h = h0
-				err = nil
-			}
-			if err != nil {
-				return err
 			}
 			ips, err := net.LookupIP(h)
 			if err != nil {
@@ -515,8 +512,6 @@ func noPort(in string) string {
 	if err != nil && strings.Contains(err.Error(), "missing port in address") {
 		return in
 	}
-	if err != nil {
-		log.Fatal(err)
-	}
+	log.ErrFatal(err)
 	return h
 }

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -108,12 +108,12 @@ func newMiniNet() (m *MiniNet, err error) {
 		numbers := app.Input("server1 server2 server3", "Please enter the space separated numbers of the servers")
 		split := strings.Split(numbers, " ")
 		cmd := exec.Command(command, split...)
-		out, err := cmd.CombinedOutput()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
 		if err != nil {
-			log.Error("while setting up servers:", string(out))
 			return nil, xerrors.Errorf("couldn't setup servers: %v", err)
 		}
-		log.Lvl1(string(out))
 	} else {
 		log.Lvl1("Using existing 'server_list'-file")
 		if log.DebugVisible() > 1 {
@@ -199,7 +199,7 @@ func (m *MiniNet) Build(build string, arg ...string) error {
 // Cleanup kills all eventually remaining processes from the last Deploy-run
 func (m *MiniNet) Cleanup() error {
 	// Cleanup eventual ssh from the proxy-forwarding to the logserver
-	err := exec.Command("pkill", "-9", "-f", "ssh -nNTf").Run()
+	err := exec.Command("pkill", "-f", "--", "-nNTf").Run()
 	if err != nil {
 		log.Lvl3("Error stopping ssh:", err)
 	}
@@ -278,7 +278,8 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 	// Verify the installation is correct
 	gw := m.HostIPs[0]
 	log.Lvl2("Verifying configuration on", gw)
-	out, err := exec.Command("ssh", "root@"+gw, "which mn").Output()
+	cmd := ssh("root", gw, "which mn")
+	out, err := cmd.Output()
 	if err != nil || !strings.HasSuffix(string(out), "mn\n") {
 		log.Error("While trying to connect to", gw, err)
 		log.Fatal("Please verify installation of mininet or run\n" +
@@ -316,6 +317,15 @@ func (m *MiniNet) Deploy(rc *RunConfig) error {
 	return nil
 }
 
+func ssh(user, host string, args ...string) *exec.Cmd {
+	h, p, err := net.SplitHostPort(host)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ph := []string{"-p", p, user + "@" + h}
+	return exec.Command("ssh", append(ph, args...)...)
+}
+
 // Start connects to the first of the remote servers to start the simulation.
 func (m *MiniNet) Start(args ...string) error {
 	// setup port forwarding for viewing log server
@@ -323,13 +333,13 @@ func (m *MiniNet) Start(args ...string) error {
 	// Remote tunneling : the sink port is used both for the sink and for the
 	// proxy => the proxy redirects packets to the same port the sink is
 	// listening.
-	// -n = stdout == /Dev/null, -N => no command stream, -T => no tty
+	// -n = stdout == /dev/null, -N => no command stream, -T => no tty, -f => background
 	var exCmd *exec.Cmd
 	redirection := fmt.Sprintf("*:%d:%s:%d", m.MonitorPort, m.ProxyAddress, m.MonitorPort)
-	login := fmt.Sprintf("%s@%s", m.Login, m.External)
 	cmd := []string{"-nNTf", "-o", "StrictHostKeyChecking=no", "-o", "ExitOnForwardFailure=yes", "-R",
-		redirection, login}
-	exCmd = exec.Command("ssh", cmd...)
+		redirection}
+
+	exCmd = ssh(m.Login, m.External, cmd...)
 	if err := exCmd.Start(); err != nil {
 		log.Fatal("Failed to start the ssh port forwarding:", err)
 	}
@@ -384,8 +394,17 @@ func (m *MiniNet) parseServers() error {
 	}
 	m.HostIPs = []string{}
 	for _, hostRaw := range strings.Split(string(hosts), "\n") {
-		h := strings.Replace(hostRaw, " ", "", -1)
-		if len(h) > 0 {
+		h0 := strings.Replace(hostRaw, " ", "", -1)
+		if len(h0) > 0 {
+			h, p, err := net.SplitHostPort(h0)
+			if err != nil && strings.Contains(err.Error(), "missing port in address") {
+				p = "22"
+				h = h0
+				err = nil
+			}
+			if err != nil {
+				return err
+			}
 			ips, err := net.LookupIP(h)
 			if err != nil {
 				if err2 := CheckOutOfFileDescriptors(); err2 != nil {
@@ -394,7 +413,7 @@ func (m *MiniNet) parseServers() error {
 				return xerrors.New("error while looking up hostname: " + err.Error())
 			}
 			log.Lvl3("Found IP for", h, ":", ips[0])
-			m.HostIPs = append(m.HostIPs, ips[0].String())
+			m.HostIPs = append(m.HostIPs, net.JoinHostPort(ips[0].String(), p))
 		}
 	}
 	log.Lvl3("Nodes are:", m.HostIPs)
@@ -413,6 +432,7 @@ func (m *MiniNet) parseServers() error {
 //
 // list is used by platform/mininet/start.py and has the following format:
 // SimulationName BandwidthMbps DelayMS
+// m.Debug, m.DebugTime, m.DebugColor, m.DebugPadding
 // physicalIP1 MininetNet1/16 NumberConodes1
 // physicalIP2 MininetNet2/16 NumberConodes2
 func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err error) {
@@ -485,7 +505,15 @@ func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err e
 		// from the first server.
 		h := (nbrHosts + nbrServers - 1 - i) / nbrServers
 		list += fmt.Sprintf("%s %s %d\n",
-			m.HostIPs[i], s.String(), h)
+			noPort(m.HostIPs[i]), s.String(), h)
 	}
 	return
+}
+
+func noPort(in string) string {
+	h, _, err := net.SplitHostPort(in)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return h
 }

--- a/simul/platform/mininet.go
+++ b/simul/platform/mininet.go
@@ -512,6 +512,9 @@ func (m *MiniNet) getHostList(rc *RunConfig) (hosts []string, list string, err e
 
 func noPort(in string) string {
 	h, _, err := net.SplitHostPort(in)
+	if err != nil && strings.Contains(err.Error(), "missing port in address") {
+		return in
+	}
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/simul/platform/mininet/install_mininet.sh
+++ b/simul/platform/mininet/install_mininet.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 
+export DEBIAN_FRONTEND="noninteractive"
+
 # Package installation
 echo 'export LC_ALL="en_US.UTF-8"' >> /etc/environment
 . /etc/environment
 apt-get update
 apt-get install -y screen rsync software-properties-common git vim cifs-utils pv htop mtr \
-golang-1.6 aufs-tools ca-certificates xz-utils btrfs-tools \
-debootstrap lxc rinse psmisc
+    golang aufs-tools ca-certificates xz-utils \
+    debootstrap lxc rinse psmisc
 
 # Configure ssh-port-forwarding
 echo GatewayPorts yes >> /etc/ssh/sshd_config
-/etc/init.d/ssh restart
+service ssh restart
 
 case "$( cat /etc/issue )" in
 *14.04*)
-    echo "Installing for Ubuntu 1404"
+    echo "Installing for Ubuntu 14.04"
+    apt-get install -y btrfs-tools
     # Mininet installation
     git clone git://github.com/mininet/mininet
     cd mininet || exit 1
@@ -22,18 +25,30 @@ case "$( cat /etc/issue )" in
     ./util/install.sh -a
     ;;
 *16.04*)
-    echo "Installing for Ubuntu 1604"
-    apt-get install -y mininet openvswitch-testcontroller
+    echo "Installing for Ubuntu 16.04"
+    apt-get install -y btrfs-tools mininet openvswitch-testcontroller
     cp /usr/bin/ovs-testcontroller /usr/bin/ovs-controller
     ;;
 *18.04*)
-    echo "Installing for Ubuntu 1804"
-    apt-get install -y mininet openvswitch-testcontroller
+    echo "Installing for Ubuntu 18.04"
+    apt-get install -y btrfs-tools mininet openvswitch-testcontroller
     for a in stop disable; do
       systemctl $a openvswitch-testcontroller
     done
     ;;
+*20.04*)
+    echo "Installing for Ubuntu 20.04"
+    # Mininet installation
+    git clone git://github.com/mininet/mininet
+    cd mininet || exit 1
+    ./util/install.sh -a
+    apt install -y openvswitch-testcontroller python-is-python3
+    for a in stop disable; do
+      systemctl $a openvswitch-testcontroller
+    done
+    service openvswitch-switch start
+    ;;
 *)
-    echo "Unknown system - only know Ubuntu 1404, 1604 and 1804!"
+    echo "Unknown system - only know Ubuntu 1404, 1604, 1804 and 2004!"
     ;;
 esac

--- a/simul/platform/mininet/setup_servers.sh
+++ b/simul/platform/mininet/setup_servers.sh
@@ -48,15 +48,10 @@ for s in $SERVERS; do
 
 done
 
-DONE=false
-while [ "$DONE" != "true" ]; do
-    if [ -n "`pgrep -f install_mininet.sh`" ]; then
-	  echo
-	  echo "$( date ) - Waiting for background installs to finish:"
-	  ps -ef | grep install_mininet.sh
-	else
-	  DONE=true
-    fi
+while [ -n "`pgrep -f install_mininet.sh`"  ]; do
+    echo
+    echo "$( date ) - Waiting for background installs to finish:"
+    ps -ef | grep [i]nstall_mininet.sh
 	sleep 2
 done
 

--- a/simul/platform/mininet/start.py
+++ b/simul/platform/mininet/start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This will run a number of hosts on the server and do all
@@ -78,7 +78,7 @@ class BaseRouter(Node):
             # and
             #   10.internalNet.remoteIndex.localIndex on the remote computer
             # these tunnels are then used to route the traffic from the different
-            # nodes in mininet to each other, always going through a bandwidht
+            # nodes in mininet to each other, always going through a bandwidth
             # and latency restricted network of mininet.
             remoteIndex += 1
             if remoteIndex == localIndex:
@@ -193,7 +193,7 @@ def RunNet():
     topo = InternetTopo(myNet=myNet, rootLog=rootLog)
     dbg( 3, "Starting on", myNet )
 
-    net = Mininet(topo=topo, link=TCLink, controller = OVSController)
+    net = Mininet(topo=topo, link=TCLink)
     net.start()
 
     for host in net.hosts[1:]:
@@ -233,6 +233,8 @@ def GetNetworks(filename):
     process = Popen(["ip", "a"], stdout=PIPE)
     (ips, err) = process.communicate()
     process.wait()
+    # python3 needs this, don't know why
+    ips = str(ips)
 
     with open(filename) as f:
         content = f.readlines()
@@ -263,7 +265,7 @@ def GetNetworks(filename):
     for (server, net, count) in list:
         totalHosts += int(count)
         t = [server, net, count]
-        if ips.find('inet %s/' % server) >= 0:
+        if ips.find('inet %s/' % server) != None:
             myNet = [t, pos]
         else:
             otherNets.append(t)

--- a/simul/test_simul/.gitignore
+++ b/simul/test_simul/.gitignore
@@ -1,2 +1,3 @@
 deter.toml
 test_simul
+server_list


### PR DESCRIPTION
install_mininet.sh installs for 20.04 from git, because
mininet releases are rarely made now, and because changes were
needed in mininet itself in order to correctly install on 20.04.
These changes were proposed by me and merged into mininet recently,
allowing this work to proceed.

start.py has a critical simplification to use the default
controller. This is required for Mininet on 20.04 to work
at all, and does not stop 14.04 from working. (Others to be tested still.)

Also: Support local development/debugging with VirtualBox,
via NAT port forwarding. (These changes work and are useful, but
are not sufficient to run an entire simulation because the
logging of monitors needs to know the real IP address of the first
server.)