### PR TITLE
Initialize ServerIdentities for local tests

### DIFF
--- a/local.go
+++ b/local.go
@@ -487,7 +487,6 @@ func NewPrivIdentity(suite network.Suite, port int) (kyber.Scalar, *network.Serv
 	kp := key.NewKeyPair(suite)
 	id := network.NewServerIdentity(kp.Public, address)
 	ServiceFactory.generateKeyPairs(id)
-	id.Address = address
 	id.Description = fmt.Sprintf("LocalNode-%d", port)
 
 	return kp.Private, id

--- a/local.go
+++ b/local.go
@@ -487,6 +487,8 @@ func NewPrivIdentity(suite network.Suite, port int) (kyber.Scalar, *network.Serv
 	kp := key.NewKeyPair(suite)
 	id := network.NewServerIdentity(kp.Public, address)
 	ServiceFactory.generateKeyPairs(id)
+	id.Address = address
+	id.Description = fmt.Sprintf("LocalNode-%d", port)
 
 	return kp.Private, id
 }


### PR DESCRIPTION
While fixing a missing test in byzcoin, I saw that the ServerIdentities are not fully
initialized for local tests. As the new configuration contract in byzcoin also
checks for Address and Description in the ServerIdentity, they also must be
set for local tests.

Once this PR is merged, the onet version should be increased.