### PR TITLE
websocket: do not error on service's close

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -350,9 +350,11 @@ outerReadLoop:
 				break outerReadLoop
 			case reply, ok := <-outChan:
 				if !ok {
-					err = xerrors.New("service finished streaming")
+					ws.WriteControl(websocket.CloseMessage,
+						websocket.FormatCloseMessage(websocket.CloseNormalClosure, "service finished streaming"),
+						time.Now().Add(time.Millisecond*500))
 					close(clientInputs)
-					break outerReadLoop
+					return
 				}
 				tx += len(reply)
 


### PR DESCRIPTION
When a stream is closed by the service itself (such as when the service was streaming progress and finished with a result), it actually errors with "unexpected error: service finished streaming". As it is quite an expected behavior, I'm removing this error and closing the websocket.

It clashes with #670, as we might want to keep the channel opened, anyway, it doesn't change the current behavior of closing the channel when service finishes, just avoid the error.