### PR TITLE
Updates the processor to close all potential stop chans

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -480,15 +480,19 @@ func (p *ServiceProcessor) ProcessClientStreamRequest(req *http.Request, path st
 				network.DefaultConstructors(p.Context.server.Suite()))
 			if err != nil {
 				log.Error(xerrors.Errorf("failed to decode message: %v", err))
+				close(outChan)
 				return
 			}
 
 			reply, stopServiceChan, err := callInterfaceFunc(mh.handler, msg, mh.streaming)
 			if err != nil {
 				log.Error(err)
+
 				if stopServiceChan != nil {
 					close(stopServiceChan)
 				}
+
+				close(outChan)
 				return
 			}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -226,10 +226,6 @@ func TestServiceProcessor_ProcessClientRequest_Streaming_Multiple(t *testing.T) 
 	n := 5
 	buf, err := protobuf.Encode(&testMsg{int64(n)})
 	require.NoError(t, err)
-	rep, _, err := p.ProcessClientRequest(nil, "testMsg", buf)
-	// Using ProcessClientRequest with a streaming request should yield an error
-	require.Nil(t, rep)
-	require.Error(t, err)
 
 	// Send 3 requests
 	inputChan := make(chan []byte, 3)


### PR DESCRIPTION
Some streaming services, like the pagination one, use a different stop chan for each call, but the actual implementation would only close the last one, which would lead to go routine leaks.

Cancels https://github.com/dedis/cothority/pull/2437

@ineiti @tharvik: that is related to https://github.com/dedis/cothority/pull/2437. Based on your comments Linus I think the problem should be solved by onet, as I originally did but finally went with the cothority PR. The pagination service should be completely stateless, and onet should ensure it closes all the stop channels.